### PR TITLE
Bugfix/disease event time

### DIFF
--- a/src/vivarium_public_health/disease/model.py
+++ b/src/vivarium_public_health/disease/model.py
@@ -100,7 +100,6 @@ class DiseaseModel(Machine):
         initial_states = pd.Series(np.array(state_names)[choice_index], index=simulants.index)
 
         simulants.loc[:, 'condition_state'] = initial_states
-
         return simulants
 
     def load_population_columns(self, pop_data):

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -199,7 +199,7 @@ class DiseaseState(BaseDiseaseState):
         disability_weight_data = get_disability_weight_func(self.cause, builder)
         self.prevalence_data = builder.lookup.build_table(get_prevalence_func(self.cause, builder))
         self._dwell_time = get_dwell_time_func(self.cause, builder)
-        self.randomness = builder.randomness.get_stream('prevalence_event_time')
+        self.randomness = builder.randomness.get_stream(f'{self.state_id}_prevalence_event_time')
 
         if isinstance(disability_weight_data, pd.DataFrame):
             self._disability_weight = builder.lookup.build_table(float(disability_weight_data.value))

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -199,7 +199,7 @@ class DiseaseState(BaseDiseaseState):
         disability_weight_data = get_disability_weight_func(self.cause, builder)
         self.prevalence_data = builder.lookup.build_table(get_prevalence_func(self.cause, builder))
         self._dwell_time = get_dwell_time_func(self.cause, builder)
-        self.randomness = builder.randomness.get_stream(f'determine_event_time_of_{self.state_id}_prevalent_cases')
+        self.randomness_prevalence = builder.randomness.get_stream(f'{self.state_id}_prevalent_cases')
 
         if isinstance(disability_weight_data, pd.DataFrame):
             self._disability_weight = builder.lookup.build_table(float(disability_weight_data.value))
@@ -226,10 +226,12 @@ class DiseaseState(BaseDiseaseState):
             # if modelers did not specify the dwell time
             if np.all(self.dwell_time(simulants_with_condition.index)) == 0:
                 infected_at = self._assign_event_time_for_prevalent_cases(simulants_with_condition, self.clock(),
-                                                                          self.randomness.get_draw, self.remission, True)
+                                                                          self.randomness_prevalence.get_draw,
+                                                                          self.remission, True)
             else:
                 infected_at = self._assign_event_time_for_prevalent_cases(simulants_with_condition, self.clock(),
-                                                                          self.randomness.get_draw, self.dwell_time)
+                                                                          self.randomness_prevalence.get_draw,
+                                                                          self.dwell_time)
             infected_at.name = self.event_time_column
             self.population_view.update(infected_at)
 

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -223,15 +223,15 @@ class DiseaseState(BaseDiseaseState):
         super().load_population_columns(pop_data)
         simulants_with_condition = self.population_view.get(pop_data.index, query=f'{self._model}=="{self.state_id}"')
         if not simulants_with_condition.empty:
-            # if modelers did not specify the dwell time
-            if np.all(self.dwell_time(simulants_with_condition.index)) == 0:
+            # if modelers did not specify the dwell time but there's remission rate available
+            if np.all(self.dwell_time(simulants_with_condition.index)) == 0 and self.remission.source:
                 infected_at = self._assign_event_time_for_prevalent_cases(simulants_with_condition, self.clock(),
                                                                           self.randomness_prevalence.get_draw,
                                                                           self.remission, True)
             else:
                 infected_at = self._assign_event_time_for_prevalent_cases(simulants_with_condition, self.clock(),
                                                                           self.randomness_prevalence.get_draw,
-                                                                          self.dwell_time)
+                                                                      self.dwell_time)
             infected_at.name = self.event_time_column
             self.population_view.update(infected_at)
 

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -312,3 +312,15 @@ def test_risk_deletion(base_config, base_plugins, disease):
 
     assert np.allclose(from_yearly(expected_rate, time_step),
                        incidence_rate(simulation.population.population.index), atol=0.00001)
+
+
+def test__assign_event_time_for_prevalent_cases():
+    pop_data = pd.DataFrame(index=range(100))
+    random_func = lambda index: pd.Series(0.4, index=index)
+    dwell_time_func = lambda index: pd.Series(10, index=index)
+    current_time = pd.Timestamp(2017, 1, 10, 12)
+
+    expected = pd.Series(pd.Timestamp(2017, 1, 6, 12), index=pop_data.index)
+    what_we_get = DiseaseState._assign_event_time_for_prevalent_cases(pop_data, current_time, random_func, dwell_time_func)
+
+    assert expected.equals(what_we_get)

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -319,14 +319,16 @@ def test__assign_event_time_for_prevalent_cases():
     random_func = lambda index: pd.Series(0.4, index=index)
     current_time = pd.Timestamp(2017, 1, 10, 12)
 
-    bad_dwell_time = pd.Series([0, 10] * 50, index=range(100))
-    bad_dwell_time_func = lambda index: bad_dwell_time.loc[index]
+    remission_func = lambda index: pd.Series(0.2, index=index)
+
+    # 1/0.2 = 5, 5*0.4 = 2 ; 2 days before the current time
+    expected = pd.Series(pd.Timestamp(2017, 1, 8, 12), index=pop_data.index)
+    assert expected.equals(DiseaseState._assign_event_time_for_prevalent_cases(pop_data, current_time, random_func,
+                                                                              remission_func, True))
+
     dwell_time_func = lambda index: pd.Series(10, index=index)
-
-    with pytest.raises(ValueError):
-        DiseaseState._assign_event_time_for_prevalent_cases(pop_data, current_time, random_func, bad_dwell_time_func)
-
+    # 10* 0.4 = 4 ; 4 days before the current time
     expected = pd.Series(pd.Timestamp(2017, 1, 6, 12), index=pop_data.index)
-    what_we_get = DiseaseState._assign_event_time_for_prevalent_cases(pop_data, current_time, random_func, dwell_time_func)
 
-    assert expected.equals(what_we_get)
+    assert expected.equals(DiseaseState._assign_event_time_for_prevalent_cases(pop_data, current_time, random_func,
+                                                                               dwell_time_func))

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -317,8 +317,14 @@ def test_risk_deletion(base_config, base_plugins, disease):
 def test__assign_event_time_for_prevalent_cases():
     pop_data = pd.DataFrame(index=range(100))
     random_func = lambda index: pd.Series(0.4, index=index)
-    dwell_time_func = lambda index: pd.Series(10, index=index)
     current_time = pd.Timestamp(2017, 1, 10, 12)
+
+    bad_dwell_time = pd.Series([0, 10] * 50, index=range(100))
+    bad_dwell_time_func = lambda index: bad_dwell_time.loc[index]
+    dwell_time_func = lambda index: pd.Series(10, index=index)
+
+    with pytest.raises(ValueError):
+        DiseaseState._assign_event_time_for_prevalent_cases(pop_data, current_time, random_func, bad_dwell_time_func)
 
     expected = pd.Series(pd.Timestamp(2017, 1, 6, 12), index=pop_data.index)
     what_we_get = DiseaseState._assign_event_time_for_prevalent_cases(pop_data, current_time, random_func, dwell_time_func)

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -319,13 +319,6 @@ def test__assign_event_time_for_prevalent_cases():
     random_func = lambda index: pd.Series(0.4, index=index)
     current_time = pd.Timestamp(2017, 1, 10, 12)
 
-    remission_func = lambda index: pd.Series(0.2, index=index)
-
-    # 1/0.2 = 5, 5*0.4 = 2 ; 2 days before the current time
-    expected = pd.Series(pd.Timestamp(2017, 1, 8, 12), index=pop_data.index)
-    assert expected.equals(DiseaseState._assign_event_time_for_prevalent_cases(pop_data, current_time, random_func,
-                                                                              remission_func, True))
-
     dwell_time_func = lambda index: pd.Series(10, index=index)
     # 10* 0.4 = 4 ; 4 days before the current time
     expected = pd.Series(pd.Timestamp(2017, 1, 6, 12), index=pop_data.index)

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -26,7 +26,7 @@ def base_data():
     def _set_prevalence(p):
         base_function = dict()
         base_function['disability_weight'] = lambda _, __: 0
-        base_function['dwell_time'] = lambda _, __: pd.Timedelta(days=0)
+        base_function['dwell_time'] = lambda _, __: pd.Timedelta(days=1)
         base_function['prevalence'] = lambda _, __: p
         return base_function
     return _set_prevalence

--- a/tests/metrics/test_disability.py
+++ b/tests/metrics/test_disability.py
@@ -29,7 +29,7 @@ def set_up_test_parameters(base_config, flu=False, mumps=False, deadly=False):
     asymp_data_funcs = {'prevalence': lambda _, __: build_table(1.0, year_start-1, year_end,
                                                                 ['age', 'year', 'sex', 'value']),
                         'disability_weight': lambda _, __: 0.0,
-                        'dwell_time': lambda _, __: pd.Timedelta(days=0),
+                        'dwell_time': lambda _, __: pd.Timedelta(days=1),
                         'excess_mortality': lambda _, __: build_table(0, year_start-1, year_end)}
 
     asymptomatic_disease_state = ExcessMortalityState('asymptomatic', get_data_functions=asymp_data_funcs)
@@ -45,7 +45,7 @@ def set_up_test_parameters(base_config, flu=False, mumps=False, deadly=False):
         flu_data_funcs = {'prevalence': lambda _, __: build_table(1.0, year_start-1, year_end,
                                                                   ['age', 'year', 'sex', 'value']),
                           'disability_weight': lambda _, __: 0.2,
-                          'dwell_time': lambda _, __: pd.Timedelta(days=0),
+                          'dwell_time': lambda _, __: pd.Timedelta(days=1),
                           'excess_mortality': lambda _, __: build_table(0, year_start-1, year_end)}
         flu = ExcessMortalityState('flu', get_data_functions=flu_data_funcs)
         flu_model = DiseaseModel('flu', states=[flu],
@@ -57,7 +57,7 @@ def set_up_test_parameters(base_config, flu=False, mumps=False, deadly=False):
         mumps_data_funcs = {'prevalence': lambda _, __: build_table(1.0, year_start-1, year_end,
                                                                     ['age', 'year', 'sex', 'value']),
                             'disability_weight': lambda _, __: 0.4,
-                            'dwell_time': lambda _, __: pd.Timedelta(days=0),
+                            'dwell_time': lambda _, __: pd.Timedelta(days=1),
                             'excess_mortality': lambda _, __: build_table(0, year_start-1, year_end)}
         mumps = ExcessMortalityState('mumps', get_data_functions=mumps_data_funcs)
         mumps_model = DiseaseModel('mumps', states=[mumps],
@@ -69,7 +69,7 @@ def set_up_test_parameters(base_config, flu=False, mumps=False, deadly=False):
         deadly_data_funcs = {'prevalence': lambda _, __: build_table(0.1, year_start-1, year_end,
                                                                      ['age', 'year', 'sex', 'value']),
                              'disability_weight': lambda _, __: 0.4,
-                             'dwell_time': lambda _, __: pd.Timedelta(days=0),
+                             'dwell_time': lambda _, __: pd.Timedelta(days=1),
                              'excess_mortality': lambda _, __: build_table(0.005, year_start-1, year_end)}
         deadly = ExcessMortalityState('deadly', get_data_functions=deadly_data_funcs)
         healthy = DiseaseState('healthy', get_data_functions=deadly_data_funcs)


### PR DESCRIPTION
this is for MIC-280. There're two bits. One is to remove the `track_event` arguments and now it always tracks the event (thus there will be ceam_experiments PR just to remove this argument from any existing files) Now filter for transition eligibility will only apply when there's non-zero dwell time. Also, if there's non-zero dwell time, we assign random time between the current time (when the simulants were initialized) and (current time - dwell time) to the simulants who start with the condition.

I don't think that it's the best situation to use the static method, but I really don't want to add more things to make the disease test even more complicated. 