### PR TITLE
Refactor/paf by risk

### DIFF
--- a/src/vivarium_public_health/risks/data_transformation.py
+++ b/src/vivarium_public_health/risks/data_transformation.py
@@ -78,7 +78,7 @@ def get_paf_data(ex: pd.DataFrame, rr: pd.DataFrame) -> pd.DataFrame:
     df = df.groupby(['age', 'sex', 'year'], as_index=False)
 
     def compute_paf(g):
-        to_drop = g['parameter']!='cat1'
+        to_drop = g['parameter'] != 'cat1'
         tmp = g['value_x'] * g['value_y']
         tmp = tmp.sum()
         g.drop(g[to_drop].index, inplace=True)

--- a/src/vivarium_public_health/risks/data_transformation.py
+++ b/src/vivarium_public_health/risks/data_transformation.py
@@ -67,3 +67,26 @@ def rebin_rr_data(rr: pd.DataFrame, exposure: pd.DataFrame) -> pd.DataFrame:
     df = df.apply(rebin_rr).reset_index().loc[:, ['year', 'parameter', 'sex', 'age', 'value', 'age_group_start',
                                                   'age_group_end', 'year_start', 'year_end']]
     return df.replace(unexposed, 'cat2')
+
+
+def get_paf_data(ex: pd.DataFrame, rr: pd.DataFrame) -> pd.DataFrame:
+
+    years = rr.year.unique()
+    ex = ex[ex['year'].isin(years)]
+    key_cols = ['sex', 'age', 'parameter', 'year', 'year_start', 'year_end', 'age_group_start', 'age_group_end']
+    df = ex.merge(rr, on=key_cols)
+    df = df.groupby(['age', 'sex', 'year'], as_index=False)
+
+    def compute_paf(g):
+        to_drop = g['parameter']!='cat1'
+        tmp = g['value_x'] * g['value_y']
+        tmp = tmp.sum()
+        g.drop(g[to_drop].index, inplace=True)
+        g.drop(['parameter', 'value_x', 'value_y'], axis=1, inplace=True)
+        g['value'] = (tmp-1)/tmp
+        return g
+
+    paf = df.apply(compute_paf).reset_index()
+    paf = paf.replace(-np.inf, 0)  # Rows with zero exposure.
+
+    return paf

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -441,8 +441,7 @@ class DichotomousDistribution:
         return base_exposure * (1-joint_paf)
 
     def ppf(self, x):
-        exposed = x < self.exposur
-        e_proportion(x.index)
+        exposed = x < self.exposure_proportion(x.index)
 
         return pd.Series(exposed.replace({True: 'cat1', False: 'cat2'}), name=self._risk + '_exposure', index=x.index)
 

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -441,7 +441,8 @@ class DichotomousDistribution:
         return base_exposure * (1-joint_paf)
 
     def ppf(self, x):
-        exposed = x < self.exposure_proportion(x.index)
+        exposed = x < self.exposur
+        e_proportion(x.index)
 
         return pd.Series(exposed.replace({True: 'cat1', False: 'cat2'}), name=self._risk + '_exposure', index=x.index)
 

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -57,7 +57,7 @@ class RiskEffect:
         return self.exposure_effect(target, self.relative_risk(index))
 
     def _get_paf_data(self, builder):
-        filter_name, filter = self.affected_entity_type, self.affected_entity
+        filter_name, filter_term = self.affected_entity_type, self.affected_entity
         if 'paf' in self._get_data_functions:
             paf_data = self._get_data_functions['paf'](builder)
 
@@ -69,10 +69,10 @@ class RiskEffect:
             else:
                 exposure = builder.data.load(f'{self.risk_type}.{self.risk}.exposure')
                 rr = builder.data.load(f'{self.risk_type}.{self.risk}.relative_risk')
-                rr = rr[rr[filter_name] == filter]
+                rr = rr[rr[filter_name] == filter_term]
                 paf_data = get_paf_data(exposure, rr)
 
-        paf_data = paf_data[paf_data[filter_name] == filter]
+        paf_data = paf_data[paf_data[filter_name] == filter_term]
         paf_data = paf_data.loc[:, ['year', 'sex', 'age', 'value', self.affected_entity_type, 'age_group_start', 'age_group_end',
                                     'year_start', 'year_end']]
 

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -62,14 +62,13 @@ class RiskEffect:
             filter_name, filter = self.affected_entity_type, self.affected_entity
             paf_data = paf_data[paf_data[filter_name] == filter]
         else:
-            exposure = builder.data.load(f'{self.risk_type}.{self.risk}.exposure')
-            rr = builder.data.load(f'{self.risk_type}.{self.risk}.relative_risk')
-            rr = rr[rr[self.affected_entity_type] == self.affected_entity]
             distribution = builder.data.load(f'{self.risk_type}.{self.risk}.distribution')
-
-            if distribution in ['c', 'lognormal', 'ensemble']:
+            if distribution in ['normal', 'lognormal', 'ensemble']:
                 paf_data = builder.data.load(f'{self.risk_type}.{self.risk}.population_attributable_fraction')
             else:
+                exposure = builder.data.load(f'{self.risk_type}.{self.risk}.exposure')
+                rr = builder.data.load(f'{self.risk_type}.{self.risk}.relative_risk')
+                rr = rr[rr[self.affected_entity_type] == self.affected_entity]
                 paf_data = get_paf_data(exposure, rr)
 
         paf_data = paf_data[['year', 'sex', 'age', 'value', 'cause', 'age_group_start', 'age_group_end', 'year_start',

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -60,20 +60,22 @@ class RiskEffect:
         filter_name, filter = self.affected_entity_type, self.affected_entity
         if 'paf' in self._get_data_functions:
             paf_data = self._get_data_functions['paf'](builder)
-            paf_data = paf_data[paf_data[filter_name] == filter]
+
         else:
             distribution = builder.data.load(f'{self.risk_type}.{self.risk}.distribution')
             if distribution in ['normal', 'lognormal', 'ensemble']:
                 paf_data = builder.data.load(f'{self.risk_type}.{self.risk}.population_attributable_fraction')
-                paf_data = paf_data[paf_data[filter_name] == filter]
+
             else:
                 exposure = builder.data.load(f'{self.risk_type}.{self.risk}.exposure')
                 rr = builder.data.load(f'{self.risk_type}.{self.risk}.relative_risk')
                 rr = rr[rr[filter_name] == filter]
                 paf_data = get_paf_data(exposure, rr)
 
+        paf_data = paf_data[paf_data[filter_name] == filter]
         paf_data = paf_data.loc[:, ['year', 'sex', 'age', 'value', self.affected_entity_type, 'age_group_start', 'age_group_end',
                                     'year_start', 'year_end']]
+
         return pivot_age_sex_year_binned(paf_data, self.affected_entity_type, 'value')
 
     def _get_rr_data(self, builder):

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -71,9 +71,9 @@ class RiskEffect:
                 rr = rr[rr[self.affected_entity_type] == self.affected_entity]
                 paf_data = get_paf_data(exposure, rr)
 
-        paf_data = paf_data[['year', 'sex', 'age', 'value', 'cause', 'age_group_start', 'age_group_end', 'year_start',
-                             'year_end']]
-        return pivot_age_sex_year_binned(paf_data, 'cause', 'value')
+        paf_data = paf_data.loc[:, ['year', 'sex', 'age', 'value', self.affected_entity_type, 'age_group_start', 'age_group_end',
+                                    'year_start', 'year_end']]
+        return pivot_age_sex_year_binned(paf_data, self.affected_entity_type, 'value')
 
     def _get_rr_data(self, builder):
         if 'rr' in self._get_data_functions:

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -57,18 +57,19 @@ class RiskEffect:
         return self.exposure_effect(target, self.relative_risk(index))
 
     def _get_paf_data(self, builder):
+        filter_name, filter = self.affected_entity_type, self.affected_entity
         if 'paf' in self._get_data_functions:
             paf_data = self._get_data_functions['paf'](builder)
-            filter_name, filter = self.affected_entity_type, self.affected_entity
             paf_data = paf_data[paf_data[filter_name] == filter]
         else:
             distribution = builder.data.load(f'{self.risk_type}.{self.risk}.distribution')
             if distribution in ['normal', 'lognormal', 'ensemble']:
                 paf_data = builder.data.load(f'{self.risk_type}.{self.risk}.population_attributable_fraction')
+                paf_data = paf_data[paf_data[filter_name] == filter]
             else:
                 exposure = builder.data.load(f'{self.risk_type}.{self.risk}.exposure')
                 rr = builder.data.load(f'{self.risk_type}.{self.risk}.relative_risk')
-                rr = rr[rr[self.affected_entity_type] == self.affected_entity]
+                rr = rr[rr[filter_name] == filter]
                 paf_data = get_paf_data(exposure, rr)
 
         paf_data = paf_data.loc[:, ['year', 'sex', 'age', 'value', self.affected_entity_type, 'age_group_start', 'age_group_end',

--- a/src/vivarium_public_health/testing/mock_artifact.py
+++ b/src/vivarium_public_health/testing/mock_artifact.py
@@ -18,7 +18,7 @@ MOCKERS = {
             'distribution': lambda *args, **kwargs: 'ensemble',
             'exposure': 120,
             'exposure_standard_deviation': 15,
-            'relative_risk': build_table([1.5, "nomarl", "test_cause"], 1990, 2018,
+            'relative_risk': build_table([1.5, "continuous", "test_cause"], 1990, 2018,
                                          ("age", "sex", "year", "value", "parameter", "cause")),
             'population_attributable_fraction': build_table([1, "test_cause_1"], 1990, 2018,
                                                             ("age", "sex", "year", "value", "cause")),

--- a/src/vivarium_public_health/testing/mock_artifact.py
+++ b/src/vivarium_public_health/testing/mock_artifact.py
@@ -9,8 +9,6 @@ MOCKERS = {
         'cause': {
             'prevalence': 0,
             'cause_specific_mortality': 0,
-            'population_attributable_fraction': build_table([1, "test_risk"], 1990, 2018,
-                                                            ("age", "sex", "year", "value", "risk_factor")),
             'excess_mortality': 0,
             'remission': 0,
             'incidence': 0.001,
@@ -20,8 +18,10 @@ MOCKERS = {
             'distribution': lambda *args, **kwargs: 'ensemble',
             'exposure': 120,
             'exposure_standard_deviation': 15,
-            'relative_risk': build_table([1.5, "continuous", "test_cause"], 1990, 2018,
+            'relative_risk': build_table([1.5, "nomarl", "test_cause"], 1990, 2018,
                                          ("age", "sex", "year", "value", "parameter", "cause")),
+            'population_attributable_fraction': build_table([1, "test_cause_1"], 1990, 2018,
+                                                            ("age", "sex", "year", "value", "cause")),
             'tmred': lambda *args, **kwargs: {
                 "distribution": "uniform",
                 "min": 80,

--- a/tests/risks/conftest.py
+++ b/tests/risks/conftest.py
@@ -1,0 +1,179 @@
+import pytest
+from typing import List
+import pandas as pd
+
+from vivarium.testing_utilities import build_table
+from vivarium_public_health.risks.base_risk import Risk
+
+
+def make_test_data_table(values: List, parameter='cat') -> pd.DataFrame:
+    year_start = 1990  # same as the base config
+    year_end = 2010
+
+    if len(values) == 1:
+        df = build_table(values[0], year_start, year_end, ('age', 'year', 'sex', 'value'))
+    else:
+        cats = [f'{parameter}{i+1}' for i in range(len(values))] if parameter == 'cat' else parameter
+        df = []
+        for cat, value in zip(cats, values):
+            df.append(build_table([cat, value], year_start, year_end, ('age','year', 'sex', 'parameter', 'value')))
+        df = pd.concat(df)
+    return df
+
+
+@pytest.fixture(scope='module')
+def continuous_risk():
+    year_start = 1990
+    year_end = 2010
+    risk = 'test_risk'
+    risk_data = dict()
+    exposure_mean = make_test_data_table([130])
+    exposure_sd = make_test_data_table([15])
+    affected_causes = ["test_cause_1", "test_cause_2"]
+    rr_data = []
+    paf_data = []
+    for cause in affected_causes:
+        rr_data.append(
+            build_table([1.01, cause], year_start, year_end, ['age', 'sex', 'year', 'value', 'cause'],
+                        ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                                        'year_end', 'sex', 'cause'), var_name='parameter', value_name='value')
+        )
+        paf_data.append(build_table([1, cause], year_start, year_end, ['age', 'sex', 'year', 'value', 'cause']))
+    rr_data = pd.concat(rr_data)
+    paf_data = pd.concat(paf_data)
+    risk_data['exposure'] = exposure_mean
+    risk_data['exposure_standard_deviation'] = exposure_sd
+    risk_data['relative_risk'] = rr_data
+    risk_data['population_attributable_fraction'] = paf_data
+    risk_data['affected_causes'] = affected_causes
+    risk_data['affected_risk_factors'] = []
+
+    tmred = {
+        "distribution": 'uniform',
+        "min": 110.0,
+        "max": 115.0,
+        "inverted": False,
+    }
+    exposure_parameters = {
+        "scale": 10.0,
+        "max_rr": 200.0,
+        "max_val": 300.0,
+        "min_val": 50.0,
+    }
+    tmrel = 0.5 * (tmred["max"] + tmred["min"])
+    risk_data['tmred'] = tmred
+    risk_data['tmrel'] = tmrel
+    risk_data['exposure_parameters'] = exposure_parameters
+    risk_data['distribution'] = 'normal'
+
+    return Risk("risk_factor", risk), risk_data
+
+
+@pytest.fixture(scope='module')
+def dichotomous_risk():
+    year_start = 1990
+    year_end = 2010
+    risk = 'test_risk'
+    risk_data = dict()
+    exposure_data = build_table(
+        0.5, year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2']
+    ).melt(id_vars=('age', 'age_group_start', 'age_group_end',
+                    'year', 'year_start', 'year_end', 'sex'), var_name='parameter', value_name='value')
+
+    affected_causes = ["test_cause_1", "test_cause_2"]
+    rr_data = []
+    paf_data = []
+    for cause in affected_causes:
+        rr_data.append(
+            build_table(
+                [1.01, 1, cause], year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2', 'cause']
+            ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                            'year_end', 'sex', 'cause'), var_name='parameter', value_name='value')
+        )
+        paf_data.append(build_table([1, cause], year_start, year_end, ['age', 'sex', 'year', 'value', 'cause']))
+    rr_data = pd.concat(rr_data)
+    paf_data = pd.concat(paf_data)
+    risk_data['exposure'] = exposure_data
+    risk_data['relative_risk'] = rr_data
+    risk_data['population_attributable_fraction'] = paf_data
+    risk_data['affected_causes'] = affected_causes
+    risk_data['affected_risk_factors'] = []
+    incidence_rate = build_table(0.01, year_start, year_end)
+    risk_data['incidence_rate'] = incidence_rate
+    risk_data['distribution'] = 'dichotomous'
+    return Risk('risk_factor', risk), risk_data
+
+
+@pytest.fixture(scope='module')
+def polytomous_risk():
+    year_start = 1990
+    year_end = 2010
+    risk = 'test_risk'
+    risk_data = dict()
+    exposure_data = build_table(
+        0.25, year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2', 'cat3', 'cat4']
+    ).melt(id_vars=('age', 'age_group_start', 'age_group_end',
+                    'year', 'year_start', 'year_end', 'sex'), var_name='parameter', value_name='value')
+
+    affected_causes = ["test_cause_1", "test_cause_2"]
+    rr_data = []
+    paf_data = []
+    for cause in affected_causes:
+        rr_data.append(
+            build_table(
+                [1.03, 1.02, 1.01, 1, cause], year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2', 'cat3', 'cat4', 'cause']
+            ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                            'year_end', 'sex', 'cause'), var_name='parameter', value_name='value')
+        )
+        paf_data.append(build_table([1, cause], year_start, year_end, ['age', 'sex', 'year', 'value', 'cause']))
+    rr_data = pd.concat(rr_data)
+    paf_data = pd.concat(paf_data)
+    risk_data['exposure'] = exposure_data
+    risk_data['relative_risk'] = rr_data
+    risk_data['population_attributable_fraction'] = paf_data
+    risk_data['affected_causes'] = affected_causes
+    risk_data['affected_risk_factors'] = []
+    incidence_rate = build_table(0.01, year_start, year_end)
+    risk_data['incidence_rate'] = incidence_rate
+    risk_data['distribution'] = 'polytomous'
+    return Risk('risk_factor', risk), risk_data
+
+
+@pytest.fixture(scope='module')
+def coverage_gap():
+    year_start = 1990
+    year_end = 2010
+    cg = 'test_coverage_gap'
+    cg_data = dict()
+    cg_exposed = 0.6
+    cg_exposure_data = build_table(
+        [cg_exposed, 1 - cg_exposed], year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2']
+    ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                    'year_end', 'sex',), var_name='parameter', value_name='value')
+
+
+
+    rr = 2
+    rr_data = build_table(
+        [rr, 1], year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2']
+    ).melt(id_vars=('age', 'age_group_start', 'age_group_end',
+                    'year', 'year_start', 'year_end', 'sex'), var_name='parameter', value_name='value')
+
+    # paf is (sum(exposure(category)*rr(category) -1 )/ (sum(exposure(category)* rr(category)
+    paf = (rr * cg_exposed + (1 - cg_exposed) - 1) / (rr * cg_exposed + (1 - cg_exposed))
+
+    paf_data = build_table(
+        paf, year_start, year_end, ['age', 'year', 'sex', 'population_attributable_fraction']
+    ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
+                    'year_end', 'sex'), var_name='population_attributable_fraction', value_name='value')
+
+    paf_data['risk_factor'] = 'test_risk'
+
+    cg_data['exposure'] = cg_exposure_data
+    rr_data['risk_factor'] = 'test_risk'
+    cg_data['relative_risk'] = rr_data
+    cg_data['population_attributable_fraction'] = paf_data
+    cg_data['affected_causes'] = []
+    cg_data['affected_risk_factors'] = ['test_risk']
+    cg_data['distribution'] = 'dichotomous'
+    return Risk('coverage_gap', cg) , cg_data

--- a/tests/risks/test_base_risk.py
+++ b/tests/risks/test_base_risk.py
@@ -34,12 +34,18 @@ def test_propensity_effect(mocker, base_config, base_plugins):
     affected_causes = ["test_cause_1", "test_cause_2"]
 
     rr_data = []
+    paf_data = []
     for cause in affected_causes:
         rr_data.append(
             build_table([1.01, 'continuous', cause], year_start, year_end,
                         ('age', 'year', 'sex', 'value', 'parameter', 'cause'))
         )
+        paf_data.append(
+            build_table([1, 'continuous', cause], year_start, year_end,
+                        ('age', 'year', 'sex', 'value', 'parameter', 'cause'))
+        )
     rr_data = pd.concat(rr_data)
+    paf_data = pd.concat(paf_data)
 
     tmred = {
             "distribution": 'uniform',
@@ -78,7 +84,7 @@ def test_propensity_effect(mocker, base_config, base_plugins):
     simulation.data.write("risk_factor.test_risk.exposure_parameters", exposure_parameters)
     simulation.data.write("risk_factor.test_risk.exposure", exposure_data)
     simulation.data.write("risk_factor.test_risk.relative_risk", rr_data)
-    simulation.data.write("risk_factor.test_risk.population_attributable_fraction", 1)
+    simulation.data.write("risk_factor.test_risk.population_attributable_fraction", paf_data)
     simulation.data.write("risk_factor.test_risk.affected_causes", affected_causes)
     simulation.data.write("risk_factor.test_risk.affected_risk_factors", [])
     simulation.data.write("risk_factor.test_risk.distribution", "ensemble")

--- a/tests/risks/test_base_risk.py
+++ b/tests/risks/test_base_risk.py
@@ -1,117 +1,31 @@
+import pytest
+
 import numpy as np
 import pandas as pd
 from scipy.stats import norm
-import pytest
 
-from vivarium.testing_utilities import build_table, TestPopulation, metadata
+from vivarium.testing_utilities import TestPopulation, metadata
 from vivarium.interface.interactive import initialize_simulation
 
-from vivarium_public_health.risks.base_risk import Risk
 
+@pytest.mark.parametrize('propensity', [0.00001, 0.5, 0.99])
+def test_propensity_effect(propensity, mocker, continuous_risk, base_config, base_plugins):
+    population_size = 1000
 
-@pytest.fixture
-def make_dummy_column(name, initial_value):
-    class _make_dummy_column:
-        def setup(self, builder):
-            self.population_view = builder.population.get_view([name])
-            builder.population.initializes_simulants(self.make_column, creates_columns=[name])
+    rf, risk_data = continuous_risk
+    base_config.update({'population': {'population_size': population_size}}, **metadata(__file__))
+    sim = initialize_simulation([TestPopulation(), rf], input_config=base_config, plugin_config=base_plugins)
+    for key, value in risk_data.items():
+        sim.data.write(f'risk_factor.test_risk.{key}', value)
 
-        def make_column(self, pop_data):
-            self.population_view.update(pd.Series(initial_value, index=pop_data.index, name=name))
-    return _make_dummy_column()
-
-
-
-def test_propensity_effect(mocker, base_config, base_plugins):
-    year_start = base_config.time.start.year
-    year_end = base_config.time.end.year
-
-    risk = "test_risk"
-
-    exposure_data = build_table(
-        0.5, year_start, year_end
-    ).melt(id_vars=('age', 'year', 'sex'), var_name='parameter', value_name='value')
-
-    affected_causes = ["test_cause_1", "test_cause_2"]
-
-    rr_data = []
-    paf_data = []
-    for cause in affected_causes:
-        rr_data.append(
-            build_table([1.01, 'continuous', cause], year_start, year_end,
-                        ('age', 'year', 'sex', 'value', 'parameter', 'cause'))
-        )
-        paf_data.append(
-            build_table([1, 'continuous', cause], year_start, year_end,
-                        ('age', 'year', 'sex', 'value', 'parameter', 'cause'))
-        )
-    rr_data = pd.concat(rr_data)
-    paf_data = pd.concat(paf_data)
-
-    tmred = {
-            "distribution": 'uniform',
-            "min": 110.0,
-            "max": 115.0,
-            "inverted": False,
-    }
-    exposure_parameters = {
-            "scale": 10.0,
-            "max_rr": 200.0,
-            "max_val": 300.0,
-            "min_val": 50.0,
-    }
-
-    class Distribution:
-        def __init__(self, *_, **__):
-            pass
-
-        def setup(self, builder):
-            data = build_table([130, 15], year_start, year_end, ['age', 'year', 'sex', 'mean', 'std'])
-            self.parameters = builder.lookup.build_table(data)
-
-        def ppf(self, propensity):
-            params = self.parameters(propensity.index)
-            return norm(loc=params['mean'], scale=params['std']).ppf(propensity)
-
-    get_distribution_mock = mocker.patch('vivarium_public_health.risks.base_risk.get_distribution')
-    get_distribution_mock.side_effect = lambda *args, **kwargs: Distribution(args, kwargs)
-
-    component = Risk("risk_factor", risk)
-
-    base_config.update({'population': {'population_size': 100000}}, **metadata(__file__))
-    simulation = initialize_simulation([TestPopulation(), component],
-                                       input_config=base_config, plugin_config=base_plugins)
-    simulation.data.write("risk_factor.test_risk.tmred", tmred)
-    simulation.data.write("risk_factor.test_risk.exposure_parameters", exposure_parameters)
-    simulation.data.write("risk_factor.test_risk.exposure", exposure_data)
-    simulation.data.write("risk_factor.test_risk.relative_risk", rr_data)
-    simulation.data.write("risk_factor.test_risk.population_attributable_fraction", paf_data)
-    simulation.data.write("risk_factor.test_risk.affected_causes", affected_causes)
-    simulation.data.write("risk_factor.test_risk.affected_risk_factors", [])
-    simulation.data.write("risk_factor.test_risk.distribution", "ensemble")
-    simulation.setup()
-
+    sim.setup()
     propensity_pipeline = mocker.Mock()
-    simulation.values.register_value_producer('test_risk.propensity', propensity_pipeline)
-    propensity_pipeline.side_effect = lambda index: pd.Series(0.00001, index)
+    sim.values.register_value_producer('test_risk.propensity', source=propensity_pipeline)
+    propensity_pipeline.side_effect = lambda index: pd.Series(propensity, index=index)
 
-    simulation.step()
+    expected_value = norm(loc=130, scale=15).ppf(propensity)
 
-    expected_value = norm(loc=130, scale=15).ppf(0.00001)
+    assert np.allclose(rf.exposure(sim.population.population.index), expected_value)
 
-    assert np.allclose(component.exposure(simulation.population.population.index), expected_value)
-
-    propensity_pipeline.side_effect = lambda index: pd.Series(0.5, index)
-
-    simulation.step()
-
-    expected_value = 130
-    assert np.allclose(component.exposure(simulation.population.population.index), expected_value)
-
-    propensity_pipeline.side_effect = lambda index: pd.Series(0.99999, index)
-    simulation.step()
-
-    expected_value = norm(loc=130, scale=15).ppf(0.99999)
-    assert np.allclose(component.exposure(simulation.population.population.index), expected_value)
 
 

--- a/tests/risks/test_base_risk.py
+++ b/tests/risks/test_base_risk.py
@@ -1,15 +1,15 @@
-
 import numpy as np
 import pandas as pd
 from scipy.stats import norm
+import pytest
 
 from vivarium.testing_utilities import build_table, TestPopulation, metadata
 from vivarium.interface.interactive import initialize_simulation
 
-
 from vivarium_public_health.risks.base_risk import Risk
 
 
+@pytest.fixture
 def make_dummy_column(name, initial_value):
     class _make_dummy_column:
         def setup(self, builder):
@@ -19,6 +19,7 @@ def make_dummy_column(name, initial_value):
         def make_column(self, pop_data):
             self.population_view.update(pd.Series(initial_value, index=pop_data.index, name=name))
     return _make_dummy_column()
+
 
 
 def test_propensity_effect(mocker, base_config, base_plugins):

--- a/tests/risks/test_data_transformation.py
+++ b/tests/risks/test_data_transformation.py
@@ -2,89 +2,67 @@ import pandas as pd
 import numpy as np
 
 import pytest
+from typing import List, Union
 
 from vivarium.testing_utilities import build_table
-from vivarium.framework.configuration import build_simulation_configuration
 from vivarium_public_health.risks.data_transformation import *
 
-def test_should_rebin():
-    test_config = build_simulation_configuration()
-    test_config['population'] = {'population_size': 100}
-    assert not should_rebin('test_risk', test_config)
+@pytest.fixture
+def make_test_data_table(values: List, parameter='cat') -> pd.DataFrame:
+    year_start = 1990  # same as the base config
+    year_end = 2010
 
-    test_config['test_risk'] = {}
-    assert not should_rebin('test_risk', test_config)
+    if len(values) == 1:
+        df = build_table(values[0], year_start, year_end, ('age','year', 'sex', 'value'))
+    else:
+        cats = [f'{parameter}{i+1}' for i in range(len(values))] if parameter == 'cat' else parameter
+        df = []
+        for cat, value in zip(cats, values):
+            df.append(build_table([cat, value], year_start, year_end, ('age','year', 'sex', 'parameter', 'value')))
+        df = pd.concat(df)
+    return df
 
-    test_config['test_risk'].rebin = False
-    assert not should_rebin('test_risk', test_config)
 
-    test_config['test_risk']['rebin'] = True
-    assert should_rebin('test_risk', test_config)
+def test_should_rebin(base_config):
+    assert not should_rebin('test_risk', base_config)
+
+    base_config['test_risk'].rebin = False
+    assert not should_rebin('test_risk', base_config)
+
+    base_config['test_risk']['rebin'] = True
+    assert should_rebin('test_risk', base_config)
 
 
-def test_rebin_exposure():
-    cats = ['cat1', 'cat2', 'cat3', 'cat4']
-    year_start = 2010
-    year_end = 2013
-
-    wrong_values = [0.1, 0.1, 0.1, 0.1]
-
-    wrong_df = []
-    for cat, value in zip(cats, wrong_values):
-        wrong_df.append(build_table([cat, value], year_start, year_end, ('age','year', 'sex', 'parameter', 'value')))
-    wrong_df = pd.concat(wrong_df)
+@pytest.mark.parametrize('values', [[0.1, 0.1, 0.1, 0.1], [0.2, 0.3, 0.4]])
+def test_rebin_exposure_fail(values):
+    wrong_df = make_test_data_table(values)
 
     with pytest.raises(AssertionError):
         rebin_exposure_data(wrong_df)
 
-    values = [0.1, 0.2, 0.3, 0.4]
-    test_df = []
-    for cat, value in zip(cats, values):
-        test_df.append(build_table([cat, value], year_start, year_end, ('age','year', 'sex', 'parameter', 'value')))
-    test_df = pd.concat(test_df)
 
-    expected = []
+@pytest.mark.parametrize(('initial', 'rebin'), [([0.1, 0.2, 0.3, 0.4], [0.6, 0.4]), ([0.2, 0.3, 0.3, 0.2], [0.8, 0.2])])
+def test_rebin_exposure(initial, rebin):
+    test_df = make_test_data_table(initial)
+    expected = make_test_data_table(rebin)
 
-    for cat, value in zip (['cat1', 'cat2'], [0.6, 0.4]):
-        expected.append(build_table([cat, value], year_start, year_end, ('age', 'year', 'sex', 'parameter', 'value')))
-
-    expected = pd.concat(expected).loc[:, ['age', 'year', 'sex', 'parameter', 'value']]
     rebinned = rebin_exposure_data(test_df).loc[:, expected.columns]
-    expected = expected.set_index(['age', 'year','sex'])
+    expected = expected.set_index(['age', 'year', 'sex'])
     rebinned = rebinned.set_index(['age', 'year', 'sex'])
 
     assert np.allclose(expected.value[expected.parameter == 'cat1'], rebinned.value[rebinned.parameter=='cat1'])
     assert np.allclose(expected.value[expected.parameter == 'cat2'], rebinned.value[rebinned.parameter == 'cat2'])
 
 
-def test_rebin_relative_risk():
-    cats = ['cat1', 'cat2', 'cat3', 'cat4']
-    year_start = 2008
-    year_end = 2015
+test_data = [([0.3, 0.1, 0.1, 0.5], [3, 2.5, 2, 1], [(0.3 * 3 + 0.1 * 2.5 + 0.1 * 2) / (0.3+0.1+0.1), 1]),
+             ([0.2, 0.5, 0.3], [5, 3, 1], [(0.2 * 5 + 0.5 * 3) / (0.2 + 0.5), 1])]
+@pytest.mark.parametrize('e, rr, rebin', test_data)
+def test_rebin_relative_risk(e, rr, rebin):
+    exposure = make_test_data_table(e)
+    relative_risk = make_test_data_table(rr)
+    expected = make_test_data_table(rebin)
 
-    exposure_data = [0.3, 0.1, 0.1, 0.5]
-
-    exposure = []
-    for cat, value in zip(cats, exposure_data):
-        exposure.append(build_table([cat, value], year_start, year_end, ('age', 'year', 'sex', 'parameter', 'value')))
-    exposure = pd.concat(exposure)
-
-    rr_data = [3, 2.5, 2, 1]
-
-    rr = []
-    for cat, value in zip(cats, rr_data):
-        rr.append(build_table([cat, value], year_start, year_end, ('age', 'year', 'sex', 'parameter', 'value')))
-    rr = pd.concat(rr)
-
-    expected = []
-
-    # expected rr should be weighted by exposure : for rebinned cat1 : (0.3 * 3 + 0.1 * 2.5 + 0.1* 2)/ (0.3+0.1+0.1)
-    for cat, value in zip(['cat1', 'cat2'], [(0.3 * 3 + 0.1 * 2.5 + 0.1 * 2) / (0.3+0.1+0.1), 1]):
-        expected.append(build_table([cat, value], year_start, year_end, ('age', 'year', 'sex', 'parameter', 'value')))
-
-    expected = pd.concat(expected).loc[:, ['age', 'year', 'sex', 'parameter', 'value']]
-
-    rebinned = rebin_rr_data(rr, exposure).loc[:, expected.columns]
+    rebinned = rebin_rr_data(relative_risk, exposure).loc[:, expected.columns]
     expected = expected.set_index(['age', 'year', 'sex'])
     rebinned = rebinned.set_index(['age', 'year', 'sex'])
 
@@ -92,26 +70,14 @@ def test_rebin_relative_risk():
     assert np.allclose(expected.value[expected.parameter == 'cat2'], rebinned.value[rebinned.parameter == 'cat2'])
 
 
-def test_get_paf_data():
-    cats = ['cat1', 'cat2', 'cat3', 'cat4']
-    e_values = [0.1, 0.2, 0.3, 0.4]
-    rr_values = [4, 3, 2, 1]
-    year_start, year_end = 2000, 2010
-    test_e = []
-    for cat, value in zip(cats, e_values):
-        test_e.append(build_table([cat, value],  year_start, year_end, ('age', 'year', 'sex', 'parameter', 'value')))
-    test_e = pd.concat(test_e)
-
-    test_rr = []
-    for cat, value in zip(cats, rr_values):
-        test_rr.append(build_table([cat, value], year_start, year_end, ('age', 'year', 'sex', 'parameter', 'value')))
-    test_rr = pd.concat(test_rr)
-
-    temp = sum(np.array(e_values) * np.array(rr_values))
-    paf = (temp-1)/temp
+test_data=[([0.1, 0.2, 0.3, 0.4], [4, 3, 2, 1], [0.5]), ([0.3, 0.6, 0.1], [20, 10, 1], [11.1/12.1])]
+@pytest.mark.parametrize('e, rr, paf', test_data)
+def test_get_paf_data(e, rr, paf):
+    exposure = make_test_data_table(e)
+    RR = make_test_data_table(rr)
+    expected = make_test_data_table(paf)
 
     key_cols =['age', 'year', 'sex']
-    paf_data = build_table(paf, year_start, year_end, ('age', 'year', 'sex', 'value'))[key_cols + ['value']].set_index(key_cols)
-    get_paf = get_paf_data(test_e, test_rr)[key_cols +['value']].set_index(key_cols)
+    get_paf = get_paf_data(exposure, RR)[key_cols +['value']].set_index(key_cols)
 
-    assert np.allclose(paf_data.value, get_paf.value)
+    assert np.allclose(expected.value, get_paf.value)

--- a/tests/risks/test_data_transformation.py
+++ b/tests/risks/test_data_transformation.py
@@ -1,19 +1,17 @@
-import pandas as pd
 import numpy as np
 
 import pytest
-from typing import List, Union
 
 from vivarium.testing_utilities import build_table
 from vivarium_public_health.risks.data_transformation import *
 
-@pytest.fixture
-def make_test_data_table(values: List, parameter='cat') -> pd.DataFrame:
+
+def make_test_data_table(values, parameter='cat') -> pd.DataFrame:
     year_start = 1990  # same as the base config
     year_end = 2010
 
     if len(values) == 1:
-        df = build_table(values[0], year_start, year_end, ('age','year', 'sex', 'value'))
+        df = build_table(values[0], year_start, year_end, ('age', 'year', 'sex', 'value'))
     else:
         cats = [f'{parameter}{i+1}' for i in range(len(values))] if parameter == 'cat' else parameter
         df = []
@@ -33,7 +31,7 @@ def test_should_rebin(base_config):
     assert should_rebin('test_risk', base_config)
 
 
-@pytest.mark.parametrize('values', [[0.1, 0.1, 0.1, 0.1], [0.2, 0.3, 0.4]])
+@pytest.mark.parametrize('values', ([0.1, 0.1, 0.1, 0.1], [0.2, 0.3, 0.4]))
 def test_rebin_exposure_fail(values):
     wrong_df = make_test_data_table(values)
 
@@ -50,7 +48,7 @@ def test_rebin_exposure(initial, rebin):
     expected = expected.set_index(['age', 'year', 'sex'])
     rebinned = rebinned.set_index(['age', 'year', 'sex'])
 
-    assert np.allclose(expected.value[expected.parameter == 'cat1'], rebinned.value[rebinned.parameter=='cat1'])
+    assert np.allclose(expected.value[expected.parameter == 'cat1'], rebinned.value[rebinned.parameter == 'cat1'])
     assert np.allclose(expected.value[expected.parameter == 'cat2'], rebinned.value[rebinned.parameter == 'cat2'])
 
 
@@ -70,14 +68,14 @@ def test_rebin_relative_risk(e, rr, rebin):
     assert np.allclose(expected.value[expected.parameter == 'cat2'], rebinned.value[rebinned.parameter == 'cat2'])
 
 
-test_data=[([0.1, 0.2, 0.3, 0.4], [4, 3, 2, 1], [0.5]), ([0.3, 0.6, 0.1], [20, 10, 1], [11.1/12.1])]
+test_data = [([0.1, 0.2, 0.3, 0.4], [4, 3, 2, 1], [0.5]), ([0.3, 0.6, 0.1], [20, 10, 1], [11.1/12.1])]
 @pytest.mark.parametrize('e, rr, paf', test_data)
-def test_get_paf_data(e, rr, paf):
+def test_get_paf_data( e, rr, paf):
     exposure = make_test_data_table(e)
     RR = make_test_data_table(rr)
     expected = make_test_data_table(paf)
 
     key_cols =['age', 'year', 'sex']
-    get_paf = get_paf_data(exposure, RR)[key_cols +['value']].set_index(key_cols)
+    get_paf = get_paf_data(exposure, RR)[key_cols + ['value']].set_index(key_cols)
 
     assert np.allclose(expected.value, get_paf.value)

--- a/tests/risks/test_data_transformation.py
+++ b/tests/risks/test_data_transformation.py
@@ -1,0 +1,58 @@
+import pandas as pd
+import numpy as np
+
+import pytest
+
+from vivarium.testing_utilities import build_table
+from vivarium.framework.configuration import build_simulation_configuration
+from vivarium_public_health.risks import distributions
+
+def test_should_rebin():
+    test_config = build_simulation_configuration()
+    test_config['population'] = {'population_size': 100}
+    assert not distributions.should_rebin('test_risk', test_config)
+
+    test_config['test_risk'] = {}
+    assert not distributions.should_rebin('test_risk', test_config)
+
+    test_config['test_risk'].rebin = False
+    assert not distributions.should_rebin('test_risk', test_config)
+
+    test_config['test_risk']['rebin'] = True
+    assert distributions.should_rebin('test_risk', test_config)
+
+
+def test_rebin_exposure():
+    cats = ['cat1', 'cat2', 'cat3', 'cat4']
+    year_start = 2010
+    year_end = 2013
+
+    wrong_values = [0.1, 0.1, 0.1, 0.1]
+
+    wrong_df = []
+    for cat, value in zip(cats, wrong_values):
+        wrong_df.append(build_table([cat, value], year_start, year_end, ('age','year', 'sex', 'parameter', 'value')))
+    wrong_df = pd.concat(wrong_df)
+
+    with pytest.raises(AssertionError):
+        distributions.rebin_exposure_data(wrong_df)
+
+    values = [0.1, 0.2, 0.3, 0.4]
+    test_df = []
+    for cat, value in zip(cats, values):
+        test_df.append(build_table([cat, value], year_start, year_end, ('age','year', 'sex', 'parameter', 'value')))
+    test_df = pd.concat(test_df)
+
+    expected = []
+
+    for cat, value in zip (['cat1', 'cat2'], [0.6, 0.4]):
+        expected.append(build_table([cat, value], year_start, year_end, ('age', 'year', 'sex', 'parameter', 'value')))
+
+    expected = pd.concat(expected).loc[:, ['age', 'year', 'sex', 'parameter', 'value']]
+    rebinned = distributions.rebin_exposure_data(test_df).loc[:, expected.columns]
+    expected = expected.set_index(['age', 'year','sex'])
+    rebinned = rebinned.set_index(['age', 'year', 'sex'])
+
+    assert np.allclose(expected.value[expected.parameter == 'cat1'], rebinned.value[rebinned.parameter=='cat1'])
+    assert np.allclose(expected.value[expected.parameter == 'cat2'], rebinned.value[rebinned.parameter == 'cat2'])
+

--- a/tests/risks/test_data_transformation.py
+++ b/tests/risks/test_data_transformation.py
@@ -5,21 +5,21 @@ import pytest
 
 from vivarium.testing_utilities import build_table
 from vivarium.framework.configuration import build_simulation_configuration
-from vivarium_public_health.risks import distributions
+from vivarium_public_health.risks.data_transformation import *
 
 def test_should_rebin():
     test_config = build_simulation_configuration()
     test_config['population'] = {'population_size': 100}
-    assert not distributions.should_rebin('test_risk', test_config)
+    assert not should_rebin('test_risk', test_config)
 
     test_config['test_risk'] = {}
-    assert not distributions.should_rebin('test_risk', test_config)
+    assert not should_rebin('test_risk', test_config)
 
     test_config['test_risk'].rebin = False
-    assert not distributions.should_rebin('test_risk', test_config)
+    assert not should_rebin('test_risk', test_config)
 
     test_config['test_risk']['rebin'] = True
-    assert distributions.should_rebin('test_risk', test_config)
+    assert should_rebin('test_risk', test_config)
 
 
 def test_rebin_exposure():
@@ -35,7 +35,7 @@ def test_rebin_exposure():
     wrong_df = pd.concat(wrong_df)
 
     with pytest.raises(AssertionError):
-        distributions.rebin_exposure_data(wrong_df)
+        rebin_exposure_data(wrong_df)
 
     values = [0.1, 0.2, 0.3, 0.4]
     test_df = []
@@ -49,10 +49,34 @@ def test_rebin_exposure():
         expected.append(build_table([cat, value], year_start, year_end, ('age', 'year', 'sex', 'parameter', 'value')))
 
     expected = pd.concat(expected).loc[:, ['age', 'year', 'sex', 'parameter', 'value']]
-    rebinned = distributions.rebin_exposure_data(test_df).loc[:, expected.columns]
+    rebinned = rebin_exposure_data(test_df).loc[:, expected.columns]
     expected = expected.set_index(['age', 'year','sex'])
     rebinned = rebinned.set_index(['age', 'year', 'sex'])
 
     assert np.allclose(expected.value[expected.parameter == 'cat1'], rebinned.value[rebinned.parameter=='cat1'])
     assert np.allclose(expected.value[expected.parameter == 'cat2'], rebinned.value[rebinned.parameter == 'cat2'])
 
+
+def test_get_paf_data():
+    cats = ['cat1', 'cat2', 'cat3', 'cat4']
+    e_values = [0.1, 0.2, 0.3, 0.4]
+    rr_values = [4, 3, 2, 1]
+    year_start, year_end = 2000, 2010
+    test_e = []
+    for cat, value in zip(cats, e_values):
+        test_e.append(build_table([cat, value],  year_start, year_end, ('age', 'year', 'sex', 'parameter', 'value')))
+    test_e = pd.concat(test_e)
+
+    test_rr = []
+    for cat, value in zip(cats, rr_values):
+        test_rr.append(build_table([cat, value], year_start, year_end, ('age', 'year', 'sex', 'parameter', 'value')))
+    test_rr = pd.concat(test_rr)
+
+    temp = sum(np.array(e_values) * np.array(rr_values))
+    paf = (temp-1)/temp
+
+    key_cols =['age', 'year', 'sex']
+    paf_data = build_table(paf, year_start, year_end, ('age', 'year', 'sex', 'value'))[key_cols + ['value']].set_index(key_cols)
+    get_paf = get_paf_data(test_e, test_rr)[key_cols +['value']].set_index(key_cols)
+
+    assert np.allclose(paf_data.value, get_paf.value)

--- a/tests/risks/test_distributions.py
+++ b/tests/risks/test_distributions.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from vivarium.framework.configuration import build_simulation_configuration
 from vivarium.testing_utilities import build_table
 from vivarium_public_health.risks import distributions
 from vivarium_public_health.util import pivot_age_sex_year_binned
@@ -165,56 +164,6 @@ def test_individual_distribution(i, mean, sd):
     for dist in expected.keys():
         for params in expected[dist].keys():
             assert np.isclose(expected[dist][params][i], generated[dist][params])
-
-
-def test_should_rebin():
-    test_config = build_simulation_configuration()
-    test_config['population'] = {'population_size': 100}
-    assert not distributions.should_rebin('test_risk', test_config)
-
-    test_config['test_risk'] = {}
-    assert not distributions.should_rebin('test_risk', test_config)
-
-    test_config['test_risk'].rebin = False
-    assert not distributions.should_rebin('test_risk', test_config)
-
-    test_config['test_risk']['rebin'] = True
-    assert distributions.should_rebin('test_risk', test_config)
-
-
-def test_rebin_exposure():
-    cats = ['cat1', 'cat2', 'cat3', 'cat4']
-    year_start = 2010
-    year_end = 2013
-
-    wrong_values = [0.1, 0.1, 0.1, 0.1]
-
-    wrong_df = []
-    for cat, value in zip(cats, wrong_values):
-        wrong_df.append(build_table([cat, value], year_start, year_end, ('age','year', 'sex', 'parameter', 'value')))
-    wrong_df = pd.concat(wrong_df)
-
-    with pytest.raises(AssertionError):
-        distributions.rebin_exposure_data(wrong_df)
-
-    values = [0.1, 0.2, 0.3, 0.4]
-    test_df = []
-    for cat, value in zip(cats, values):
-        test_df.append(build_table([cat, value], year_start, year_end, ('age','year', 'sex', 'parameter', 'value')))
-    test_df = pd.concat(test_df)
-
-    expected = []
-
-    for cat, value in zip (['cat1', 'cat2'], [0.6, 0.4]):
-        expected.append(build_table([cat, value], year_start, year_end, ('age', 'year', 'sex', 'parameter', 'value')))
-
-    expected = pd.concat(expected).loc[:, ['age', 'year', 'sex', 'parameter', 'value']]
-    rebinned = distributions.rebin_exposure_data(test_df).loc[:, expected.columns]
-    expected = expected.set_index(['age', 'year','sex'])
-    rebinned = rebinned.set_index(['age', 'year', 'sex'])
-
-    assert np.allclose(expected.value[expected.parameter == 'cat1'], rebinned.value[rebinned.parameter=='cat1'])
-    assert np.allclose(expected.value[expected.parameter == 'cat2'], rebinned.value[rebinned.parameter == 'cat2'])
 
 
 def test_get_distribution_dichotomous_risk(mocker):

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -382,12 +382,14 @@ def test_ContinuousRiskComponent(get_distribution_mock, base_config, base_plugin
     affected_causes = ["test_cause_1", "test_cause_2"]
 
     rr_data = []
+    paf_data = []
     for cause in affected_causes:
         rr_data.append(
             build_table([1.01, cause], year_start, year_end, ['age', 'sex', 'year', 'value', 'cause'],
                         ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
                             'year_end', 'sex', 'cause'), var_name='parameter', value_name='value')
         )
+        paf_data.append()
     rr_data = pd.concat(rr_data)
 
     tmred = {
@@ -402,6 +404,8 @@ def test_ContinuousRiskComponent(get_distribution_mock, base_config, base_plugin
             "max_val": 300.0,
             "min_val": 50.0,
     }
+
+    paf_data = build_table(1, year_start, year_end, ['age', 'sex', 'year', 'vlaue'])
 
     class Distribution:
         def __init__(self, *_, **__):
@@ -424,7 +428,7 @@ def test_ContinuousRiskComponent(get_distribution_mock, base_config, base_plugin
                                        input_config=base_config, plugin_config=base_plugins)
     simulation.data.write("risk_factor.test_risk.exposure", exposure_data)
     simulation.data.write("risk_factor.test_risk.relative_risk", rr_data)
-    simulation.data.write("risk_factor.test_risk.population_attributable_fraction", 1)
+    simulation.data.write("risk_factor.test_risk.population_attributable_fraction", paf_data)
     simulation.data.write("risk_factor.test_risk.affected_causes", affected_causes)
     simulation.data.write("risk_factor.test_risk.affected_risk_factors", [])
     simulation.data.write("risk_factor.test_risk.distribution", "ensemble")

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -1,31 +1,13 @@
-import pytest
 import numpy as np
 import pandas as pd
-from scipy.stats import norm
 
 from vivarium.framework.utilities import from_yearly
-from vivarium.testing_utilities import build_table, TestPopulation, metadata
+from vivarium.testing_utilities import build_table, TestPopulation
 from vivarium.interface.interactive import initialize_simulation
 
 from vivarium_public_health.disease import RateTransition
-from vivarium_public_health.risks.effect import DirectEffect, get_exposure_effect
+from vivarium_public_health.risks.effect import DirectEffect, get_exposure_effect, IndirectEffect
 from vivarium_public_health.risks.base_risk import Risk
-
-
-@pytest.fixture
-def get_distribution_mock(mocker):
-    return mocker.patch('vivarium_public_health.risks.base_risk.get_distribution')
-
-
-def make_dummy_column(name, initial_value):
-    class _make_dummy_column:
-        def setup(self, builder):
-            self.population_view = builder.population.get_view([name])
-            builder.population.initializes_simulants(self.make_column, creates_columns=[name])
-
-        def make_column(self, pop_data):
-            self.population_view.update(pd.Series(initial_value, index=pop_data.index, name=name))
-    return _make_dummy_column()
 
 
 def test_RiskEffect(base_config, base_plugins, mocker):
@@ -140,45 +122,27 @@ def test_risk_deletion(base_config, base_plugins, mocker):
     assert np.allclose(joint_paf(rf_simulation.population.population.index), risk_paf)
 
 
-def test_continuous_exposure_effect(base_config, base_plugins):
-    risk = "test_risk"
-    tmred = {
-            "distribution": 'uniform',
-            "min": 110.0,
-            "max": 115.0,
-            "inverted": False,
-    }
-    exposure_parameters = {
-            "scale": 10.0,
-            "max_rr": 200.0,
-            "max_val": 300.0,
-            "min_val": 50.0,
-    }
-
-    tmrel = 0.5 * (tmred["max"] + tmred["min"])
+def test_continuous_exposure_effect(mocker, base_config, base_plugins, continuous_risk):
+    risk, risk_data = continuous_risk
 
     class exposure_function_wrapper:
 
         def setup(self, builder):
-            self.exposure_function = get_exposure_effect(builder, risk, 'risk_factor')
+            self.exposure_function = get_exposure_effect(builder, 'test_risk', 'risk_factor')
 
         def __call__(self, *args, **kwargs):
             return self.exposure_function(*args, **kwargs)
 
     exposure_function = exposure_function_wrapper()
 
-    tmrel = 0.5 * (tmred["max"] + tmred["min"])
-
     components = [TestPopulation(), exposure_function]
     simulation = initialize_simulation(components, input_config=base_config, plugin_config=base_plugins)
-    simulation.data.write("risk_factor.test_risk.distribution", "ensemble")
-    simulation.data.write("risk_factor.test_risk.tmred", tmred)
-    simulation.data.write("risk_factor.test_risk.exposure_parameters", exposure_parameters)
+    for key, value in risk_data.items():
+        simulation.data.write(f'risk_factor.test_risk.{key}', value)
 
-    def test_risk_exposure(index):
-        return pd.Series(tmrel, index=index)
-
-    simulation.values.register_value_producer('test_risk.exposure', source=test_risk_exposure)
+    risk_exposure_pipeline = mocker.Mock()
+    simulation.values.register_value_producer('test_risk.exposure', source=risk_exposure_pipeline)
+    risk_exposure_pipeline.side_effect = lambda index: pd.Series(risk_data['tmrel'], index=index)
 
     simulation.setup()
 
@@ -187,35 +151,22 @@ def test_continuous_exposure_effect(base_config, base_plugins):
 
     assert np.all(exposure_function(rates, rr) == 0.01)
 
-    def test_risk_exposure(index):
-        return pd.Series(tmrel + 50, index=index)
+    simulation.values.register_value_producer('test_risk.exposure', source=risk_exposure_pipeline)
+    risk_exposure_pipeline.side_effect = lambda index: pd.Series(risk_data['tmrel']+50, index=index)
 
-    components = [TestPopulation(), exposure_function]
-    simulation = initialize_simulation(components, input_config=base_config, plugin_config=base_plugins)
-    simulation.data.write("risk_factor.test_risk.distribution", "ensemble")
-    simulation.data.write("risk_factor.test_risk.tmred", tmred)
-    simulation.data.write("risk_factor.test_risk.exposure_parameters", exposure_parameters)
-
-    simulation.values.register_value_producer('test_risk.exposure', source=test_risk_exposure)
-
-    simulation.setup()
-
-    rates = pd.Series(0.01, index=simulation.population.population.index)
-    rr = pd.Series(1.01, index=simulation.population.population.index)
-
-    expected_value = 0.01 * (1.01 ** (((tmrel + 50) - tmrel) / exposure_parameters["scale"]))
+    expected_value = 0.01 * (1.01 ** (((risk_data['tmrel'] + 50) - risk_data['tmrel'])
+                                      / risk_data['exposure_parameters']["scale"]))
 
     assert np.allclose(exposure_function(rates, rr), expected_value)
 
 
 def test_categorical_exposure_effect(base_config, base_plugins, mocker):
-    risk = "test_risk"
     risk_effect = mocker.Mock()
-    risk_effect.risk = risk
+    risk_effect.risk = 'test_risk'
 
     class exposure_function_wrapper:
         def setup(self, builder):
-            self.exposure_function = get_exposure_effect(builder, risk, 'risk_factor')
+            self.exposure_function = get_exposure_effect(builder, 'test_risk', 'risk_factor')
 
         def __call__(self, *args, **kwargs):
             return self.exposure_function(*args, **kwargs)
@@ -225,9 +176,9 @@ def test_categorical_exposure_effect(base_config, base_plugins, mocker):
 
     simulation = initialize_simulation(components, input_config=base_config, plugin_config=base_plugins)
 
-    def test_risk_exposure(index):
-        return pd.Series(['cat2'] * len(index), index=index)
+    test_risk_exposure = mocker.Mock()
     simulation.values.register_value_producer('test_risk.exposure', test_risk_exposure)
+    test_risk_exposure.side_effect = lambda index: pd.Series(['cat2'] * len(index), index=index)
     simulation.data.write("risk_factor.test_risk.distribution", "dichotomous")
     simulation.setup()
 
@@ -236,14 +187,8 @@ def test_categorical_exposure_effect(base_config, base_plugins, mocker):
 
     assert np.all(exposure_function(rates, rr) == 0.01)
 
-    simulation = initialize_simulation(components, input_config=base_config, plugin_config=base_plugins)
-
-    def test_risk_exposure(index):
-        return pd.Series(['cat1'] * len(index), index=index)
-
-    simulation.values.register_value_producer('test_risk.exposure', test_risk_exposure)
-    simulation.data.write("risk_factor.test_risk.distribution", "dichotomous")
-    simulation.setup()
+    test_risk_exposure.side_effect = lambda index: pd.Series(['cat1'] * len(index), index=index)
+    simulation.step()
 
     rates = pd.Series(0.01, index=simulation.population.population.index)
     rr = pd.DataFrame({'cat1': 1.01, 'cat2': 1}, index=simulation.population.population.index)
@@ -251,49 +196,21 @@ def test_categorical_exposure_effect(base_config, base_plugins, mocker):
     assert np.allclose(exposure_function(rates, rr), 0.0101)
 
 
-def test_CategoricalRiskComponent_dichotomous_case(base_config, base_plugins):
-    year_start = base_config.time.start.year
-    year_end = base_config.time.end.year
+def test_CategoricalRiskComponent_dichotomous_case(base_config, base_plugins, dichotomous_risk):
     time_step = pd.Timedelta(days=base_config.time.step_size)
-    base_config.update({'input_data': {'input_draw_number': 1}}, **metadata(__file__))
-    risk = "test_risk"
+    risk, risk_data = dichotomous_risk
+    affected_causes = risk_data['affected_causes']
 
-    component = Risk("risk_factor", risk)
     base_config.update({'population': {'population_size': 100000}}, layer='override')
-    simulation = initialize_simulation([TestPopulation(), component],
+    simulation = initialize_simulation([TestPopulation(), risk],
                                        input_config=base_config, plugin_config=base_plugins)
-
-    exposure_data = build_table(
-        0.5, year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2']
-    ).melt(id_vars=('age', 'age_group_start', 'age_group_end',
-                    'year', 'year_start', 'year_end', 'sex'), var_name='parameter', value_name='value')
-
-    simulation.data.write("risk_factor.test_risk.exposure", exposure_data)
-
-    affected_causes = ["test_cause_1", "test_cause_2"]
-    rr_data = []
-    for cause in affected_causes:
-        rr_data.append(
-            build_table(
-                [1.01, 1, cause], year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2', 'cause']
-            ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
-                            'year_end', 'sex', 'cause'), var_name='parameter', value_name='value')
-        )
-    rr_data = pd.concat(rr_data)
-
-    simulation.data.write("risk_factor.test_risk.relative_risk", rr_data)
-    simulation.data.write("risk_factor.test_risk.population_attributable_fraction", 1)
-    simulation.data.write("risk_factor.test_risk.affected_causes", affected_causes)
-    simulation.data.write("risk_factor.test_risk.distribution", "dichotomous")
-    simulation.data.write("risk_factor.test_risk.affected_risk_factors", [])
+    for key, value in risk_data.items():
+        simulation.data.write(f'risk_factor.test_risk.{key}', value)
 
     simulation.setup()
 
-    simulation.step()
-
     incidence_rate = simulation.values.register_rate_producer(affected_causes[0]+'.incidence_rate')
-    incidence_rate.source = simulation.tables.build_table(build_table(0.01, year_start, year_end),
-                                                          key_columns=('sex',),
+    incidence_rate.source = simulation.tables.build_table(risk_data['incidence_rate'], key_columns=('sex',),
                                                           parameter_columns=[('age', 'age_group_start', 'age_group_end'),
                                                                              ('year', 'year_start', 'year_end')],
                                                           value_columns=None)
@@ -311,46 +228,22 @@ def test_CategoricalRiskComponent_dichotomous_case(base_config, base_plugins):
     assert np.allclose(incidence_rate(unexposed_index), from_yearly(expected_unexposed_value, time_step))
 
 
-def test_CategoricalRiskComponent_polytomous_case(base_config, base_plugins):
-    year_start = base_config.time.start.year
-    year_end = base_config.time.end.year
+def test_CategoricalRiskComponent_polytomous_case(base_config, base_plugins, polytomous_risk):
     time_step = pd.Timedelta(days=base_config.time.step_size)
+    risk, risk_data = polytomous_risk
+    affected_causes = risk_data['affected_causes']
 
-    risk = "test_risk"
-
-    component = Risk("risk_factor", risk)
     base_config.update({'population': {'population_size': 100000}}, layer='override')
-    simulation = initialize_simulation([TestPopulation(), component],
+    simulation = initialize_simulation([TestPopulation(), risk],
                                        input_config=base_config, plugin_config=base_plugins)
 
-    exposure_data = build_table(
-        0.25, year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2', 'cat3', 'cat4']
-    ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
-                    'year_end', 'sex'), var_name='parameter', value_name='value')
+    for key, value in risk_data.items():
+        simulation.data.write(f'risk_factor.test_risk.{key}', value)
 
-    affected_causes = ["test_cause_1", "test_cause_2"]
-    rr_data = []
-    for cause in affected_causes:
-        rr_data.append(
-            build_table([1.03, 1.02, 1.01, 1, cause], year_start, year_end,
-                        ['age', 'year', 'sex', 'cat1', 'cat2', 'cat3', 'cat4', 'cause']
-                        ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
-                            'year_end', 'sex', 'cause'), var_name='parameter', value_name='value')
-        )
-    rr_data = pd.concat(rr_data)
-
-    simulation.data.write("risk_factor.test_risk.exposure", exposure_data)
-    simulation.data.write("risk_factor.test_risk.relative_risk", rr_data)
-    simulation.data.write("risk_factor.test_risk.population_attributable_fraction", 1)
-    simulation.data.write("risk_factor.test_risk.affected_causes", affected_causes)
-    simulation.data.write("risk_factor.test_risk.affected_risk_factors", [])
-    simulation.data.write("risk_factor.test_risk.distribution", "polytomous")
     simulation.setup()
 
-    simulation.step()
-
     incidence_rate = simulation.values.register_rate_producer(affected_causes[0]+'.incidence_rate')
-    incidence_rate.source = simulation.tables.build_table(build_table(0.01, year_start, year_end),
+    incidence_rate.source = simulation.tables.build_table(risk_data['incidence_rate'],
                                                           key_columns=('sex',),
                                                           parameter_columns=[('age', 'age_group_start', 'age_group_end'),
                                                                              ('year', 'year_start', 'year_end')],
@@ -368,75 +261,20 @@ def test_CategoricalRiskComponent_polytomous_case(base_config, base_plugins):
         assert np.allclose(incidence_rate(exposed_index), from_yearly(expected, time_step), rtol=0.01)
 
 
-def test_ContinuousRiskComponent(get_distribution_mock, base_config, base_plugins):
+def test_ContinuousRiskComponent(continuous_risk, base_config, base_plugins):
+    year_start, year_end = base_config.time.start.year, base_config.time.end.year
     time_step = pd.Timedelta(days=base_config.time.step_size)
-    year_start = base_config.time.start.year
-    year_end = base_config.time.end.year
-
-    risk = "test_risk"
-
-    exposure_data = build_table(
-        0.5, year_start, year_end
-    ).melt(id_vars=('age', 'year', 'sex'), var_name='parameter', value_name='value')
-
-    affected_causes = ["test_cause_1", "test_cause_2"]
-
-    rr_data = []
-    paf_data = []
-    for cause in affected_causes:
-        rr_data.append(
-            build_table([1.01, cause], year_start, year_end, ['age', 'sex', 'year', 'value', 'cause'],
-                        ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
-                            'year_end', 'sex', 'cause'), var_name='parameter', value_name='value')
-        )
-        paf_data.append(build_table([1, cause], year_start, year_end, ['age', 'sex', 'year', 'value', 'cause']))
-    rr_data = pd.concat(rr_data)
-    paf_data = pd.concat(paf_data)
-
-    tmred = {
-            "distribution": 'uniform',
-            "min": 110.0,
-            "max": 115.0,
-            "inverted": False,
-    }
-    exposure_parameters = {
-            "scale": 10.0,
-            "max_rr": 200.0,
-            "max_val": 300.0,
-            "min_val": 50.0,
-    }
-
-
-    class Distribution:
-        def __init__(self, *_, **__):
-            pass
-
-        def setup(self, builder):
-            data = build_table([130, 0.000001], year_start, year_end, ['age', 'year', 'sex', 'mean', 'std'])
-            self.parameters = builder.lookup.build_table(data)
-
-        def ppf(self, propensity):
-            params = self.parameters(propensity.index)
-            return norm(loc=params['mean'], scale=params['std']).ppf(propensity)
-
-    get_distribution_mock.side_effect = lambda *args, **kwargs: Distribution(args, kwargs)
-
-    component = Risk("risk_factor", risk)
+    risk, risk_data = continuous_risk
+    risk_data['exposure_standard_deviation'] = build_table(0.0001, year_start, year_end, ('age', 'year', 'sex', 'value'))
 
     base_config.update({'population': {'population_size': 100000}}, layer='override')
-    simulation = initialize_simulation([TestPopulation(), component],
+    simulation = initialize_simulation([TestPopulation(), risk],
                                        input_config=base_config, plugin_config=base_plugins)
-    simulation.data.write("risk_factor.test_risk.exposure", exposure_data)
-    simulation.data.write("risk_factor.test_risk.relative_risk", rr_data)
-    simulation.data.write("risk_factor.test_risk.population_attributable_fraction", paf_data)
-    simulation.data.write("risk_factor.test_risk.affected_causes", affected_causes)
-    simulation.data.write("risk_factor.test_risk.affected_risk_factors", [])
-    simulation.data.write("risk_factor.test_risk.distribution", "ensemble")
-    simulation.data.write("risk_factor.test_risk.tmred", tmred)
-    simulation.data.write("risk_factor.test_risk.exposure_parameters", exposure_parameters)
-    simulation.setup()
+    for key, value in risk_data.items():
+        simulation.data.write(f'risk_factor.test_risk.{key}', value)
 
-    simulation.step()
+    simulation.setup()
+    affected_causes = risk_data['affected_causes']
 
     incidence_rate = simulation.values.register_rate_producer(affected_causes[0]+'.incidence_rate')
     incidence_rate.source = simulation.tables.build_table(build_table(0.01, year_start, year_end),
@@ -446,6 +284,7 @@ def test_ContinuousRiskComponent(get_distribution_mock, base_config, base_plugin
                                                           value_columns=None)
 
     exposure = simulation.values.get_value('test_risk.exposure')
+
     assert np.allclose(exposure(simulation.population.population.index), 130, rtol=0.001)
 
     expected_value = 0.01 * (1.01**((130 - 112) / 10))
@@ -454,26 +293,21 @@ def test_ContinuousRiskComponent(get_distribution_mock, base_config, base_plugin
                        from_yearly(expected_value, time_step), rtol=0.001)
 
 
-def test_IndirectEffect_dichotomous(base_config, base_plugins):
-    year_start = base_config.time.start.year
-    year_end = base_config.time.end.year
+def test_IndirectEffect_dichotomous(base_config, base_plugins, dichotomous_risk, coverage_gap):
+    affected_risk, risk_data = dichotomous_risk
+    coverage_gap, cg_data = coverage_gap
+    rf_exposed = 0.5
+    rr = 2 # rr between cg/affected_risk
+
     base_config.update({'population': {'population_size': 100000}}, layer='override')
     affected_risk = Risk('risk_factor', 'test_risk')
-    rf_exposed = 0.4
-
-    rf_exposure_data = build_table(
-        [rf_exposed, 1-rf_exposed], year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2']
-    ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
-                    'year_end', 'sex'), var_name='parameter', value_name='value')
 
     # start with the only risk factor without indirect effect from coverage_gap
     simulation = initialize_simulation([TestPopulation(), affected_risk],
                                        input_config=base_config, plugin_config=base_plugins)
 
-    simulation.data.write("risk_factor.test_risk.exposure", rf_exposure_data)
-    simulation.data.write("risk_factor.test_risk.distribution", "dichotomous")
-    simulation.data.write("risk_factor.test_risk.affected_causes", [])
-    simulation.data.write("risk_factor.test_risk.affected_risk_factors", [])
+    for key, value in risk_data.items():
+        simulation.data.write(f'risk_factor.test_risk.{key}', value)
 
     simulation.setup()
 
@@ -482,44 +316,14 @@ def test_IndirectEffect_dichotomous(base_config, base_plugins):
     assert np.isclose(rf_exposed, exposure(pop.index).value_counts()['cat1']/len(pop), rtol=0.01)
 
     # add the coverage gap which should change the exposure of test risk
-    coverage_gap = Risk('coverage_gap', 'test_coverage_gap')
     simulation = initialize_simulation([TestPopulation(), affected_risk, coverage_gap],
                                        input_config=base_config, plugin_config=base_plugins)
 
-    cg_exposed = 0.6
-    cg_exposure_data = build_table(
-        [cg_exposed, 1-cg_exposed], year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2']
-    ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
-                    'year_end', 'sex',), var_name='parameter', value_name='value')
+    for key, value in risk_data.items():
+        simulation.data.write(f'risk_factor.test_risk.{key}', value)
 
-    rr = 2
-    rr_data = build_table(
-        [rr, 1], year_start, year_end, ['age', 'year', 'sex', 'cat1', 'cat2']
-    ).melt(id_vars=('age', 'age_group_start', 'age_group_end',
-                    'year', 'year_start', 'year_end', 'sex'), var_name='parameter', value_name='value')
-
-    rr_data['risk_factor'] = 'test_risk'
-
-    # paf is (sum(exposure(category)*rr(category) -1 )/ (sum(exposure(category)* rr(category)
-    paf = (rr * cg_exposed + (1-cg_exposed) - 1) / (rr * cg_exposed + (1-cg_exposed))
-
-    paf_data = build_table(
-        paf, year_start, year_end, ['age', 'year', 'sex', 'population_attributable_fraction']
-    ).melt(id_vars=('age', 'age_group_start', 'age_group_end', 'year', 'year_start',
-                    'year_end', 'sex'), var_name='population_attributable_fraction', value_name='value')
-
-    paf_data['risk_factor'] = 'test_risk'
-
-    simulation.data.write("risk_factor.test_risk.exposure", rf_exposure_data)
-    simulation.data.write("risk_factor.test_risk.distribution", "dichotomous")
-    simulation.data.write("risk_factor.test_risk.affected_causes", [])
-    simulation.data.write("risk_factor.test_risk.affected_risk_factors", [])
-    simulation.data.write("coverage_gap.test_coverage_gap.exposure", cg_exposure_data)
-    simulation.data.write("coverage_gap.test_coverage_gap.distribution", "dichotomous")
-    simulation.data.write("coverage_gap.test_coverage_gap.relative_risk", rr_data)
-    simulation.data.write("coverage_gap.test_coverage_gap.affected_risk_factors", ['test_risk'])
-    simulation.data.write("coverage_gap.test_coverage_gap.affected_causes", [])
-    simulation.data.write("coverage_gap.test_coverage_gap.population_attributable_fraction", paf_data)
+    for key, value in cg_data.items():
+        simulation.data.write(f'coverage_gap.test_coverage_gap.{key}', value)
 
     simulation.setup()
 

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -8,7 +8,7 @@ from vivarium.testing_utilities import build_table, TestPopulation, metadata
 from vivarium.interface.interactive import initialize_simulation
 
 from vivarium_public_health.disease import RateTransition
-from vivarium_public_health.risks.effect import DirectEffect, get_exposure_effect, rebin_rr_data
+from vivarium_public_health.risks.effect import DirectEffect, get_exposure_effect
 from vivarium_public_health.risks.base_risk import Risk
 
 


### PR DESCRIPTION
We decided to change the way of pulling paf (by cause -> by risk) According to the changes in data pulling and loading, we also compute all the pafs for the categorical risk (and coverage gap) on the fly. Many of changes are just moving around the data transformation code and make the tests work along with the new changes. 