### PR TITLE
Bugfix/fertility rate filter

### DIFF
--- a/src/vivarium_public_health/population/add_new_birth_cohorts.py
+++ b/src/vivarium_public_health/population/add_new_birth_cohorts.py
@@ -178,7 +178,7 @@ class FertilityAgeSpecificRates:
         self.randomness = builder.randomness.get_stream('fertility')
         asfr_data = builder.data.load("covariate.age_specific_fertility_rate.estimate")[['year_start', 'year_end',
                                                                                          'age_group_start',
-                                                                                         'age_group_end', 'value']]
+                                                                                         'age_group_end', 'mean_value']]
         asfr_source = builder.lookup.build_table(asfr_data, key_columns=(),
                                                  parameter_columns=[('age', 'age_group_start', 'age_group_end'),
                                                                     ('year', 'year_start', 'year_end')],)

--- a/src/vivarium_public_health/population/add_new_birth_cohorts.py
+++ b/src/vivarium_public_health/population/add_new_birth_cohorts.py
@@ -176,9 +176,9 @@ class FertilityAgeSpecificRates:
         """
 
         self.randomness = builder.randomness.get_stream('fertility')
-        asfr_data = builder.data.load("covariate.age_specific_fertility_rate.estimate")[['year_start', 'year_end',
-                                                                                         'age_group_start',
-                                                                                         'age_group_end', 'mean_value']]
+        asfr_data = builder.data.load("covariate.age_specific_fertility_rate.estimate")
+        asfr_data = asfr_data[asfr_data.sex == 'Female'][['year_start', 'year_end',
+                                                          'age_group_start', 'age_group_end', 'mean_value']]
         asfr_source = builder.lookup.build_table(asfr_data, key_columns=(),
                                                  parameter_columns=[('age', 'age_group_start', 'age_group_end'),
                                                                     ('year', 'year_start', 'year_end')],)

--- a/tests/population/test_add_new_birth_cohort.py
+++ b/tests/population/test_add_new_birth_cohort.py
@@ -127,8 +127,9 @@ def test_fertility_module(base_config, base_plugins):
     components = [TestPopulation(), FertilityAgeSpecificRates()]
     simulation = initialize_simulation(components, base_config, base_plugins)
 
-    simulation.data.write("covariate.age_specific_fertility_rate.estimate",
-                          build_table(0.05, 1990, 2018).query("sex == 'Female'").drop("sex", "columns"))
+    asfr_data = build_table(0.05, 1990, 2018).query("sex == 'Female'")\
+        .drop("sex", "columns").rename(columns={'value': 'mean_value'})
+    simulation.data.write("covariate.age_specific_fertility_rate.estimate", asfr_data)
 
     simulation.setup()
 

--- a/tests/population/test_add_new_birth_cohort.py
+++ b/tests/population/test_add_new_birth_cohort.py
@@ -127,8 +127,7 @@ def test_fertility_module(base_config, base_plugins):
     components = [TestPopulation(), FertilityAgeSpecificRates()]
     simulation = initialize_simulation(components, base_config, base_plugins)
 
-    asfr_data = build_table(0.05, 1990, 2018).query("sex == 'Female'")\
-        .drop("sex", "columns").rename(columns={'value': 'mean_value'})
+    asfr_data = build_table(0.05, 1990, 2018).rename(columns={'value': 'mean_value'})
     simulation.data.write("covariate.age_specific_fertility_rate.estimate", asfr_data)
 
     simulation.setup()


### PR DESCRIPTION
Hit some bugs in the existing FertilityAgeSpecificRates component when I was trying to use it for the forecasting data where it was trying to pull a column that didn't exist and wasn't filtering down to just women so ended up with duplicates that broke in interpolation. 