### PR TITLE
Feature/order 0 interp

### DIFF
--- a/src/vivarium_public_health/dataset_manager/dataset_manager.py
+++ b/src/vivarium_public_health/dataset_manager/dataset_manager.py
@@ -17,7 +17,7 @@ class ArtifactManagerInterface:
     def __init__(self, controller):
         self._controller = controller
 
-    def load(self, entity_key: str, keep_age_group_edges: bool=False, **column_filters: _Filter) -> pd.DataFrame:
+    def load(self, entity_key: str, keep_age_group_edges: bool=True, **column_filters: _Filter) -> pd.DataFrame:
         """Loads data associated with a formatted entity key.
 
         The provided entity key must be of the form
@@ -84,7 +84,7 @@ class ArtifactManager:
         base_filter_terms = [f'draw == {draw}', get_location_term(location)]
         return Artifact(artifact_path, base_filter_terms)
 
-    def load(self, entity_key: str, keep_age_group_edges: bool=False, **column_filters: _Filter):
+    def load(self, entity_key: str, keep_age_group_edges: bool=True, **column_filters: _Filter):
         """Loads data associated with the given entity key.
 
         Parameters

--- a/src/vivarium_public_health/population/add_new_birth_cohorts.py
+++ b/src/vivarium_public_health/population/add_new_birth_cohorts.py
@@ -163,8 +163,12 @@ class FertilityAgeSpecificRates:
         """
 
         self.randomness = builder.randomness.get_stream('fertility')
-        asfr_data = builder.data.load("covariate.age_specific_fertility_rate.estimate")[['year', 'age', 'value']]
-        asfr_source = builder.lookup.build_table(asfr_data, key_columns=(), parameter_columns=('year', 'age',))
+        asfr_data = builder.data.load("covariate.age_specific_fertility_rate.estimate")[['year', 'year_start', 'year_end',
+                                                                                         'age', 'age_group_start',
+                                                                                         'age_group_end', 'value']]
+        asfr_source = builder.lookup.build_table(asfr_data, key_columns=(),
+                                                 parameter_columns=[('age', 'age_group_start', 'age_group_end'),
+                                                                    ('year', 'year_start', 'year_end')],)
         self.asfr = builder.value.register_rate_producer('fertility rate', source=asfr_source)
         self.population_view = builder.population.get_view(['last_birth_time', 'sex', 'parent_id'])
         self.simulant_creator = builder.population.get_simulant_creator()

--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -343,10 +343,11 @@ def _compute_ages(uniform_rv, start, height, slope, normalization):
 
 
 def get_cause_deleted_mortality(all_cause_mortality, list_of_csmrs):
-    index_cols = ['age', 'sex', 'year']
+    index_cols = ['age', 'age_group_start', 'age_group_end', 'sex', 'year', 'year_start', 'year_end']
     all_cause_mortality = all_cause_mortality.set_index(index_cols).copy()
     for csmr in list_of_csmrs:
         if csmr is None:
             continue
         all_cause_mortality = all_cause_mortality.subtract(csmr.set_index(index_cols)).dropna()
+
     return all_cause_mortality.reset_index().rename(columns={'value': 'death_due_to_other_causes'})

--- a/src/vivarium_public_health/population/mortality.py
+++ b/src/vivarium_public_health/population/mortality.py
@@ -19,7 +19,8 @@ class Mortality:
         self.mortality_rate = builder.value.register_rate_producer('mortality_rate', source=self.mortality_rate_source)
 
         life_expectancy_data = builder.data.load("population.theoretical_minimum_risk_life_expectancy")
-        self.life_expectancy = builder.lookup.build_table(life_expectancy_data, key_columns=[], parameter_columns=('age',))
+        self.life_expectancy = builder.lookup.build_table(life_expectancy_data, key_columns=[],
+                                                          parameter_columns=[('age','age_group_start', 'age_group_end')])
 
         self.death_emitter = builder.event.get_emitter('deaths')
         self.random = builder.randomness.get_stream('mortality_handler')

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -450,7 +450,9 @@ def get_distribution(risk: str, risk_type: str, builder) -> \
     if distribution in ["dichotomous", "polytomous"]:
         exposure_data = builder.data.load(f"{risk_type}.{risk}.exposure")
         exposure_data = pd.pivot_table(exposure_data,
-                                       index=['year', 'age', 'sex'],
+                                       index=['year', 'year_start', 'year_end',
+                                              'age', 'age_group_start', 'age_group_end',
+                                              'sex'],
                                        columns='parameter', values='value'
                                        ).dropna().reset_index()
 
@@ -462,7 +464,8 @@ def get_distribution(risk: str, risk_type: str, builder) -> \
     exposure_mean = exposure_mean.rename(index=str, columns={"value": "mean"})
     exposure_sd = exposure_sd.rename(index=str, columns={"value": "standard_deviation"})
 
-    exposure = exposure_mean.merge(exposure_sd).set_index(['age', 'sex', 'year'])
+    exposure = exposure_mean.merge(exposure_sd).set_index(['year', 'year_start', 'year_end',
+                                                           'age', 'age_group_start', 'age_group_end', 'sex'])
 
     if distribution == 'ensemble':
         weights = builder.data.load(f'risk_factor.{risk}.ensemble_weights')

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -449,12 +449,21 @@ def get_distribution(risk: str, risk_type: str, builder) -> \
     distribution = builder.data.load(f"{risk_type}.{risk}.distribution")
     if distribution in ["dichotomous", "polytomous"]:
         exposure_data = builder.data.load(f"{risk_type}.{risk}.exposure")
+        # to avoid MemoryError, pull off the mid and right edge columns and do the pivot with only left edge
+        mapping = exposure_data[['sex','year', 'year_start', 'year_end',
+                                 'age', 'age_group_start', 'age_group_end']].drop_duplicates()
         exposure_data = pd.pivot_table(exposure_data,
-                                       index=['year', 'year_start', 'year_end',
-                                              'age', 'age_group_start', 'age_group_end',
-                                              'sex'],
+                                       index=['year_start','age_group_start', 'sex'],
                                        columns='parameter', values='value'
                                        ).dropna().reset_index()
+        # merge back on the other edges
+        idx = exposure_data.index
+        exposure_data = exposure_data.set_index(['year_start', 'age_group_start', 'sex'], drop=False)
+        mapping = mapping.set_index(['year_start', 'age_group_start', 'sex'], drop=False)
+
+        exposure_data[['year', 'year_end', 'age', 'age_group_end']] = mapping[['year', 'year_end', 'age', 'age_group_end']]
+
+        exposure_data = exposure_data.set_index(idx)
 
         return DichotomousDistribution(exposure_data, risk) if distribution == 'dichotomous' \
             else PolytomousDistribution(exposure_data, risk)

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from vivarium_public_health.util import pivot_age_sex_year_binned
 
 
 def get_exposure_effect(builder, risk, risk_type):
@@ -82,9 +83,7 @@ class RiskEffect:
                          'age_group_start', 'age_group_end', 'year_start', 'year_end']
         rr_data = rr_data.loc[row_filter, column_filter]
 
-        rr_data = pd.pivot_table(rr_data, index=['year', 'age', 'sex', 'age_group_start',
-                                                 'age_group_end', 'year_start', 'year_end'], columns='parameter', values='value')
-        return rr_data.dropna().reset_index()
+        return pivot_age_sex_year_binned(rr_data, 'parameter', 'value')
 
 
 class DirectEffect(RiskEffect):

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -69,7 +69,7 @@ class RiskEffect:
             paf_data = builder.data.load(f"{prefix}.population_attributable_fraction")
 
         paf_data = paf_data[paf_data[filter_name] == filter]
-        return paf_data[['year', 'sex', 'age', 'value']]
+        return paf_data[['year', 'sex', 'age', 'value', 'age_group_start', 'age_group_end', 'year_start', 'year_end']]
 
     def _get_rr_data(self, builder):
         if 'rr' in self._get_data_functions:
@@ -78,10 +78,12 @@ class RiskEffect:
             rr_data = builder.data.load(f"{self.risk_type}.{self.risk}.relative_risk")
 
         row_filter = rr_data[f'{self.affected_entity_type}'] == self.affected_entity
-        column_filter = ['year', 'parameter', 'sex', 'age', 'value']
+        column_filter = ['year', 'parameter', 'sex', 'age', 'value',
+                         'age_group_start', 'age_group_end', 'year_start', 'year_end']
         rr_data = rr_data.loc[row_filter, column_filter]
 
-        rr_data = pd.pivot_table(rr_data, index=['year', 'age', 'sex'], columns='parameter', values='value')
+        rr_data = pd.pivot_table(rr_data, index=['year', 'age', 'sex', 'age_group_start',
+                                                 'age_group_end', 'year_start', 'year_end'], columns='parameter', values='value')
         return rr_data.dropna().reset_index()
 
 

--- a/src/vivarium_public_health/testing/mock_artifact.py
+++ b/src/vivarium_public_health/testing/mock_artifact.py
@@ -53,7 +53,8 @@ MOCKERS = {
         },
         'population': {
             'structure': make_uniform_pop_data(),
-            'theoretical_minimum_risk_life_expectancy': build_table(98, 1990, 1990).query('sex=="Both"').filter(['age', 'value'])
+            'theoretical_minimum_risk_life_expectancy': build_table(98.0, 1990, 1990).query('sex=="Both"')\
+                .filter(['age', 'age_group_start', 'age_group_end', 'value'])
         },
 }
 

--- a/src/vivarium_public_health/treatment/healthcare_access.py
+++ b/src/vivarium_public_health/treatment/healthcare_access.py
@@ -67,12 +67,12 @@ class HealthcareAccess:
         interpolation_order = builder.configuration.interpolation.order
         self.hospitalization_cost = defaultdict(float)
         self._ip_cost_df = builder.data.load("healthcare_entity.inpatient_visits.cost")
-        self.__hospitalization_cost = builder.lookup.build_table(self._ip_cost_df[['year', 'value']],
-                                                                 tuple(), ('year',))
+        self.__hospitalization_cost = builder.lookup.build_table(self._ip_cost_df[['year', 'year_start', 'year_end', 'value']],
+                                                                 tuple(), [('year', 'year_start', 'year_end')])
 
         self._op_cost_df = builder.data.load("healthcare_entity.outpatient_visits.cost")
-        self.__appointment_cost = builder.lookup.build_table(self._op_cost_df[['year', 'value']],
-                                                             tuple(), ('year',))
+        self.__appointment_cost = builder.lookup.build_table(self._op_cost_df[['year', 'year_start', 'year_end', 'value']],
+                                                             tuple(), [('year', 'year_start', 'year_end')])
 
         self.outpatient_cost = defaultdict(float)
 

--- a/src/vivarium_public_health/treatment/schedule.py
+++ b/src/vivarium_public_health/treatment/schedule.py
@@ -10,9 +10,11 @@ class TreatmentSchedule:
         self._schedule = pd.DataFrame()
 
     def setup(self, builder):
+
         coverages = self._get_coverage(builder)
         self.dose_coverages = {
-            dose: builder.lookup.build_table(dose_coverage, key_columns=(), parameter_columns=('year',))
+            dose: builder.lookup.build_table(dose_coverage, key_columns=(),
+                                             parameter_columns=[('year', 'year_start', 'year_end')])
             for dose, dose_coverage in coverages.items()
         }
         self.doses = builder.configuration[self.name].doses

--- a/src/vivarium_public_health/util.py
+++ b/src/vivarium_public_health/util.py
@@ -112,10 +112,8 @@ def pivot_age_sex_year_binned(data, columns, values):
     # to avoid MemoryError, pull off the mid and right edge columns and do the pivot with only left edge
     mapping = data[['sex', 'year', 'year_start', 'year_end',
                     'age', 'age_group_start', 'age_group_end']].drop_duplicates()
-    exposure_data = pd.pivot_table(data,
-                                   index=['year_start', 'age_group_start', 'sex'],
-                                   columns=columns, values=values
-                                   ).dropna().reset_index()
+    data = pd.pivot_table(data, index=['year_start', 'age_group_start', 'sex'],
+                          columns=columns, values=values).dropna().reset_index()
     # merge back on the other edges
     idx = data.index
     data = data.set_index(['year_start', 'age_group_start', 'sex'], drop=False)

--- a/tests/dataset_manager/test_dataset_manager.py
+++ b/tests/dataset_manager/test_dataset_manager.py
@@ -43,21 +43,22 @@ def test_subset_rows():
 
 
 def test_subset_columns():
-    values = [0, 'Kenya', 12, 35, 'red', 100]
-    data = build_table(values, 1990, 2010, columns=('age', 'year', 'sex', 'draw', 'location',
-                                                    'age_group_start', 'age_group_end', 'color', 'value'))
+    values = [0, 'Kenya', 'red', 100]
+    data = build_table(values, 1990, 2010, columns=('age', 'year', 'sex', 'draw', 'location', 'color', 'value'))
 
     filtered_data = _subset_columns(data, keep_age_group_edges=False)
-    assert filtered_data.equals(data[['age', 'year', 'sex', 'color', 'value']])
+    assert filtered_data.equals(data[['age', 'year', 'year_start', 'year_end', 'sex', 'color', 'value']])
 
     filtered_data = _subset_columns(data, keep_age_group_edges=False, color='red')
-    assert filtered_data.equals(data[['age', 'year', 'sex', 'value']])
+    assert filtered_data.equals(data[['age', 'year', 'year_start', 'year_end', 'sex', 'value']])
 
     filtered_data = _subset_columns(data, keep_age_group_edges=True)
-    assert filtered_data.equals(data[['age', 'year', 'sex', 'age_group_start', 'age_group_end', 'color', 'value']])
+    assert filtered_data.equals(data[['age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                                      'year_end', 'sex', 'color', 'value']])
 
     filtered_data = _subset_columns(data, keep_age_group_edges=True, color='red')
-    assert filtered_data.equals(data[['age', 'year', 'sex', 'age_group_start', 'age_group_end', 'value']])
+    assert filtered_data.equals(data[['age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                                      'year_end', 'sex', 'value']])
 
 
 def test_location_term():

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -222,7 +222,8 @@ def test_mortality_rate(base_config, base_plugins, disease):
     mortality_rate = simulation.values.register_rate_producer('mortality_rate')
     mortality_rate.source = simulation.tables.build_table(build_table(0.0, year_start, year_end),
                                                           key_columns=('sex',),
-                                                          parameter_columns=('age', 'year'),
+                                                          parameter_columns=[('age', 'age_group_start', 'age_group_end'),
+                                                                             ('year', 'year_start', 'year_end')],
                                                           value_columns=None)
 
     simulation.step()
@@ -254,7 +255,8 @@ def test_incidence(base_config, base_plugins, disease):
 
     transition.base_rate = simulation.tables.build_table(build_table(0.7, year_start, year_end),
                                                          key_columns=('sex',),
-                                                         parameter_columns=('age', 'year'),
+                                                         parameter_columns=[('age', 'age_group_start', 'age_group_end'),
+                                                                            ('year', 'year_start', 'year_end')],
                                                          value_columns=None)
 
     incidence_rate = simulation.values.get_rate('sick.incidence_rate')
@@ -291,7 +293,8 @@ def test_risk_deletion(base_config, base_plugins, disease):
     paf = 0.1
     transition.base_rate = simulation.tables.build_table(build_table(base_rate, year_start, year_end),
                                                          key_columns=('sex',),
-                                                         parameter_columns=('age', 'year'),
+                                                         parameter_columns=[('age', 'age_group_start', 'age_group_end'),
+                                                                            ('year', 'year_start', 'year_end')],
                                                          value_columns=None)
 
     incidence_rate = simulation.values.get_rate('sick.incidence_rate')
@@ -299,7 +302,8 @@ def test_risk_deletion(base_config, base_plugins, disease):
     simulation.values.register_value_modifier(
         'sick.paf', modifier=simulation.tables.build_table(build_table(paf, year_start, year_end),
                                                            key_columns=('sex',),
-                                                           parameter_columns=('age', 'year'),
+                                                           parameter_columns=[('age', 'age_group_start', 'age_group_end'),
+                                                                              ('year', 'year_start', 'year_end')],
                                                            value_columns=None))
 
     simulation.step()

--- a/tests/risks/test_distributions.py
+++ b/tests/risks/test_distributions.py
@@ -10,10 +10,12 @@ def test_risk_factor(mocker):
     test_rf = mocker.MagicMock()
     test_rf.test_risk = dict()
     test_rf.test_risk['distribution'] = 'ensemble'
-    exposure_mean = pd.DataFrame({'year': [1990]*4, 'sex': [1]*4,
-                                  'age': [2, 3, 4, 5], 'value': [10, 20, 30, 40]})
-    exposure_sd = pd.DataFrame({'year': [1990]*4, 'sex': [1]*4,
-                                'age': [2, 3, 4, 5], 'value': [1, 3, 5, 7]})
+    exposure_mean = pd.DataFrame({'year': [1990]*4, 'year_start': [1990]*4, 'year_end': [1992]*4, 'sex': [1]*4,
+                                  'age': [2, 3, 4, 5], 'age_group_start': [2, 3, 4, 5], 'age_group_end': [3, 4, 5, 6],
+                                  'value': [10, 20, 30, 40]})
+    exposure_sd = pd.DataFrame({'year': [1990]*4, 'year_start': [1990]*4, 'year_end': [1992]*4, 'sex': [1]*4,
+                                'age': [2, 3, 4, 5], 'age_group_start': [2, 3, 4, 5], 'age_group_end': [3, 4, 5, 6],
+                                'value': [1, 3, 5, 7]})
     weights = {'betasr': 0.1, 'exp': 0.1, 'gamma': 0.1, 'gumbel': 0.1, 'invgamma': 0.1,
                'llogis': 0.1,  'lnorm': 0.1, 'mgamma': 0.1,  'mgumbel': 0.1,
                'norm': 0.03, 'invweibull': 0.03, 'weibull': 0.04}

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -265,7 +265,8 @@ def test_CategoricalRiskComponent_dichotomous_case(base_config, base_plugins):
 
     exposure_data = build_table(
         0.5, year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2']
-    ).melt(id_vars=('age', 'year', 'sex'), var_name='parameter', value_name='value')
+    ).melt(id_vars=('age', 'age_group_start', 'age_group_end',
+                    'year', 'year_start', 'year_end', 'sex'), var_name='parameter', value_name='value')
 
     simulation.data.write("risk_factor.test_risk.exposure", exposure_data)
 
@@ -325,7 +326,8 @@ def test_CategoricalRiskComponent_polytomous_case(base_config, base_plugins):
 
     exposure_data = build_table(
         0.25, year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2', 'cat3', 'cat4']
-    ).melt(id_vars=('age', 'year', 'sex'), var_name='parameter', value_name='value')
+    ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                    'year_end', 'sex'), var_name='parameter', value_name='value')
 
     affected_causes = ["test_cause_1", "test_cause_2"]
     rr_data = []
@@ -456,7 +458,8 @@ def test_IndirectEffect_dichotomous(base_config, base_plugins):
 
     rf_exposure_data = build_table(
         [rf_exposed, 1-rf_exposed], year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2']
-    ).melt(id_vars=('age', 'year', 'sex'), var_name='parameter', value_name='value')
+    ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                    'year_end', 'sex'), var_name='parameter', value_name='value')
 
     # start with the only risk factor without indirect effect from coverage_gap
     simulation = initialize_simulation([TestPopulation(), affected_risk],
@@ -480,7 +483,8 @@ def test_IndirectEffect_dichotomous(base_config, base_plugins):
     cg_exposed = 0.6
     cg_exposure_data = build_table(
         [cg_exposed, 1-cg_exposed], year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2']
-    ).melt(id_vars=('age', 'year', 'sex'), var_name='parameter', value_name='value')
+    ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                    'year_end', 'sex',), var_name='parameter', value_name='value')
 
     rr = 2
     rr_data = build_table(

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -61,14 +61,16 @@ def test_RiskEffect(base_config, base_plugins, mocker):
     rates = simulation.values.register_rate_producer('test_cause.incidence_rate')
     rates.source = simulation.tables.build_table(build_table(0.01, year_start, year_end),
                                                  key_columns=('sex',),
-                                                 parameter_columns=('age', 'year'),
+                                                 parameter_columns=[('age', 'age_group_start', 'age_group_end'),
+                                                                    ('year', 'year_start', 'year_end')],
                                                  value_columns=None)
 
     # This one should not
     other_rates = simulation.values.register_rate_producer('some_other_cause.incidence_rate')
     other_rates.source = simulation.tables.build_table(build_table(0.01, year_start, year_end),
                                                        key_columns=('sex',),
-                                                       parameter_columns=('age', 'year'),
+                                                       parameter_columns=[('age', 'age_group_start', 'age_group_end'),
+                                                                          ('year', 'year_start', 'year_end')],
                                                        value_columns=None)
 
     assert np.allclose(rates(simulation.population.population.index), from_yearly(0.01, time_step))
@@ -273,7 +275,8 @@ def test_CategoricalRiskComponent_dichotomous_case(base_config, base_plugins):
         rr_data.append(
             build_table(
                 [1.01, 1, cause], year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2', 'cause']
-            ).melt(id_vars=('age', 'year', 'sex', 'cause'), var_name='parameter', value_name='value')
+            ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                            'year_end', 'sex', 'cause'), var_name='parameter', value_name='value')
         )
     rr_data = pd.concat(rr_data)
 
@@ -282,6 +285,7 @@ def test_CategoricalRiskComponent_dichotomous_case(base_config, base_plugins):
 
     simulation.data.write("risk_factor.test_risk.affected_causes", affected_causes)
     simulation.data.write("risk_factor.test_risk.distribution", "dichotomous")
+    simulation.data.write("risk_factor.test_risk.affected_risk_factors", [])
 
     simulation.setup()
 
@@ -290,7 +294,8 @@ def test_CategoricalRiskComponent_dichotomous_case(base_config, base_plugins):
     incidence_rate = simulation.values.register_rate_producer(affected_causes[0]+'.incidence_rate')
     incidence_rate.source = simulation.tables.build_table(build_table(0.01, year_start, year_end),
                                                           key_columns=('sex',),
-                                                          parameter_columns=('age', 'year'),
+                                                          parameter_columns=[('age', 'age_group_start', 'age_group_end'),
+                                                                             ('year', 'year_start', 'year_end')],
                                                           value_columns=None)
 
     categories = simulation.values.get_value('test_risk.exposure')(simulation.population.population.index)
@@ -328,7 +333,8 @@ def test_CategoricalRiskComponent_polytomous_case(base_config, base_plugins):
         rr_data.append(
             build_table([1.03, 1.02, 1.01, 1, cause], year_start, year_end,
                         ['age', 'year', 'sex', 'cat1', 'cat2', 'cat3', 'cat4', 'cause']
-                        ).melt(id_vars=('age', 'year', 'sex', 'cause'), var_name='parameter', value_name='value')
+                        ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                            'year_end', 'sex', 'cause'), var_name='parameter', value_name='value')
         )
     rr_data = pd.concat(rr_data)
 
@@ -344,7 +350,8 @@ def test_CategoricalRiskComponent_polytomous_case(base_config, base_plugins):
     incidence_rate = simulation.values.register_rate_producer(affected_causes[0]+'.incidence_rate')
     incidence_rate.source = simulation.tables.build_table(build_table(0.01, year_start, year_end),
                                                           key_columns=('sex',),
-                                                          parameter_columns=('age', 'year'),
+                                                          parameter_columns=[('age', 'age_group_start', 'age_group_end'),
+                                                                             ('year', 'year_start', 'year_end')],
                                                           value_columns=None)
 
     categories = simulation.values.get_value('test_risk.exposure')(simulation.population.population.index)
@@ -376,7 +383,8 @@ def test_ContinuousRiskComponent(get_distribution_mock, base_config, base_plugin
     for cause in affected_causes:
         rr_data.append(
             build_table([1.01, cause], year_start, year_end, ['age', 'sex', 'year', 'value', 'cause'],
-                        ).melt(id_vars=('age', 'year', 'sex', 'cause'), var_name='parameter', value_name='value')
+                        ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                            'year_end', 'sex', 'cause'), var_name='parameter', value_name='value')
         )
     rr_data = pd.concat(rr_data)
 
@@ -426,7 +434,8 @@ def test_ContinuousRiskComponent(get_distribution_mock, base_config, base_plugin
     incidence_rate = simulation.values.register_rate_producer(affected_causes[0]+'.incidence_rate')
     incidence_rate.source = simulation.tables.build_table(build_table(0.01, year_start, year_end),
                                                           key_columns=('sex',),
-                                                          parameter_columns=('age', 'year'),
+                                                          parameter_columns=[('age', 'age_group_start', 'age_group_end'),
+                                                                             ('year', 'year_start', 'year_end')],
                                                           value_columns=None)
 
     exposure = simulation.values.get_value('test_risk.exposure')
@@ -476,7 +485,8 @@ def test_IndirectEffect_dichotomous(base_config, base_plugins):
     rr = 2
     rr_data = build_table(
         [rr, 1], year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2']
-    ).melt(id_vars=('age', 'year', 'sex'), var_name='parameter', value_name='value')
+    ).melt(id_vars=('age', 'age_group_start', 'age_group_end',
+                    'year', 'year_start', 'year_end', 'sex'), var_name='parameter', value_name='value')
 
     rr_data['risk_factor'] = 'test_risk'
 
@@ -485,7 +495,8 @@ def test_IndirectEffect_dichotomous(base_config, base_plugins):
 
     paf_data = build_table(
         paf, year_start, year_end, ['age', 'year', 'sex', 'population_attributable_fraction']
-    ).melt(id_vars=('age', 'year', 'sex'), var_name='population_attributable_fraction', value_name='value')
+    ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                    'year_end', 'sex'), var_name='population_attributable_fraction', value_name='value')
 
     paf_data['risk_factor'] = 'test_risk'
 


### PR DESCRIPTION
all the changes to public health to accompany the changed binned, order 0 interp in vivarium

the most non-obvious change is I had to rework whenever pivot table was called because with the bin edges in there, I ran into memory errors (apparently pivot table makes a bunch of copies of the data) so I pivoted on the start edges and then re-attached the ends after

tests won't pass until upstream interpolation is updated in vivarium, but locally all tests + smoke tests run when I'm on the feature/order_0_interp branch in all repos