### PR TITLE
remove list/tuple from default configuration

### DIFF
--- a/src/vivarium_public_health/treatment/mass_treatment_campaign.py
+++ b/src/vivarium_public_health/treatment/mass_treatment_campaign.py
@@ -27,10 +27,22 @@ class MassTreatmentCampaign:
                 },
             },
             'dose_age_range': {
-                'first': (270, 360),
-                'second': (450, 513),
-                'booster': (1080, 1440),
-                'catchup': (1080, 1440),
+                'first': {
+                    'start': 270,
+                    'end': 360,
+                },
+                'second': {
+                    'start': 450,
+                    'end': 513,
+                },
+                'booster': {
+                    'start': 1080,
+                    'end': 1440,
+                },
+                'catchup': {
+                    'start': 1080,
+                    'end': 1440,
+                },
             },
             'coverage_proportion': {
                 'second': 0.8,

--- a/src/vivarium_public_health/treatment/schedule.py
+++ b/src/vivarium_public_health/treatment/schedule.py
@@ -75,7 +75,7 @@ class TreatmentSchedule:
         population = self.population_view.get(simulant_data.index)
         age_draw = self.randomness.get_draw(population.index, additional_key=f'{dose}_age')
 
-        min_age, max_age = self.dose_ages[dose]
+        min_age, max_age = self.dose_ages[dose]['start'], self.dose_ages[dose]['end']
         mean_age = (min_age + max_age) / 2
         age_std_dev = (mean_age - min_age) / 3
 

--- a/tests/treatment/test_schedule.py
+++ b/tests/treatment/test_schedule.py
@@ -14,8 +14,14 @@ def config(base_config):
         'test_treatment': {
             'doses': ['first', 'second'],
             'dose_age_range': {
-                'first': (60, 90),
-                'second': (180, 180)
+                'first': {
+                    'start': 60,
+                    'end': 90,
+                },
+                'second': {
+                    'start': 180,
+                    'end': 180,
+                },
             },
         }
     }, **metadata)
@@ -130,13 +136,13 @@ def test_when_should_receive_dose(treatment_schedule, mocker):
 
     # any ages outsider [min_age, max_age] should be pushed inside of the ranage.
     age_at_first_dose = tx._determine_when_should_receive_dose('first', pop)
-    assert min(age_at_first_dose) == tx.dose_ages['first'][0] * 1.01
-    assert max(age_at_first_dose) == tx.dose_ages['first'][1] * 0.99
+    assert min(age_at_first_dose) == tx.dose_ages['first']['start'] * 1.01
+    assert max(age_at_first_dose) == tx.dose_ages['first']['end'] * 0.99
 
     # min_age and max_age are same, should be all equal to a single age
     age_at_second_dose = tx._determine_when_should_receive_dose('second', pop)
-    assert min(age_at_second_dose) == tx.dose_ages['second'][0]
-    assert max(age_at_second_dose) == tx.dose_ages['second'][1]
+    assert min(age_at_second_dose) == tx.dose_ages['second']['start']
+    assert max(age_at_second_dose) == tx.dose_ages['second']['end']
 
 
 def test_get_newly_dosed_simulants(treatment_schedule):


### PR DESCRIPTION
small PR for [removing lists/tuples from the mass treatment campaign configuration](https://jira.ihme.washington.edu/browse/MIC-246 ). The corresponding PR for ceam_experiments is also coming. 