### PR TITLE
only try to filter data in load if it's a dataframe

### DIFF
--- a/src/vivarium_public_health/dataset_manager/dataset_manager.py
+++ b/src/vivarium_public_health/dataset_manager/dataset_manager.py
@@ -101,10 +101,11 @@ class ArtifactManager:
 
         Returns
         -------
-            The data associated with the given key filtered down to the requested subset.
+            The data associated with the given key, filtered down to the requested subset
+            if the data is a dataframe.
         """
         data = self.artifact.load(entity_key)
-        return filter_data(data, keep_age_group_edges, **column_filters)
+        return filter_data(data, keep_age_group_edges, **column_filters) if isinstance(data, pd.DataFrame) else data
 
 
 def filter_data(data: pd.DataFrame, keep_age_group_edges: bool, **column_filters: _Filter) -> pd.DataFrame:


### PR DESCRIPTION
The load method in dataset_manager breaks for entity keys where the data is only a string rather than a dataset (e.g., the distribution type for a risk factor) because it automatically tries to subset the data. This fix only tries to filter if the data is a dataframe (which is the expected type for the input to the filter method) and otherwise just returns the data. 