### PR TITLE
Feature/artifact filter via config

### DIFF
--- a/src/vivarium_public_health/dataset_manager/__init__.py
+++ b/src/vivarium_public_health/dataset_manager/__init__.py
@@ -1,4 +1,4 @@
 """This subpackage contains the data artifact and a vivarium plugin to manage it."""
 from .artifact import Artifact, EntityKey, ArtifactException
 from .dataset_manager import (ArtifactManager, ArtifactManagerInterface, parse_artifact_path_config,
-                              filter_data, get_location_term)
+                              filter_data, get_location_term, validate_filter_term)

--- a/src/vivarium_public_health/dataset_manager/artifact.py
+++ b/src/vivarium_public_health/dataset_manager/artifact.py
@@ -42,6 +42,10 @@ class Artifact:
         """A list of all the keys contained within the artifact."""
         return self._keys
 
+    @property
+    def filter_terms(self) -> List[str]:
+        return self._filter_terms
+
     def load(self, entity_key: str) -> Any:
         """Loads the data associated with provided EntityKey.
 

--- a/src/vivarium_public_health/dataset_manager/artifact.py
+++ b/src/vivarium_public_health/dataset_manager/artifact.py
@@ -32,7 +32,7 @@ class Artifact:
         """
 
         self.path = path
-        self.filter_terms = filter_terms
+        self._filter_terms = filter_terms
 
         self._cache = {}
         self._keys = [EntityKey(k) for k in hdf.get_keys(self.path)]
@@ -65,7 +65,7 @@ class Artifact:
             raise ArtifactException(f"{entity_key} should be in {self.path}.")
 
         if entity_key not in self._cache:
-            data = hdf.load(self.path, entity_key, self.filter_terms)
+            data = hdf.load(self.path, entity_key, self._filter_terms)
 
             assert data is not None, f"Data for {entity_key} is not available. Check your model specification."
 

--- a/src/vivarium_public_health/dataset_manager/dataset_manager.py
+++ b/src/vivarium_public_health/dataset_manager/dataset_manager.py
@@ -60,16 +60,21 @@ class ArtifactManager:
     configuration_defaults = {
         'input_data': {
             'artifact_path': None,
-            'artifact_filter_terms': None
+            'artifact_filter_term': None
         }
     }
 
     def setup(self, builder: Builder):
         """Performs this component's simulation setup."""
         self.artifact = self._load_artifact(builder.configuration)
+        # because not all columns are accessible via artifact filter terms, apply config filters separately
+        self.config_filter_term = validate_filter_term(builder.configuration.input_data.artifact_filter_term)
 
     def _load_artifact(self, configuration: ConfigTree) -> Artifact:
-        """Looks up the path to the artifact hdf file, builds a default filter, and generates the data artifact.
+        """Looks up the path to the artifact hdf file, builds a default filter,
+        and generates the data artifact. Stores any configuration specified filter
+        terms separately to be applied on loading, because not all columns are
+        available via artifact filter terms.
 
         Parameters
         ----------
@@ -83,7 +88,6 @@ class ArtifactManager:
         artifact_path = parse_artifact_path_config(configuration)
         draw = configuration.input_data.input_draw_number
         location = configuration.input_data.location
-        config_filter_terms = configuration.input_data.artifact_filter_terms
         base_filter_terms = [f'draw == {draw}', get_location_term(location)]
         return Artifact(artifact_path, base_filter_terms)
 
@@ -107,27 +111,31 @@ class ArtifactManager:
             The data associated with the given key, filtered down to the requested subset
             if the data is a dataframe.
         """
-        data = _config_filter(self.artifact.load(entity_key), self.config_filter_terms)
-        return filter_data(data, keep_age_group_edges, **column_filters) if isinstance(data, pd.DataFrame) else data
+        data = self.artifact.load(entity_key)
+        return filter_data(data, keep_age_group_edges, self.config_filter_term, **column_filters) if isinstance(data, pd.DataFrame) else data
 
 
-def filter_data(data: pd.DataFrame, keep_age_group_edges: bool, **column_filters: _Filter) -> pd.DataFrame:
+def filter_data(data: pd.DataFrame, keep_age_group_edges: bool,
+                config_filter_term: str=None, **column_filters: _Filter) -> pd.DataFrame:
     """Uses the provided column filters and age_group conditions to subset the raw data."""
+    data = _config_filter(data, config_filter_term)
     data = _subset_rows(data, **column_filters)
     data = _subset_columns(data, keep_age_group_edges, **column_filters)
     return data
 
-def _config_filter(data: pd.DataFrame, config_filter_terms: str) -> pd.DataFrame:
-    if config_filter_terms is not None:
-        return None
+
+def _config_filter(data, config_filter_term):
+    filter_column = re.split('[<=>]', config_filter_term.split()[0])[0]
+    if filter_column in data.columns:
+        data = data.query(config_filter_term)
+    return data
 
 
-def _parse_config_filter(data_columns, config_filter_terms):
-    ind_terms = re.split('[()]', config_filter_terms)
-
-        #re.split('[&|]').split(' and ').split(' or ')  # now we have a list of each term
-    filter_columns = [re.split()]
-
+def validate_filter_term(config_filter_term):
+    multiple_filter_indicators = [' and ', ' or ', '|', '&']
+    if config_filter_term is not None and any(x in config_filter_term for x in multiple_filter_indicators):
+        raise NotImplementedError("Only a single filter term via the configuration is currently supported.")
+    return config_filter_term
 
 
 def _subset_rows(data: pd.DataFrame, **column_filters: _Filter) -> pd.DataFrame:

--- a/src/vivarium_public_health/dataset_manager/dataset_manager.py
+++ b/src/vivarium_public_health/dataset_manager/dataset_manager.py
@@ -1,6 +1,7 @@
 """A vivarium plugin for managing complex data."""
 from pathlib import Path
 from typing import Union, Sequence
+import re
 
 import pandas as pd
 from vivarium.config_tree import ConfigTree
@@ -59,6 +60,7 @@ class ArtifactManager:
     configuration_defaults = {
         'input_data': {
             'artifact_path': None,
+            'artifact_filter_terms': None
         }
     }
 
@@ -81,6 +83,7 @@ class ArtifactManager:
         artifact_path = parse_artifact_path_config(configuration)
         draw = configuration.input_data.input_draw_number
         location = configuration.input_data.location
+        config_filter_terms = configuration.input_data.artifact_filter_terms
         base_filter_terms = [f'draw == {draw}', get_location_term(location)]
         return Artifact(artifact_path, base_filter_terms)
 
@@ -104,7 +107,7 @@ class ArtifactManager:
             The data associated with the given key, filtered down to the requested subset
             if the data is a dataframe.
         """
-        data = self.artifact.load(entity_key)
+        data = _config_filter(self.artifact.load(entity_key), self.config_filter_terms)
         return filter_data(data, keep_age_group_edges, **column_filters) if isinstance(data, pd.DataFrame) else data
 
 
@@ -113,6 +116,18 @@ def filter_data(data: pd.DataFrame, keep_age_group_edges: bool, **column_filters
     data = _subset_rows(data, **column_filters)
     data = _subset_columns(data, keep_age_group_edges, **column_filters)
     return data
+
+def _config_filter(data: pd.DataFrame, config_filter_terms: str) -> pd.DataFrame:
+    if config_filter_terms is not None:
+        return None
+
+
+def _parse_config_filter(data_columns, config_filter_terms):
+    ind_terms = re.split('[()]', config_filter_terms)
+
+        #re.split('[&|]').split(' and ').split(' or ')  # now we have a list of each term
+    filter_columns = [re.split()]
+
 
 
 def _subset_rows(data: pd.DataFrame, **column_filters: _Filter) -> pd.DataFrame:

--- a/src/vivarium_public_health/dataset_manager/dataset_manager.py
+++ b/src/vivarium_public_health/dataset_manager/dataset_manager.py
@@ -125,9 +125,10 @@ def filter_data(data: pd.DataFrame, keep_age_group_edges: bool,
 
 
 def _config_filter(data, config_filter_term):
-    filter_column = re.split('[<=>]', config_filter_term.split()[0])[0]
-    if filter_column in data.columns:
-        data = data.query(config_filter_term)
+    if config_filter_term:
+        filter_column = re.split('[<=>]', config_filter_term.split()[0])[0]
+        if filter_column in data.columns:
+            data = data.query(config_filter_term)
     return data
 
 

--- a/tests/dataset_manager/test_artifact.py
+++ b/tests/dataset_manager/test_artifact.py
@@ -55,7 +55,7 @@ def test_artifact_creation(hdf_mock, keys_mock):
     a = Artifact(path)
 
     assert a.path == path
-    assert a.filter_terms is None
+    assert a._filter_terms is None
     assert a._cache == {}
     assert a.keys == [EntityKey(k) for k in keys_mock]
     hdf_mock.get_keys.assert_called_once_with(path)
@@ -65,7 +65,7 @@ def test_artifact_creation(hdf_mock, keys_mock):
     a = Artifact(path, filter_terms)
 
     assert a.path == path
-    assert a.filter_terms == filter_terms
+    assert a._filter_terms == filter_terms
     assert a._cache == {}
     assert a.keys == [EntityKey(k) for k in keys_mock]
     hdf_mock.get_keys.assert_called_once_with(path)
@@ -261,7 +261,7 @@ def test_loading_key_leaves_filters_unchanged():
 
     for key in _KEYS:
         a.load(key)
-        assert a.filter_terms == filter_terms
+        assert a._filter_terms == filter_terms
 
 
 def test_EntityKey_init_failure():

--- a/tests/dataset_manager/test_artifact.py
+++ b/tests/dataset_manager/test_artifact.py
@@ -55,7 +55,7 @@ def test_artifact_creation(hdf_mock, keys_mock):
     a = Artifact(path)
 
     assert a.path == path
-    assert a._filter_terms is None
+    assert a.filter_terms is None
     assert a._cache == {}
     assert a.keys == [EntityKey(k) for k in keys_mock]
     hdf_mock.get_keys.assert_called_once_with(path)
@@ -65,7 +65,7 @@ def test_artifact_creation(hdf_mock, keys_mock):
     a = Artifact(path, filter_terms)
 
     assert a.path == path
-    assert a._filter_terms == filter_terms
+    assert a.filter_terms == filter_terms
     assert a._cache == {}
     assert a.keys == [EntityKey(k) for k in keys_mock]
     hdf_mock.get_keys.assert_called_once_with(path)
@@ -261,7 +261,7 @@ def test_loading_key_leaves_filters_unchanged():
 
     for key in _KEYS:
         a.load(key)
-        assert a._filter_terms == filter_terms
+        assert a.filter_terms == filter_terms
 
 
 def test_EntityKey_init_failure():

--- a/tests/dataset_manager/test_dataset_manager.py
+++ b/tests/dataset_manager/test_dataset_manager.py
@@ -7,7 +7,7 @@ from vivarium.testing_utilities import build_table, metadata
 
 from vivarium_public_health.dataset_manager.dataset_manager import (_subset_rows, _subset_columns, get_location_term,
                                                                     parse_artifact_path_config, ArtifactManager,
-                                                                    filter_data)
+                                                                    _config_filter)
 @pytest.fixture()
 def artifact_mock(mocker):
     mock = mocker.patch('vivarium_public_health.dataset_manager.dataset_manager.Artifact')
@@ -126,15 +126,15 @@ def test_load_with_df_data(artifact_mock):
     assert isinstance(am.load('df_data.key'), pd.DataFrame)
 
 
-def test_filter_data_with_config_filter_term():
+def test__config_filter():
     df = pd.DataFrame({'year': range(1990, 2000, 1), 'color': ['red', 'yellow']*5})
-    filtered = filter_data(df, False, 'year in [1992, 1995]')
+    filtered = +_config_filter(df, 'year in [1992, 1995]')
 
     assert set(filtered.year) == {1992, 1995}
 
 
-def test_filter_data_config_filter_on_nonexistent_column():
+def test__config_filter_on_nonexistent_column():
     df = pd.DataFrame({'year': range(1990, 2000, 1), 'color': ['red', 'yellow']*5})
-    filtered = filter_data(df, False, 'fake_col in [1992, 1995]')
+    filtered = _config_filter(df, 'fake_col in [1992, 1995]')
 
     assert df.equals(filtered)

--- a/tests/dataset_manager/test_dataset_manager.py
+++ b/tests/dataset_manager/test_dataset_manager.py
@@ -6,7 +6,8 @@ import pytest
 from vivarium.testing_utilities import build_table, metadata
 
 from vivarium_public_health.dataset_manager.dataset_manager import (_subset_rows, _subset_columns, get_location_term,
-                                                                    parse_artifact_path_config, ArtifactManager)
+                                                                    parse_artifact_path_config, ArtifactManager,
+                                                                    filter_data)
 @pytest.fixture()
 def artifact_mock(mocker):
     mock = mocker.patch('vivarium_public_health.dataset_manager.dataset_manager.Artifact')
@@ -107,17 +108,33 @@ def test_parse_artifact_path_config_fail_relative(base_config):
 def test_load_with_string_data(artifact_mock):
     am = ArtifactManager()
     am.artifact = artifact_mock
+    am.config_filter_term = None
     assert am.load('string_data.key') == 'string_data'
 
 
 def test_load_with_no_data(artifact_mock):
     am = ArtifactManager()
     am.artifact = artifact_mock
+    am.config_filter_term = None
     assert am.load('no_data.key') is None
 
 
 def test_load_with_df_data(artifact_mock):
     am = ArtifactManager()
     am.artifact = artifact_mock
+    am.config_filter_term = None
     assert isinstance(am.load('df_data.key'), pd.DataFrame)
 
+
+def test_filter_data_with_config_filter_term():
+    df = pd.DataFrame({'year': range(1990, 2000, 1), 'color': ['red', 'yellow']*5})
+    filtered = filter_data(df, False, 'year in [1992, 1995]')
+
+    assert set(filtered.year) == {1992, 1995}
+
+
+def test_filter_data_config_filter_on_nonexistent_column():
+    df = pd.DataFrame({'year': range(1990, 2000, 1), 'color': ['red', 'yellow']*5})
+    filtered = filter_data(df, False, 'fake_col in [1992, 1995]')
+
+    assert df.equals(filtered)

--- a/tests/dataset_manager/test_dataset_manager.py
+++ b/tests/dataset_manager/test_dataset_manager.py
@@ -121,6 +121,7 @@ def test_load_with_no_data(artifact_mock):
 def test_load_with_df_data(artifact_mock):
     am = ArtifactManager()
     am.artifact = artifact_mock
+    am.config_filter_term = None
     assert isinstance(am.load('df_data.key'), pd.DataFrame)
 
 

--- a/tests/dataset_manager/test_dataset_manager.py
+++ b/tests/dataset_manager/test_dataset_manager.py
@@ -115,14 +115,12 @@ def test_load_with_string_data(artifact_mock):
 def test_load_with_no_data(artifact_mock):
     am = ArtifactManager()
     am.artifact = artifact_mock
-    am.config_filter_term = None
     assert am.load('no_data.key') is None
 
 
 def test_load_with_df_data(artifact_mock):
     am = ArtifactManager()
     am.artifact = artifact_mock
-    am.config_filter_term = None
     assert isinstance(am.load('df_data.key'), pd.DataFrame)
 
 

--- a/tests/dataset_manager/test_dataset_manager.py
+++ b/tests/dataset_manager/test_dataset_manager.py
@@ -7,7 +7,7 @@ from vivarium.testing_utilities import build_table, metadata
 
 from vivarium_public_health.dataset_manager.dataset_manager import (_subset_rows, _subset_columns, get_location_term,
                                                                     parse_artifact_path_config, ArtifactManager,
-                                                                    _config_filter)
+                                                                    _config_filter, validate_filter_term)
 @pytest.fixture()
 def artifact_mock(mocker):
     mock = mocker.patch('vivarium_public_health.dataset_manager.dataset_manager.Artifact')
@@ -126,15 +126,21 @@ def test_load_with_df_data(artifact_mock):
     assert isinstance(am.load('df_data.key'), pd.DataFrame)
 
 
-def test__config_filter():
+def test_config_filter():
     df = pd.DataFrame({'year': range(1990, 2000, 1), 'color': ['red', 'yellow']*5})
     filtered = +_config_filter(df, 'year in [1992, 1995]')
 
     assert set(filtered.year) == {1992, 1995}
 
 
-def test__config_filter_on_nonexistent_column():
+def test_config_filter_on_nonexistent_column():
     df = pd.DataFrame({'year': range(1990, 2000, 1), 'color': ['red', 'yellow']*5})
     filtered = _config_filter(df, 'fake_col in [1992, 1995]')
 
     assert df.equals(filtered)
+
+def test_validate_filter_term():
+    multiple_filter_terms = 'draw in [0, 1] and year > 1990'
+
+    with pytest.raises(NotImplementedError):
+        validate_filter_term(multiple_filter_terms)


### PR DESCRIPTION
Make filter_terms on artifact private to indicate they shouldn't be changed once an artifact is created (otherwise you get unexpected results on load b/c of the cache).

Add the ability to specify a single filter term in the config under 'artifact_filter_term' which is applied to all data containing the column specified in the filter term. 

Corresponding PR in vivarium_inputs for passthrough. 

Added unit tests + tested by specifying a filter term in config restricting years and then trying to run sim outside those years w/o extrapolation with artifact to make sure it fails. 