### PR TITLE
Bugfix/generate population in between data years

### DIFF
--- a/src/vivarium_public_health/population/base_population.py
+++ b/src/vivarium_public_health/population/base_population.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 
 from .data_transformations import assign_demographic_proportions, rescale_binned_proportions, smooth_ages
 
@@ -44,6 +45,16 @@ class BasePopulation:
         if self.config.exit_age is not None:
             builder.components.add_components([AgedOutSimulants()])
 
+    @staticmethod
+    def select_sub_population_data(reference_population_data, year):
+        if year in reference_population_data.year.unique():
+            sub_pop_data = reference_population_data[reference_population_data.year == pop_data.creation_time.year]
+        elif year > reference_population_data.year.max():
+            sub_pop_data = reference_population_data[reference_population_data.year == reference_population_data.year.max()]
+        else:  # pop_data.creation_time.year < reference_population_data.year.min():
+            sub_pop_data = reference_population_data[reference_population_data.year == reference_population_data.year.min()]
+
+        return sub_pop_data
 
     # TODO: Move most of this docstring to an rst file.
     def generate_base_population(self, pop_data):
@@ -72,12 +83,7 @@ class BasePopulation:
         age_params = {'age_start': pop_data.user_data.get('age_start', self.config.age_start),
                       'age_end': pop_data.user_data.get('age_end', self.config.age_end)}
 
-        if pop_data.creation_time.year in self.population_data.year.unique():
-            sub_pop_data = self.population_data[self.population_data.year == pop_data.creation_time.year]
-        elif pop_data.creation_time.year > self.population_data.year.max():
-            sub_pop_data = self.population_data[self.population_data.year == self.population_data.year.max()]
-        else:  # pop_data.creation_time.year < self.population_data.year.min():
-            sub_pop_data = self.population_data[self.population_data.year == self.population_data.year.min()]
+        sub_pop_data = self.select_sub_population_data(self.population_data, pop_data.creation_time.year)
 
         self.population_view.update(generate_population(simulant_ids=pop_data.index,
                                                         creation_time=pop_data.creation_time,

--- a/src/vivarium_public_health/population/base_population.py
+++ b/src/vivarium_public_health/population/base_population.py
@@ -47,14 +47,9 @@ class BasePopulation:
 
     @staticmethod
     def select_sub_population_data(reference_population_data, year):
-        if year in reference_population_data.year.unique():
-            sub_pop_data = reference_population_data[reference_population_data.year == pop_data.creation_time.year]
-        elif year > reference_population_data.year.max():
-            sub_pop_data = reference_population_data[reference_population_data.year == reference_population_data.year.max()]
-        else:  # pop_data.creation_time.year < reference_population_data.year.min():
-            sub_pop_data = reference_population_data[reference_population_data.year == reference_population_data.year.min()]
-
-        return sub_pop_data
+        reference_years = sorted(set(reference_population_data.year))
+        ref_year_index = np.digitize(year, reference_years).item()-1
+        return reference_population_data[reference_population_data.year == reference_years[ref_year_index]]
 
     # TODO: Move most of this docstring to an rst file.
     def generate_base_population(self, pop_data):

--- a/tests/population/test_base_population.py
+++ b/tests/population/test_base_population.py
@@ -61,6 +61,14 @@ def make_full_simulants():
     return base_simulants
 
 
+def test_select_sub_population_data():
+    data = pd.DataFrame({'year': [1990, 1995, 2000, 2005], 'population': [100, 110, 120, 130]})
+
+    sub_pop = bp.BasePopulation.select_sub_population_data(data, 1997)
+
+    assert sub_pop.year.values.item() == 1995
+
+
 def test_BasePopulation(config, base_plugins, generate_population_mock):
     num_days = 600
     time_step = 100  # Days


### PR DESCRIPTION
This is a bug I noticed when I was going through to pull out age and year and decided to fix it separately so the logic changes could be reviewed without the mess of all the age/year drops. 

The bug was that previously, unless we had population structure data for every year, it would use the first year of data in generating a base population. This isn't a problem in all of the actual simulations because gbd does have population data for every year. But it was a quick bug to fix, and in a lot of our tests for other parts, we use made up data with years like [1990, 1995, 2000, 2005]. In that case, asking for the population data to use for 1997 would give you the data for 1990 (the first and second commits in this PR were to show that was how it was behaving previously). 