### PR TITLE
Bugfix/filter columns hdf load

### DIFF
--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -90,8 +90,7 @@ def load(path: str, entity_key: 'EntityKey', filter_terms: Optional[List[str]]) 
             with filenode.open_node(node, 'r') as file_node:
                 data = json.load(file_node)
         else:
-            if filter_terms:
-                filter_terms = _get_valid_filters(filter_terms, node.table.colnames)
+            filter_terms = _get_valid_filter_terms(filter_terms, node.table.colnames)
             data = pd.read_hdf(path, entity_key.path, where=filter_terms)
 
         return data
@@ -182,7 +181,7 @@ def _get_node_name(node: tables.node.Node) -> str:
     return node_name
 
 
-def _get_valid_filters(filter_terms, colnames):
+def _get_valid_filter_terms(filter_terms, colnames):
     """Removes any filter terms referencing non-existent columns
 
     Parameters

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -195,7 +195,8 @@ def _get_valid_filter_terms(filter_terms, colnames):
     Returns
     -------
         The list of valid filter terms (terms that do not reference any column
-        not existing in the data)
+        not existing in the data). Returns none if the list is empty because
+        the `where` argument doesn't like empty lists.
     """
     if not filter_terms:
         return None
@@ -208,4 +209,4 @@ def _get_valid_filter_terms(filter_terms, colnames):
         term_columns = set([i.split()[0] for i in t])
         if not term_columns.issubset(colnames):
             filter_terms.remove(term)
-    return filter_terms
+    return filter_terms if filter_terms else None

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -91,6 +91,8 @@ def load(path: str, entity_key: 'EntityKey', filter_terms: Optional[List[str]]) 
                 data = json.load(file_node)
         else:
             filter_terms = _get_valid_filter_terms(filter_terms, node.table.colnames)
+            if not filter_terms:
+                filter_terms = None
             data = pd.read_hdf(path, entity_key.path, where=filter_terms)
 
         return data

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -91,8 +91,6 @@ def load(path: str, entity_key: 'EntityKey', filter_terms: Optional[List[str]]) 
                 data = json.load(file_node)
         else:
             filter_terms = _get_valid_filter_terms(filter_terms, node.table.colnames)
-            if not filter_terms:
-                filter_terms = None
             data = pd.read_hdf(path, entity_key.path, where=filter_terms)
 
         return data
@@ -199,6 +197,8 @@ def _get_valid_filter_terms(filter_terms, colnames):
         The list of valid filter terms (terms that do not reference any column
         not existing in the data)
     """
+    if not filter_terms:
+        return None
     for term in filter_terms:
         # first strip out all the parentheses - the where in read_hdf requires all references to be valid
         t = re.sub('[()]', '', term)

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -95,6 +95,7 @@ def load(path: str, entity_key: 'EntityKey', filter_terms: Optional[List[str]]) 
 
         return data
 
+
 def remove(path: str, entity_key: 'EntityKey'):
     """Removes a piece of data from an hdf file.
 

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -74,7 +74,8 @@ def load(path: str, entity_key: 'EntityKey', filter_terms: Optional[List[str]]) 
         A representation of the internal hdf path where the data is located.
     filter_terms :
         A list of terms used to filter the data formatted in a way that is
-        suitable for use with the `where` argument of `pd.read_hdf`.
+        suitable for use with the `where` argument of `pd.read_hdf`. Only
+        filters applying to existing columns in the data are used.
 
     Returns
     -------
@@ -88,9 +89,11 @@ def load(path: str, entity_key: 'EntityKey', filter_terms: Optional[List[str]]) 
             with filenode.open_node(node, 'r') as file_node:
                 data = json.load(file_node)
         else:
-            data = pd.read_hdf(path, entity_key.path, where=filter_terms)
+            filter_columns = dict((i.split()[0], i) for i in filter_terms)
+            existing_filter_terms = [filter_columns[i] for i in set(node.table.colnames).intersection(filter_columns)]
+            data = pd.read_hdf(path, entity_key.path, where=existing_filter_terms)
 
-    return data
+        return data
 
 
 def remove(path: str, entity_key: 'EntityKey'):

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -200,6 +200,7 @@ def _get_valid_filter_terms(filter_terms, colnames):
     """
     if not filter_terms:
         return None
+    terms = filter_terms.copy()
     for term in filter_terms:
         # first strip out all the parentheses - the where in read_hdf requires all references to be valid
         t = re.sub('[()]', '', term)
@@ -208,5 +209,5 @@ def _get_valid_filter_terms(filter_terms, colnames):
         # get the unique columns referenced by this term
         term_columns = set([i.split()[0] for i in t])
         if not term_columns.issubset(colnames):
-            filter_terms.remove(term)
-    return filter_terms if filter_terms else None
+            terms.remove(term)
+    return terms if terms else None

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -200,7 +200,7 @@ def _get_valid_filter_terms(filter_terms, colnames):
     """
     if not filter_terms:
         return None
-    terms = filter_terms.copy()
+    valid_terms = filter_terms.copy()
     for term in filter_terms:
         # first strip out all the parentheses - the where in read_hdf requires all references to be valid
         t = re.sub('[()]', '', term)
@@ -209,5 +209,5 @@ def _get_valid_filter_terms(filter_terms, colnames):
         # get the unique columns referenced by this term
         term_columns = set([i.split()[0] for i in t])
         if not term_columns.issubset(colnames):
-            terms.remove(term)
-    return terms if terms else None
+            valid_terms.remove(term)
+    return valid_terms if valid_terms else None

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -207,7 +207,7 @@ def _get_valid_filter_terms(filter_terms, colnames):
         # then split each condition out
         t = re.split('[&|]', t)
         # get the unique columns referenced by this term
-        term_columns = set([i.split()[0] for i in t])
+        term_columns = set([re.split('[<=>\s]', i.strip())[0] for i in t])
         if not term_columns.issubset(colnames):
             valid_terms.remove(term)
     return valid_terms if valid_terms else None

--- a/tests/dataset_manager/test_artifact.py
+++ b/tests/dataset_manager/test_artifact.py
@@ -1,4 +1,6 @@
 import pytest
+import pandas as pd
+from pathlib import Path
 
 from vivarium_public_health.dataset_manager.artifact import Artifact, ArtifactException, EntityKey, _to_tree
 
@@ -38,6 +40,12 @@ def hdf_mock(mocker, keys_mock):
     mock.load.side_effect = mock_load
 
     return mock
+
+# keys in test artifact
+_KEYS = ['population.age_bins',
+         'population.structure',
+         'population.theoretical_minimum_risk_life_expectancy',
+         'cause.all_causes.restrictions']
 
 
 def test_artifact_creation(hdf_mock, keys_mock):
@@ -96,7 +104,7 @@ def test_artifact_load_key_has_no_data(hdf_mock):
 
 def test_artifact_load(hdf_mock, keys_mock):
     path = '/place/with/artifact.hdf'
-    filter_terms = ['location == Global', 'draw == 10', 'fake_filter in [1, 2]']
+    filter_terms = ['location == Global', 'draw == 10']
 
     a = Artifact(path, filter_terms)
 
@@ -242,6 +250,33 @@ def test_clear_cache(hdf_mock):
     a.clear_cache()
 
     assert a._cache == {}
+
+
+def test_artifact_load_full():
+    path = str(Path(__file__).parent / 'artifact.hdf')
+    filter_terms = ['location == Global', 'draw == 10', 'fake_filter']
+
+    a = Artifact(path, filter_terms)
+
+    for key in _KEYS:
+        result = a.load(key)
+        if 'restrictions' in EntityKey(key):
+            assert isinstance(result, dict)
+        else:
+            assert isinstance(result, pd.DataFrame)
+
+
+def test_loading_key_leaves_filters_unchanged():
+    # loading each key will drop the fake_filter from filter_terms for that key
+    # make sure that artifact's filter terms stay the same though
+    path = str(Path(__file__).parent / 'artifact.hdf')
+    filter_terms = ['location == Global', 'draw == 10', 'fake_filter']
+
+    a = Artifact(path, filter_terms)
+
+    for key in _KEYS:
+        a.load(key)
+        assert a.filter_terms == filter_terms
 
 
 def test_EntityKey_init_failure():

--- a/tests/dataset_manager/test_artifact.py
+++ b/tests/dataset_manager/test_artifact.py
@@ -96,7 +96,7 @@ def test_artifact_load_key_has_no_data(hdf_mock):
 
 def test_artifact_load(hdf_mock, keys_mock):
     path = '/place/with/artifact.hdf'
-    filter_terms = ['location == Global', 'draw == 10']
+    filter_terms = ['location == Global', 'draw == 10', 'fake_filter in [1, 2]']
 
     a = Artifact(path, filter_terms)
 

--- a/tests/dataset_manager/test_artifact.py
+++ b/tests/dataset_manager/test_artifact.py
@@ -252,20 +252,6 @@ def test_clear_cache(hdf_mock):
     assert a._cache == {}
 
 
-def test_artifact_load_full():
-    path = str(Path(__file__).parent / 'artifact.hdf')
-    filter_terms = ['location == Global', 'draw == 10', 'fake_filter']
-
-    a = Artifact(path, filter_terms)
-
-    for key in _KEYS:
-        result = a.load(key)
-        if 'restrictions' in EntityKey(key):
-            assert isinstance(result, dict)
-        else:
-            assert isinstance(result, pd.DataFrame)
-
-
 def test_loading_key_leaves_filters_unchanged():
     # loading each key will drop the fake_filter from filter_terms for that key
     # make sure that artifact's filter terms stay the same though

--- a/tests/dataset_manager/test_hdf.py
+++ b/tests/dataset_manager/test_hdf.py
@@ -128,6 +128,26 @@ def test_load(hdf_file_path, hdf_key):
         assert isinstance(data, pd.DataFrame)
 
 
+def test_load_with_invalid_filters(hdf_file_path, hdf_key):
+    key = EntityKey(hdf_key)
+    data = hdf.load(hdf_file_path, key, filter_terms=["fake_filter==0"])
+    if 'restrictions' in key:
+        assert isinstance(data, dict)
+    else:
+        assert isinstance(data, pd.DataFrame)
+
+
+def test_load_with_valid_filters(hdf_file_path, hdf_key):
+    key = EntityKey(hdf_key)
+    data = hdf.load(hdf_file_path, key, filter_terms=["year == 2006"])
+    if 'restrictions' in key:
+        assert isinstance(data, dict)
+    else:
+        assert isinstance(data, pd.DataFrame)
+        if 'year' in data.columns:
+            assert set(data.year) == {2006}
+
+
 def test_remove(hdf_file_path, hdf_key):
     key = EntityKey(hdf_key)
     hdf.remove(hdf_file_path, key)

--- a/tests/dataset_manager/test_hdf.py
+++ b/tests/dataset_manager/test_hdf.py
@@ -214,7 +214,7 @@ def test_get_valid_filter_terms_no_terms():
 
 def _construct_no_valid_filters(columns):
     fake_cols = [c[1:] for c in columns] # strip out the first char to make a list of all fake cols
-    terms = [c + '=0' for c in fake_cols]
+    terms = [c + ' <= 0' for c in fake_cols]
     return _complicate_terms_to_parse(terms)
 
 


### PR DESCRIPTION
This is a workable (but not necessarily pretty) fix to the fact that the base filter terms (which reference draws and location) were applied to all keys in the data artifact, which broke things like population.structure that don't have draws. Now any filter terms referencing columns that aren't present in the data are skipped.