### PR TITLE
Bugfix/pipeline not filter untracked simulants

### DIFF
--- a/src/vivarium_public_health/disease/transition.py
+++ b/src/vivarium_public_health/disease/transition.py
@@ -14,9 +14,8 @@ class RateTransition(Transition):
         rate_data, pipeline_name = self._get_rate_data(builder)
         self.base_rate = builder.lookup.build_table(rate_data)
         self.effective_rate = builder.value.register_rate_producer(pipeline_name, source=self.rates)
-        self.base_paf = lambda index: [builder.lookup.build_table(0)(index)]
         self.joint_paf = builder.value.register_value_producer(f'{self.output_state.state_id}.incidence_rate.paf',
-                                                               source=self.base_paf,
+                                                               source=lambda index: [builder.lookup.build_table(0)(index)],
                                                                preferred_combiner=list_combiner,
                                                                preferred_post_processor=joint_value_post_processor)
     def _get_rate_data(self, builder):

--- a/src/vivarium_public_health/disease/transition.py
+++ b/src/vivarium_public_health/disease/transition.py
@@ -1,1 +1,63 @@
-import pandas as pdfrom vivarium.framework.state_machine import Transitionfrom vivarium.framework.utilities import rate_to_probabilityfrom vivarium.framework.values import list_combiner, joint_value_post_processorclass RateTransition(Transition):    def __init__(self, input_state, output_state, get_data_functions=None, **kwargs):        super().__init__(input_state, output_state, probability_func=self._probability, **kwargs)        self._get_data_functions = get_data_functions if get_data_functions is not None else {}    def setup(self, builder):        rate_data, pipeline_name = self._get_rate_data(builder)        self.base_rate = builder.lookup.build_table(rate_data)        self.effective_rate = builder.value.register_rate_producer(pipeline_name, source=self.rates)        self.base_paf = lambda index: [builder.lookup.build_table(0)(index)]        self.joint_paf = builder.value.register_value_producer(f'{self.output_state.state_id}.incidence_rate.paf',                                                               source=self.base_paf,                                                               preferred_combiner=list_combiner,                                                               preferred_post_processor=joint_value_post_processor)    def _get_rate_data(self, builder):        if 'incidence_rate' in self._get_data_functions:            rate_data = self._get_data_functions['incidence_rate'](self.output_state.cause, builder)            pipeline_name = f'{self.output_state.state_id}.incidence_rate'        elif 'remission_rate' in self._get_data_functions:            rate_data = self._get_data_functions['remission_rate'](self.output_state.cause, builder)            pipeline_name = f'{self.input_state.state_id}.remission_rate'        else:            raise ValueError("No valid data functions supplied.")        return rate_data, pipeline_name    def _probability(self, index):        return rate_to_probability(self.effective_rate(index))    def rates(self, index):        base_rates = self.base_rate(index)        joint_mediated_paf = self.joint_paf(index)        # risk-deleted incidence is calculated by taking incidence and multiplying it by (1 - Joint PAF)        return pd.Series(base_rates.values * (1 - joint_mediated_paf.values), index=index)    def __str__(self):        return f'RateTransition(from={self.input_state.state_id}, to={self.output_state.state_id})'class ProportionTransition(Transition):    def __init__(self, input_state, output_state, get_data_functions=None, **kwargs):        super().__init__(input_state, output_state, probability_func=self._probability, **kwargs)        self._get_data_functions = get_data_functions if get_data_functions is not None else {}    def setup(self, builder):        super().setup(builder)        get_proportion_func = self._get_data_functions.get('proportion', None)        if get_proportion_func is None:            raise ValueError('Must supply a proportion function')        self._proportion_data = get_proportion_func(self.output_state.cause, builder)        self.proportion = builder.lookup.build_table(self._proportion_data)    def _probability(self, index):        return self.proportion(index)    def __str__(self):        return f'ProportionTransition(from={self.input_state.state_id}, {self.output_state.state_id})'
+import pandas as pd
+
+from vivarium.framework.state_machine import Transition
+from vivarium.framework.utilities import rate_to_probability
+from vivarium.framework.values import list_combiner, joint_value_post_processor
+
+
+class RateTransition(Transition):
+    def __init__(self, input_state, output_state, get_data_functions=None, **kwargs):
+        super().__init__(input_state, output_state, probability_func=self._probability, **kwargs)
+        self._get_data_functions = get_data_functions if get_data_functions is not None else {}
+
+    def setup(self, builder):
+        rate_data, pipeline_name = self._get_rate_data(builder)
+        self.base_rate = builder.lookup.build_table(rate_data)
+        self.effective_rate = builder.value.register_rate_producer(pipeline_name, source=self.rates)
+        self.base_paf = lambda index: [builder.lookup.build_table(0)(index)]
+        self.joint_paf = builder.value.register_value_producer(f'{self.output_state.state_id}.incidence_rate.paf',
+                                                               source=self.base_paf,
+                                                               preferred_combiner=list_combiner,
+                                                               preferred_post_processor=joint_value_post_processor)
+    def _get_rate_data(self, builder):
+        if 'incidence_rate' in self._get_data_functions:
+            rate_data = self._get_data_functions['incidence_rate'](self.output_state.cause, builder)
+            pipeline_name = f'{self.output_state.state_id}.incidence_rate'
+        elif 'remission_rate' in self._get_data_functions:
+            rate_data = self._get_data_functions['remission_rate'](self.output_state.cause, builder)
+            pipeline_name = f'{self.input_state.state_id}.remission_rate'
+        else:
+            raise ValueError("No valid data functions supplied.")
+        return rate_data, pipeline_name
+
+    def _probability(self, index):
+        return rate_to_probability(self.effective_rate(index))
+
+    def rates(self, index):
+        base_rates = self.base_rate(index)
+        joint_mediated_paf = self.joint_paf(index)
+        # risk-deleted incidence is calculated by taking incidence and multiplying it by (1 - Joint PAF)
+        return pd.Series(base_rates.values * (1 - joint_mediated_paf.values), index=index)
+
+    def __str__(self):
+        return f'RateTransition(from={self.input_state.state_id}, to={self.output_state.state_id})'
+
+
+class ProportionTransition(Transition):
+    def __init__(self, input_state, output_state, get_data_functions=None, **kwargs):
+        super().__init__(input_state, output_state, probability_func=self._probability, **kwargs)
+        self._get_data_functions = get_data_functions if get_data_functions is not None else {}
+
+    def setup(self, builder):
+        super().setup(builder)
+        get_proportion_func = self._get_data_functions.get('proportion', None)
+        if get_proportion_func is None:
+            raise ValueError('Must supply a proportion function')
+        self._proportion_data = get_proportion_func(self.output_state.cause, builder)
+        self.proportion = builder.lookup.build_table(self._proportion_data)
+
+    def _probability(self, index):
+        return self.proportion(index)
+
+    def __str__(self):
+        return f'ProportionTransition(from={self.input_state.state_id}, {self.output_state.state_id})'

--- a/src/vivarium_public_health/disease/transition.py
+++ b/src/vivarium_public_health/disease/transition.py
@@ -1,63 +1,1 @@
-import pandas as pd
-
-from vivarium.framework.state_machine import Transition
-from vivarium.framework.utilities import rate_to_probability
-from vivarium.framework.values import list_combiner, joint_value_post_processor
-
-
-class RateTransition(Transition):
-    def __init__(self, input_state, output_state, get_data_functions=None, **kwargs):
-        super().__init__(input_state, output_state, probability_func=self._probability, **kwargs)
-        self._get_data_functions = get_data_functions if get_data_functions is not None else {}
-
-    def setup(self, builder):
-        rate_data, pipeline_name = self._get_rate_data(builder)
-        self.base_rate = builder.lookup.build_table(rate_data)
-        self.effective_rate = builder.value.register_rate_producer(pipeline_name, source=self.rates)
-        self.joint_paf = builder.value.register_value_producer(f'{self.output_state.state_id}.incidence_rate.paf',
-                                                               source=lambda index: [pd.Series(0, index=index)],
-                                                               preferred_combiner=list_combiner,
-                                                               preferred_post_processor=joint_value_post_processor)
-
-    def _get_rate_data(self, builder):
-        if 'incidence_rate' in self._get_data_functions:
-            rate_data = self._get_data_functions['incidence_rate'](self.output_state.cause, builder)
-            pipeline_name = f'{self.output_state.state_id}.incidence_rate'
-        elif 'remission_rate' in self._get_data_functions:
-            rate_data = self._get_data_functions['remission_rate'](self.output_state.cause, builder)
-            pipeline_name = f'{self.input_state.state_id}.remission_rate'
-        else:
-            raise ValueError("No valid data functions supplied.")
-        return rate_data, pipeline_name
-
-    def _probability(self, index):
-        return rate_to_probability(self.effective_rate(index))
-
-    def rates(self, index):
-        base_rates = self.base_rate(index)
-        joint_mediated_paf = self.joint_paf(index)
-        # risk-deleted incidence is calculated by taking incidence and multiplying it by (1 - Joint PAF)
-        return pd.Series(base_rates.values * (1 - joint_mediated_paf.values), index=index)
-
-    def __str__(self):
-        return f'RateTransition(from={self.input_state.state_id}, to={self.output_state.state_id})'
-
-
-class ProportionTransition(Transition):
-    def __init__(self, input_state, output_state, get_data_functions=None, **kwargs):
-        super().__init__(input_state, output_state, probability_func=self._probability, **kwargs)
-        self._get_data_functions = get_data_functions if get_data_functions is not None else {}
-
-    def setup(self, builder):
-        super().setup(builder)
-        get_proportion_func = self._get_data_functions.get('proportion', None)
-        if get_proportion_func is None:
-            raise ValueError('Must supply a proportion function')
-        self._proportion_data = get_proportion_func(self.output_state.cause, builder)
-        self.proportion = builder.lookup.build_table(self._proportion_data)
-
-    def _probability(self, index):
-        return self.proportion(index)
-
-    def __str__(self):
-        return f'ProportionTransition(from={self.input_state.state_id}, {self.output_state.state_id})'
+import pandas as pdfrom vivarium.framework.state_machine import Transitionfrom vivarium.framework.utilities import rate_to_probabilityfrom vivarium.framework.values import list_combiner, joint_value_post_processorclass RateTransition(Transition):    def __init__(self, input_state, output_state, get_data_functions=None, **kwargs):        super().__init__(input_state, output_state, probability_func=self._probability, **kwargs)        self._get_data_functions = get_data_functions if get_data_functions is not None else {}    def setup(self, builder):        rate_data, pipeline_name = self._get_rate_data(builder)        self.base_rate = builder.lookup.build_table(rate_data)        self.effective_rate = builder.value.register_rate_producer(pipeline_name, source=self.rates)        self.base_paf = lambda index: [builder.lookup.build_table(0)(index)]        self.joint_paf = builder.value.register_value_producer(f'{self.output_state.state_id}.incidence_rate.paf',                                                               source=self.base_paf,                                                               preferred_combiner=list_combiner,                                                               preferred_post_processor=joint_value_post_processor)    def _get_rate_data(self, builder):        if 'incidence_rate' in self._get_data_functions:            rate_data = self._get_data_functions['incidence_rate'](self.output_state.cause, builder)            pipeline_name = f'{self.output_state.state_id}.incidence_rate'        elif 'remission_rate' in self._get_data_functions:            rate_data = self._get_data_functions['remission_rate'](self.output_state.cause, builder)            pipeline_name = f'{self.input_state.state_id}.remission_rate'        else:            raise ValueError("No valid data functions supplied.")        return rate_data, pipeline_name    def _probability(self, index):        return rate_to_probability(self.effective_rate(index))    def rates(self, index):        base_rates = self.base_rate(index)        joint_mediated_paf = self.joint_paf(index)        # risk-deleted incidence is calculated by taking incidence and multiplying it by (1 - Joint PAF)        return pd.Series(base_rates.values * (1 - joint_mediated_paf.values), index=index)    def __str__(self):        return f'RateTransition(from={self.input_state.state_id}, to={self.output_state.state_id})'class ProportionTransition(Transition):    def __init__(self, input_state, output_state, get_data_functions=None, **kwargs):        super().__init__(input_state, output_state, probability_func=self._probability, **kwargs)        self._get_data_functions = get_data_functions if get_data_functions is not None else {}    def setup(self, builder):        super().setup(builder)        get_proportion_func = self._get_data_functions.get('proportion', None)        if get_proportion_func is None:            raise ValueError('Must supply a proportion function')        self._proportion_data = get_proportion_func(self.output_state.cause, builder)        self.proportion = builder.lookup.build_table(self._proportion_data)    def _probability(self, index):        return self.proportion(index)    def __str__(self):        return f'ProportionTransition(from={self.input_state.state_id}, {self.output_state.state_id})'

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -65,8 +65,9 @@ class DichotomousDistribution:
         self._base_exposure = builder.lookup.build_table(self.exposure_data)
         self.exposure_proportion = builder.value.register_value_producer(f'{self._risk}.exposure_parameters',
                                                                          source=self.exposure)
+        self.base_paf = lambda index: [builder.lookup.build_table(0)(index)]
         self.joint_paf = builder.value.register_value_producer(f'{self._risk}.exposure_parameters.paf',
-                                                               source=lambda index: [pd.Series(0, index=index)],
+                                                               source=self.base_paf,
                                                                preferred_combiner=list_combiner,
                                                                preferred_post_processor=joint_value_post_processor)
 

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -65,9 +65,8 @@ class DichotomousDistribution:
         self._base_exposure = builder.lookup.build_table(self.exposure_data)
         self.exposure_proportion = builder.value.register_value_producer(f'{self._risk}.exposure_parameters',
                                                                          source=self.exposure)
-        self.base_paf = lambda index: [builder.lookup.build_table(0)(index)]
         self.joint_paf = builder.value.register_value_producer(f'{self._risk}.exposure_parameters.paf',
-                                                               source=self.base_paf,
+                                                               source=lambda index: [builder.lookup.build_table(0)(index)],
                                                                preferred_combiner=list_combiner,
                                                                preferred_post_processor=joint_value_post_processor)
 

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -37,8 +37,8 @@ def get_test_prevalence(simulation, key):
     Helper function to calculate the prevalence for the given state(key)
     """
     try:
-        simulants_status_counts = simulation.population._population.test.value_counts().to_dict()
-        result = float(simulants_status_counts[key] / simulation.population._population.test.size)
+        simulants_status_counts = simulation.get_population().test.value_counts().to_dict()
+        result = float(simulants_status_counts[key] / simulation.get_population().test.size)
     except KeyError:
         result = 0
     return result
@@ -71,18 +71,18 @@ def test_dwell_time(assign_cause_mock, base_config, disease, base_data):
     # Move everyone into the event state
     simulation.step()
     event_time = simulation.clock.time
-    assert np.all(simulation.population._population[disease] == 'event')
+    assert np.all(simulation.get_population()[disease] == 'event')
 
     simulation.step()
     simulation.step()
     # Not enough time has passed for people to move out of the event state, so they should all still be there
-    assert np.all(simulation.population._population[disease] == 'event')
+    assert np.all(simulation.get_population()[disease] == 'event')
 
     simulation.step()
     # Now enough time has passed so people should transition away
-    assert np.all(simulation.population._population[disease] == 'sick')
-    assert np.all(simulation.population._population.event_event_time == pd.to_datetime(event_time))
-    assert np.all(simulation.population._population.event_event_count == 1)
+    assert np.all(simulation.get_population()[disease] == 'sick')
+    assert np.all(simulation.get_population().event_event_time == pd.to_datetime(event_time))
+    assert np.all(simulation.get_population().event_event_count == 1)
 
 
 def test_dwell_time_with_mortality(base_config, base_plugins, disease):
@@ -115,23 +115,23 @@ def test_dwell_time_with_mortality(base_config, base_plugins, disease):
 
     # Move everyone into the event state
     simulation.step()
-    assert np.all(simulation.population._population[disease] == 'event')
+    assert np.all(simulation.get_population()[disease] == 'event')
 
     simulation.step()
     # Not enough time has passed for people to move out of the event state, so they should all still be there
-    assert np.all(simulation.population._population[disease] == 'event')
+    assert np.all(simulation.get_population()[disease] == 'event')
 
     simulation.step()
 
     # Make sure some people have died and remained in event state
-    assert (simulation.population._population['alive'] == 'alive').sum() < pop_size
+    assert (simulation.get_population()['alive'] == 'alive').sum() < pop_size
 
-    assert ((simulation.population._population['alive'] == 'dead').sum() ==
-            (simulation.population._population[disease] == 'event').sum())
+    assert ((simulation.get_population()['alive'] == 'dead').sum() ==
+            (simulation.get_population()[disease] == 'event').sum())
 
     # enough time has passed so living people should transition away to sick
-    assert ((simulation.population._population['alive'] == 'alive').sum() ==
-           (simulation.population._population[disease] == 'sick').sum())
+    assert ((simulation.get_population()['alive'] == 'alive').sum() ==
+           (simulation.get_population()[disease] == 'sick').sum())
 
 
 
@@ -228,7 +228,7 @@ def test_mortality_rate(base_config, base_plugins, disease):
 
     simulation.step()
     # Folks instantly transition to sick so now our mortality rate should be much higher
-    assert np.allclose(from_yearly(0.7, time_step), mortality_rate(simulation.population._population.index)['sick'])
+    assert np.allclose(from_yearly(0.7, time_step), mortality_rate(simulation.get_population().index)['sick'])
 
 
 def test_incidence(base_config, base_plugins, disease):
@@ -264,7 +264,7 @@ def test_incidence(base_config, base_plugins, disease):
     simulation.step()
 
     assert np.allclose(from_yearly(0.7, time_step),
-                       incidence_rate(simulation.population._population.index), atol=0.00001)
+                       incidence_rate(simulation.get_population().index), atol=0.00001)
 
 
 def test_risk_deletion(base_config, base_plugins, disease):
@@ -311,7 +311,7 @@ def test_risk_deletion(base_config, base_plugins, disease):
     expected_rate = base_rate * (1 - paf)
 
     assert np.allclose(from_yearly(expected_rate, time_step),
-                       incidence_rate(simulation.population._population.index), atol=0.00001)
+                       incidence_rate(simulation.get_population().index), atol=0.00001)
 
 
 def test__assign_event_time_for_prevalent_cases():

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -37,8 +37,8 @@ def get_test_prevalence(simulation, key):
     Helper function to calculate the prevalence for the given state(key)
     """
     try:
-        simulants_status_counts = simulation.population.population.test.value_counts().to_dict()
-        result = float(simulants_status_counts[key] / simulation.population.population.test.size)
+        simulants_status_counts = simulation.population._population.test.value_counts().to_dict()
+        result = float(simulants_status_counts[key] / simulation.population._population.test.size)
     except KeyError:
         result = 0
     return result
@@ -71,18 +71,18 @@ def test_dwell_time(assign_cause_mock, base_config, disease, base_data):
     # Move everyone into the event state
     simulation.step()
     event_time = simulation.clock.time
-    assert np.all(simulation.population.population[disease] == 'event')
+    assert np.all(simulation.population._population[disease] == 'event')
 
     simulation.step()
     simulation.step()
     # Not enough time has passed for people to move out of the event state, so they should all still be there
-    assert np.all(simulation.population.population[disease] == 'event')
+    assert np.all(simulation.population._population[disease] == 'event')
 
     simulation.step()
     # Now enough time has passed so people should transition away
-    assert np.all(simulation.population.population[disease] == 'sick')
-    assert np.all(simulation.population.population.event_event_time == pd.to_datetime(event_time))
-    assert np.all(simulation.population.population.event_event_count == 1)
+    assert np.all(simulation.population._population[disease] == 'sick')
+    assert np.all(simulation.population._population.event_event_time == pd.to_datetime(event_time))
+    assert np.all(simulation.population._population.event_event_count == 1)
 
 
 def test_dwell_time_with_mortality(base_config, base_plugins, disease):
@@ -115,23 +115,23 @@ def test_dwell_time_with_mortality(base_config, base_plugins, disease):
 
     # Move everyone into the event state
     simulation.step()
-    assert np.all(simulation.population.population[disease] == 'event')
+    assert np.all(simulation.population._population[disease] == 'event')
 
     simulation.step()
     # Not enough time has passed for people to move out of the event state, so they should all still be there
-    assert np.all(simulation.population.population[disease] == 'event')
+    assert np.all(simulation.population._population[disease] == 'event')
 
     simulation.step()
 
     # Make sure some people have died and remained in event state
-    assert (simulation.population.population['alive'] == 'alive').sum() < pop_size
+    assert (simulation.population._population['alive'] == 'alive').sum() < pop_size
 
-    assert ((simulation.population.population['alive'] == 'dead').sum() ==
-            (simulation.population.population[disease] == 'event').sum())
+    assert ((simulation.population._population['alive'] == 'dead').sum() ==
+            (simulation.population._population[disease] == 'event').sum())
 
     # enough time has passed so living people should transition away to sick
-    assert ((simulation.population.population['alive'] == 'alive').sum() ==
-           (simulation.population.population[disease] == 'sick').sum())
+    assert ((simulation.population._population['alive'] == 'alive').sum() ==
+           (simulation.population._population[disease] == 'sick').sum())
 
 
 
@@ -228,7 +228,7 @@ def test_mortality_rate(base_config, base_plugins, disease):
 
     simulation.step()
     # Folks instantly transition to sick so now our mortality rate should be much higher
-    assert np.allclose(from_yearly(0.7, time_step), mortality_rate(simulation.population.population.index)['sick'])
+    assert np.allclose(from_yearly(0.7, time_step), mortality_rate(simulation.population._population.index)['sick'])
 
 
 def test_incidence(base_config, base_plugins, disease):
@@ -264,7 +264,7 @@ def test_incidence(base_config, base_plugins, disease):
     simulation.step()
 
     assert np.allclose(from_yearly(0.7, time_step),
-                       incidence_rate(simulation.population.population.index), atol=0.00001)
+                       incidence_rate(simulation.population._population.index), atol=0.00001)
 
 
 def test_risk_deletion(base_config, base_plugins, disease):
@@ -311,7 +311,7 @@ def test_risk_deletion(base_config, base_plugins, disease):
     expected_rate = base_rate * (1 - paf)
 
     assert np.allclose(from_yearly(expected_rate, time_step),
-                       incidence_rate(simulation.population.population.index), atol=0.00001)
+                       incidence_rate(simulation.population._population.index), atol=0.00001)
 
 
 def test__assign_event_time_for_prevalent_cases():

--- a/tests/metrics/test_disability.py
+++ b/tests/metrics/test_disability.py
@@ -89,15 +89,15 @@ def set_up_test_parameters(base_config, flu=False, mumps=False, deadly=False):
 
 def test_that_ylds_are_0_at_sim_beginning(base_config):
     simulation, disability = set_up_test_parameters(base_config)
-    ylds = int(simulation.get_value('metrics')(simulation.population._population.index)['years_lived_with_disability'])
+    ylds = int(simulation.get_value('metrics')(simulation.get_population().index)['years_lived_with_disability'])
     assert ylds == 0
 
 
 def test_that_healthy_people_dont_accrue_disability_weights(base_config):
     simulation, disability = set_up_test_parameters(base_config)
     simulation.run_for(duration=pd.Timedelta(days=365))
-    pop_size = len(simulation.population._population)
-    ylds = simulation.get_value('metrics')(simulation.population._population.index)['years_lived_with_disability']
+    pop_size = len(simulation.get_population())
+    ylds = simulation.get_value('metrics')(simulation.get_population().index)['years_lived_with_disability']
     assert np.isclose(ylds, pop_size * 0.0, rtol=0.01)
 
 
@@ -105,8 +105,8 @@ def test_single_disability_weight(base_config):
     simulation, disability = set_up_test_parameters(base_config, flu=True)
     flu_dw = 0.2
     simulation.run_for(duration=pd.Timedelta(days=365))
-    pop_size = len(simulation.population._population)
-    ylds = simulation.get_value('metrics')(simulation.population._population.index)['years_lived_with_disability']
+    pop_size = len(simulation.get_population())
+    ylds = simulation.get_value('metrics')(simulation.get_population().index)['years_lived_with_disability']
     assert np.isclose(ylds, pop_size * flu_dw, rtol=0.01)
 
 
@@ -115,8 +115,8 @@ def test_joint_disability_weight(base_config):
     flu_dw = 0.2
     mumps_dw = 0.4
     simulation.run_for(duration=pd.Timedelta(days=365))
-    pop_size = len(simulation.population._population)
-    ylds = simulation.get_value('metrics')(simulation.population._population.index)['years_lived_with_disability']
+    pop_size = len(simulation.get_population())
+    ylds = simulation.get_value('metrics')(simulation.get_population().index)['years_lived_with_disability']
     # check that JOINT disability weight is correctly calculated
     assert np.isclose(ylds, pop_size * (1-(1-flu_dw)*(1-mumps_dw)), rtol=0.01)
 
@@ -125,7 +125,7 @@ def test_joint_disability_weight(base_config):
 def test_dead_people_dont_accrue_disability(base_config):
     simulation, disability = set_up_test_parameters(base_config, deadly=True)
     simulation.run_for(duration=pd.Timedelta(days=365))
-    pop = simulation.population._population
+    pop = simulation.get_population()
     dead = pop[pop.alive == 'dead']
     assert len(dead) > 0
     assert np.all(disability.disability_weight(dead.index) == 0)

--- a/tests/metrics/test_disability.py
+++ b/tests/metrics/test_disability.py
@@ -89,15 +89,15 @@ def set_up_test_parameters(base_config, flu=False, mumps=False, deadly=False):
 
 def test_that_ylds_are_0_at_sim_beginning(base_config):
     simulation, disability = set_up_test_parameters(base_config)
-    ylds = int(simulation.get_value('metrics')(simulation.population.population.index)['years_lived_with_disability'])
+    ylds = int(simulation.get_value('metrics')(simulation.population._population.index)['years_lived_with_disability'])
     assert ylds == 0
 
 
 def test_that_healthy_people_dont_accrue_disability_weights(base_config):
     simulation, disability = set_up_test_parameters(base_config)
     simulation.run_for(duration=pd.Timedelta(days=365))
-    pop_size = len(simulation.population.population)
-    ylds = simulation.get_value('metrics')(simulation.population.population.index)['years_lived_with_disability']
+    pop_size = len(simulation.population._population)
+    ylds = simulation.get_value('metrics')(simulation.population._population.index)['years_lived_with_disability']
     assert np.isclose(ylds, pop_size * 0.0, rtol=0.01)
 
 
@@ -105,8 +105,8 @@ def test_single_disability_weight(base_config):
     simulation, disability = set_up_test_parameters(base_config, flu=True)
     flu_dw = 0.2
     simulation.run_for(duration=pd.Timedelta(days=365))
-    pop_size = len(simulation.population.population)
-    ylds = simulation.get_value('metrics')(simulation.population.population.index)['years_lived_with_disability']
+    pop_size = len(simulation.population._population)
+    ylds = simulation.get_value('metrics')(simulation.population._population.index)['years_lived_with_disability']
     assert np.isclose(ylds, pop_size * flu_dw, rtol=0.01)
 
 
@@ -115,8 +115,8 @@ def test_joint_disability_weight(base_config):
     flu_dw = 0.2
     mumps_dw = 0.4
     simulation.run_for(duration=pd.Timedelta(days=365))
-    pop_size = len(simulation.population.population)
-    ylds = simulation.get_value('metrics')(simulation.population.population.index)['years_lived_with_disability']
+    pop_size = len(simulation.population._population)
+    ylds = simulation.get_value('metrics')(simulation.population._population.index)['years_lived_with_disability']
     # check that JOINT disability weight is correctly calculated
     assert np.isclose(ylds, pop_size * (1-(1-flu_dw)*(1-mumps_dw)), rtol=0.01)
 
@@ -125,7 +125,7 @@ def test_joint_disability_weight(base_config):
 def test_dead_people_dont_accrue_disability(base_config):
     simulation, disability = set_up_test_parameters(base_config, deadly=True)
     simulation.run_for(duration=pd.Timedelta(days=365))
-    pop = simulation.population.population
+    pop = simulation.population._population
     dead = pop[pop.alive == 'dead']
     assert len(dead) > 0
     assert np.all(disability.disability_weight(dead.index) == 0)

--- a/tests/population/test_add_new_birth_cohort.py
+++ b/tests/population/test_add_new_birth_cohort.py
@@ -27,7 +27,7 @@ def test_FertilityDeterministic(base_config):
     simulation = setup_simulation(components, base_config)
     num_steps = simulation.run_for(duration=pd.Timedelta(days=num_days))
     assert num_steps == num_days // time_step
-    pop = simulation.population._population
+    pop = simulation.get_population()
 
     # No death in this model.
     assert np.all(pop.alive == 'alive'), 'expect all simulants to be alive'
@@ -57,7 +57,7 @@ def test_FertilityCrudeBirthRate(base_config, base_plugins):
     simulation.setup()
 
     simulation.run_for(duration=pd.Timedelta(days=num_days))
-    pop = simulation.population._population
+    pop = simulation.get_population()
 
     # No death in this model.
     assert np.all(pop.alive == 'alive'), 'expect all simulants to be alive'
@@ -105,9 +105,9 @@ def test_FertilityCrudeBirthRate(base_config, base_plugins):
     birth_rate = []
     pop = []
     for i in range(10):
-        pop.append(len(simulation.population._population))
+        pop.append(len(simulation.get_population()))
         simulation.take_steps()
-        birth_rate.append((len(simulation.population._population)-pop[-1])/pop[-1])
+        birth_rate.append((len(simulation.get_population())-pop[-1])/pop[-1])
     given_birth_rate = 0.0625  # 500 / 8000 (population data from mock_artifact)
     np.testing.assert_allclose(birth_rate, given_birth_rate, atol=0.01)
 
@@ -134,13 +134,13 @@ def test_fertility_module(base_config, base_plugins):
 
     time_start = simulation.clock.time
 
-    assert 'last_birth_time' in simulation.population._population.columns,\
+    assert 'last_birth_time' in simulation.get_population().columns,\
         'expect Fertility module to update state table.'
-    assert 'parent_id' in simulation.population._population.columns, \
+    assert 'parent_id' in simulation.get_population().columns, \
         'expect Fertility module to update state table.'
 
     simulation.run_for(duration=pd.Timedelta(days=num_days))
-    pop = simulation.population._population
+    pop = simulation.get_population()
 
     # No death in this model.
     assert np.all(pop.alive == 'alive'), 'expect all simulants to be alive'

--- a/tests/population/test_add_new_birth_cohort.py
+++ b/tests/population/test_add_new_birth_cohort.py
@@ -27,10 +27,10 @@ def test_FertilityDeterministic(base_config):
     simulation = setup_simulation(components, base_config)
     num_steps = simulation.run_for(duration=pd.Timedelta(days=num_days))
     assert num_steps == num_days // time_step
-    pop = simulation.population.population
+    pop = simulation.population._population
 
     # No death in this model.
-    assert np.all(simulation.population.population.alive == 'alive'), 'expect all simulants to be alive'
+    assert np.all(pop.alive == 'alive'), 'expect all simulants to be alive'
     assert (int(num_days * annual_new_simulants / 365)
             == len(pop.age) - start_population_size), 'expect new simulants'
 
@@ -57,10 +57,10 @@ def test_FertilityCrudeBirthRate(base_config, base_plugins):
     simulation.setup()
 
     simulation.run_for(duration=pd.Timedelta(days=num_days))
-    pop = simulation.population.population
+    pop = simulation.population._population
 
     # No death in this model.
-    assert np.all(simulation.population.population.alive == 'alive'), 'expect all simulants to be alive'
+    assert np.all(pop.alive == 'alive'), 'expect all simulants to be alive'
 
     # TODO: Write a more rigorous test.
     assert len(pop.age) > start_population_size, 'expect new simulants'
@@ -105,9 +105,9 @@ def test_FertilityCrudeBirthRate(base_config, base_plugins):
     birth_rate = []
     pop = []
     for i in range(10):
-        pop.append(len(simulation.population.population))
+        pop.append(len(simulation.population._population))
         simulation.take_steps()
-        birth_rate.append((len(simulation.population.population)-pop[-1])/pop[-1])
+        birth_rate.append((len(simulation.population._population)-pop[-1])/pop[-1])
     given_birth_rate = 0.0625  # 500 / 8000 (population data from mock_artifact)
     np.testing.assert_allclose(birth_rate, given_birth_rate, atol=0.01)
 
@@ -134,16 +134,16 @@ def test_fertility_module(base_config, base_plugins):
 
     time_start = simulation.clock.time
 
-    assert 'last_birth_time' in simulation.population.population.columns,\
+    assert 'last_birth_time' in simulation.population._population.columns,\
         'expect Fertility module to update state table.'
-    assert 'parent_id' in simulation.population.population.columns, \
+    assert 'parent_id' in simulation.population._population.columns, \
         'expect Fertility module to update state table.'
 
     simulation.run_for(duration=pd.Timedelta(days=num_days))
-    pop = simulation.population.population
+    pop = simulation.population._population
 
     # No death in this model.
-    assert np.all(simulation.population.population.alive == 'alive'), 'expect all simulants to be alive'
+    assert np.all(pop.alive == 'alive'), 'expect all simulants to be alive'
 
     # TODO: Write a more rigorous test.
     assert len(pop.age) > start_population_size, 'expect new simulants'

--- a/tests/population/test_base_population.py
+++ b/tests/population/test_base_population.py
@@ -104,7 +104,7 @@ def test_BasePopulation(config, base_plugins, generate_population_mock):
     assert mock_args['age_params'] == age_params
     assert mock_args['population_data'].equals(sub_pop)
     assert mock_args['randomness_streams'] == base_pop.randomness
-    pop = simulation.get_population(untracked=True)
+    pop = simulation.get_population()
     for column in pop:
         assert pop[column].equals(sims[column])
 
@@ -112,6 +112,7 @@ def test_BasePopulation(config, base_plugins, generate_population_mock):
 
     simulation.run_for(duration=pd.Timedelta(days=num_days))
 
+    pop = simulation.get_population()
     assert np.allclose(pop.age, final_ages, atol=0.5/365)  # Within a half of a day.
 
 

--- a/tests/population/test_base_population.py
+++ b/tests/population/test_base_population.py
@@ -104,14 +104,15 @@ def test_BasePopulation(config, base_plugins, generate_population_mock):
     assert mock_args['age_params'] == age_params
     assert mock_args['population_data'].equals(sub_pop)
     assert mock_args['randomness_streams'] == base_pop.randomness
-    for column in simulation.population.population:
-        assert simulation.population.population[column].equals(sims[column])
+    pop = simulation.population._population
+    for column in pop:
+        assert pop[column].equals(sims[column])
 
-    final_ages = simulation.population.population.age + num_days/365
+    final_ages = pop.age + num_days/365
 
     simulation.run_for(duration=pd.Timedelta(days=num_days))
 
-    assert np.allclose(simulation.population.population.age, final_ages, atol=0.5/365)  # Within a half of a day.
+    assert np.allclose(pop.age, final_ages, atol=0.5/365)  # Within a half of a day.
 
 
 def test_age_out_simulants(config, base_plugins):
@@ -130,9 +131,9 @@ def test_age_out_simulants(config, base_plugins):
     simulation = setup_simulation(components, input_config=config, plugin_config=base_plugins)
     time_start = simulation.clock.time
 
-    assert len(simulation.population.population) == len(simulation.population.population.age.unique())
+    assert len(simulation.population._population) == len(simulation.population._population.age.unique())
     simulation.run_for(duration=pd.Timedelta(days=num_days))
-    pop = simulation.population.population
+    pop = simulation.population._population
     assert len(pop) == len(pop[~pop.tracked])
     exit_after_300_days = pop.exit_time >= time_start + pd.Timedelta(300, unit='D')
     exit_before_400_days = pop.exit_time <= time_start + pd.Timedelta(400, unit='D')

--- a/tests/population/test_base_population.py
+++ b/tests/population/test_base_population.py
@@ -104,7 +104,7 @@ def test_BasePopulation(config, base_plugins, generate_population_mock):
     assert mock_args['age_params'] == age_params
     assert mock_args['population_data'].equals(sub_pop)
     assert mock_args['randomness_streams'] == base_pop.randomness
-    pop = simulation.population._population
+    pop = simulation.get_population(untracked=True)
     for column in pop:
         assert pop[column].equals(sims[column])
 
@@ -131,9 +131,9 @@ def test_age_out_simulants(config, base_plugins):
     simulation = setup_simulation(components, input_config=config, plugin_config=base_plugins)
     time_start = simulation.clock.time
 
-    assert len(simulation.population._population) == len(simulation.population._population.age.unique())
+    assert len(simulation.get_population()) == len(simulation.get_population().age.unique())
     simulation.run_for(duration=pd.Timedelta(days=num_days))
-    pop = simulation.population._population
+    pop = simulation.get_population()
     assert len(pop) == len(pop[~pop.tracked])
     exit_after_300_days = pop.exit_time >= time_start + pd.Timedelta(300, unit='D')
     exit_before_400_days = pop.exit_time <= time_start + pd.Timedelta(400, unit='D')

--- a/tests/risks/test_base_risk.py
+++ b/tests/risks/test_base_risk.py
@@ -26,7 +26,7 @@ def test_propensity_effect(propensity, mocker, continuous_risk, base_config, bas
 
     expected_value = norm(loc=130, scale=15).ppf(propensity)
 
-    assert np.allclose(rf.exposure(sim.population._population.index), expected_value)
+    assert np.allclose(rf.exposure(sim.get_population().index), expected_value)
 
 
 def test_Risk_config_data(base_config, base_plugins):
@@ -39,10 +39,10 @@ def test_Risk_config_data(base_config, base_plugins):
     simulation.setup()
 
     # Make sure dummy exposure is being used
-    exp = simulation.values.get_value('test_risk.exposure')(simulation.population._population.index)
+    exp = simulation.values.get_value('test_risk.exposure')(simulation.get_population().index)
     exposed_proportion = (exp == 'cat1').sum() / len(exp)
     assert np.isclose(exposed_proportion, exposure_level, atol=0.005)  # population is 1000
 
     # Make sure value was correctly pulled from config
-    sim_exposure_level = simulation.values.get_value('test_risk.exposure_parameters')(simulation.population._population.index)
+    sim_exposure_level = simulation.values.get_value('test_risk.exposure_parameters')(simulation.get_population().index)
     assert np.all(sim_exposure_level == exposure_level)

--- a/tests/risks/test_base_risk.py
+++ b/tests/risks/test_base_risk.py
@@ -26,7 +26,7 @@ def test_propensity_effect(propensity, mocker, continuous_risk, base_config, bas
 
     expected_value = norm(loc=130, scale=15).ppf(propensity)
 
-    assert np.allclose(rf.exposure(sim.population.population.index), expected_value)
+    assert np.allclose(rf.exposure(sim.population._population.index), expected_value)
 
 
 def test_Risk_config_data(base_config, base_plugins):
@@ -39,10 +39,10 @@ def test_Risk_config_data(base_config, base_plugins):
     simulation.setup()
 
     # Make sure dummy exposure is being used
-    exp = simulation.values.get_value('test_risk.exposure')(simulation.population.population.index)
+    exp = simulation.values.get_value('test_risk.exposure')(simulation.population._population.index)
     exposed_proportion = (exp == 'cat1').sum() / len(exp)
     assert np.isclose(exposed_proportion, exposure_level, atol=0.005)  # population is 1000
 
     # Make sure value was correctly pulled from config
-    sim_exposure_level = simulation.values.get_value('test_risk.exposure_parameters')(simulation.population.population.index)
+    sim_exposure_level = simulation.values.get_value('test_risk.exposure_parameters')(simulation.population._population.index)
     assert np.all(sim_exposure_level == exposure_level)

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -55,13 +55,13 @@ def test_incidence_rate_risk_effect(base_config, base_plugins, mocker):
                                                                           ('year', 'year_start', 'year_end')],
                                                        value_columns=None)
 
-    assert np.allclose(rates(simulation.population._population.index), from_yearly(0.01, time_step))
-    assert np.allclose(other_rates(simulation.population._population.index), from_yearly(0.01, time_step))
+    assert np.allclose(rates(simulation.get_population().index), from_yearly(0.01, time_step))
+    assert np.allclose(other_rates(simulation.get_population().index), from_yearly(0.01, time_step))
 
     test_exposure[0] = 1
 
-    assert np.allclose(rates(simulation.population._population.index), from_yearly(0.0101, time_step))
-    assert np.allclose(other_rates(simulation.population._population.index), from_yearly(0.01, time_step))
+    assert np.allclose(rates(simulation.get_population().index), from_yearly(0.0101, time_step))
+    assert np.allclose(other_rates(simulation.get_population().index), from_yearly(0.01, time_step))
 
 
 def test_risk_deletion(base_config, base_plugins, mocker):
@@ -98,8 +98,8 @@ def test_risk_deletion(base_config, base_plugins, mocker):
     joint_paf = base_simulation.get_value('infected.incidence_rate.paf')
 
     # Validate the base case
-    assert np.allclose(incidence(base_simulation.population._population.index), from_yearly(base_rate, time_step))
-    assert np.allclose(joint_paf(base_simulation.population._population.index), 0)
+    assert np.allclose(incidence(base_simulation.get_population().index), from_yearly(base_rate, time_step))
+    assert np.allclose(joint_paf(base_simulation.get_population().index), 0)
 
     transition = RateTransition(mocker.MagicMock(state_id='susceptible'),
                                 mocker.MagicMock(state_id='infected'), rate_data_functions)
@@ -117,9 +117,9 @@ def test_risk_deletion(base_config, base_plugins, mocker):
     incidence = rf_simulation.get_value('infected.incidence_rate')
     joint_paf = rf_simulation.get_value('infected.incidence_rate.paf')
 
-    assert np.allclose(incidence(rf_simulation.population._population.index),
+    assert np.allclose(incidence(rf_simulation.get_population().index),
                        from_yearly(base_rate * (1 - risk_paf), time_step))
-    assert np.allclose(joint_paf(rf_simulation.population._population.index), risk_paf)
+    assert np.allclose(joint_paf(rf_simulation.get_population().index), risk_paf)
 
 
 def test_continuous_exposure_effect(mocker, base_config, base_plugins, continuous_risk):
@@ -147,8 +147,8 @@ def test_continuous_exposure_effect(mocker, base_config, base_plugins, continuou
 
     simulation.setup()
 
-    rates = pd.Series(0.01, index=simulation.population._population.index)
-    rr = pd.Series(1.01, index=simulation.population._population.index)
+    rates = pd.Series(0.01, index=simulation.get_population().index)
+    rr = pd.Series(1.01, index=simulation.get_population().index)
 
     assert np.all(exposure_function(rates, rr) == 0.01)
 
@@ -183,16 +183,16 @@ def test_categorical_exposure_effect(base_config, base_plugins, mocker):
     simulation.data.write("risk_factor.test_risk.distribution", "dichotomous")
     simulation.setup()
 
-    rates = pd.Series(0.01, index=simulation.population._population.index)
-    rr = pd.DataFrame({'cat1': 1.01, 'cat2': 1}, index=simulation.population._population.index)
+    rates = pd.Series(0.01, index=simulation.get_population().index)
+    rr = pd.DataFrame({'cat1': 1.01, 'cat2': 1}, index=simulation.get_population().index)
 
     assert np.all(exposure_function(rates, rr) == 0.01)
 
     test_risk_exposure.side_effect = lambda index: pd.Series(['cat1'] * len(index), index=index)
     simulation.step()
 
-    rates = pd.Series(0.01, index=simulation.population._population.index)
-    rr = pd.DataFrame({'cat1': 1.01, 'cat2': 1}, index=simulation.population._population.index)
+    rates = pd.Series(0.01, index=simulation.get_population().index)
+    rr = pd.DataFrame({'cat1': 1.01, 'cat2': 1}, index=simulation.get_population().index)
 
     assert np.allclose(exposure_function(rates, rr), 0.0101)
 
@@ -218,8 +218,8 @@ def test_CategoricalRiskComponent_dichotomous_case(base_config, base_plugins, di
                                                                              ('year', 'year_start', 'year_end')],
                                                           value_columns=None)
 
-    categories = simulation.values.get_value('test_risk.exposure')(simulation.population._population.index)
-    assert np.isclose(categories.value_counts()['cat1'] / len(simulation.population._population), 0.5, rtol=0.01)
+    categories = simulation.values.get_value('test_risk.exposure')(simulation.get_population().index)
+    assert np.isclose(categories.value_counts()['cat1'] / len(simulation.get_population()), 0.5, rtol=0.01)
 
     expected_exposed_value = 0.01 * 1.01
     expected_unexposed_value = 0.01
@@ -254,10 +254,10 @@ def test_CategoricalRiskComponent_polytomous_case(base_config, base_plugins, pol
                                                                              ('year', 'year_start', 'year_end')],
                                                           value_columns=None)
 
-    categories = simulation.values.get_value('test_risk.exposure')(simulation.population._population.index)
+    categories = simulation.values.get_value('test_risk.exposure')(simulation.get_population().index)
 
     for category in ['cat1', 'cat2', 'cat3', 'cat4']:
-        assert np.isclose(categories.value_counts()[category] / len(simulation.population._population), 0.25, rtol=0.02)
+        assert np.isclose(categories.value_counts()[category] / len(simulation.get_population()), 0.25, rtol=0.02)
 
     expected_exposed_value = 0.01 * np.array([1.02, 1.03, 1.01])
 
@@ -291,11 +291,11 @@ def test_ContinuousRiskComponent(continuous_risk, base_config, base_plugins):
 
     exposure = simulation.values.get_value('test_risk.exposure')
 
-    assert np.allclose(exposure(simulation.population._population.index), 130, rtol=0.001)
+    assert np.allclose(exposure(simulation.get_population().index), 130, rtol=0.001)
 
     expected_value = 0.01 * (1.01**((130 - 112) / 10))
 
-    assert np.allclose(incidence_rate(simulation.population._population.index),
+    assert np.allclose(incidence_rate(simulation.get_population().index),
                        from_yearly(expected_value, time_step), rtol=0.001)
 
 
@@ -317,7 +317,7 @@ def test_exposure_params_risk_effect_dichotomous(base_config, base_plugins, dich
 
     simulation.setup()
 
-    pop = simulation.population._population
+    pop = simulation.get_population()
     exposure = simulation.values.get_value('test_risk.exposure')
     assert np.isclose(rf_exposed, exposure(pop.index).value_counts()['cat1']/len(pop), rtol=0.01)
 
@@ -336,7 +336,7 @@ def test_exposure_params_risk_effect_dichotomous(base_config, base_plugins, dich
 
     simulation.setup()
 
-    pop = simulation.population._population
+    pop = simulation.get_population()
     rf_exposure = simulation.values.get_value('test_risk.exposure')(pop.index)
 
     # proportion of simulants exposed to each category of affected risk stays same
@@ -370,7 +370,7 @@ def test_RiskEffect_config_data(base_config, base_plugins):
     simulation.setup()
 
     # make sure our dummy exposure value is being properly used
-    exp = simulation.values.get_value('test_risk.exposure')(simulation.population._population.index)
+    exp = simulation.values.get_value('test_risk.exposure')(simulation.get_population().index)
     assert((exp == 'cat1').all())
 
     # This one should be affected by our DummyRiskEffect
@@ -389,5 +389,5 @@ def test_RiskEffect_config_data(base_config, base_plugins):
                                                                           ('year', 'year_start', 'year_end')],
                                                        value_columns=None)
 
-    assert np.allclose(rates(simulation.population._population.index), from_yearly(0.01, time_step)*50)
-    assert np.allclose(other_rates(simulation.population._population.index), from_yearly(0.01, time_step))
+    assert np.allclose(rates(simulation.get_population().index), from_yearly(0.01, time_step)*50)
+    assert np.allclose(other_rates(simulation.get_population().index), from_yearly(0.01, time_step))

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -55,13 +55,13 @@ def test_incidence_rate_risk_effect(base_config, base_plugins, mocker):
                                                                           ('year', 'year_start', 'year_end')],
                                                        value_columns=None)
 
-    assert np.allclose(rates(simulation.population.population.index), from_yearly(0.01, time_step))
-    assert np.allclose(other_rates(simulation.population.population.index), from_yearly(0.01, time_step))
+    assert np.allclose(rates(simulation.population._population.index), from_yearly(0.01, time_step))
+    assert np.allclose(other_rates(simulation.population._population.index), from_yearly(0.01, time_step))
 
     test_exposure[0] = 1
 
-    assert np.allclose(rates(simulation.population.population.index), from_yearly(0.0101, time_step))
-    assert np.allclose(other_rates(simulation.population.population.index), from_yearly(0.01, time_step))
+    assert np.allclose(rates(simulation.population._population.index), from_yearly(0.0101, time_step))
+    assert np.allclose(other_rates(simulation.population._population.index), from_yearly(0.01, time_step))
 
 
 def test_risk_deletion(base_config, base_plugins, mocker):
@@ -98,8 +98,8 @@ def test_risk_deletion(base_config, base_plugins, mocker):
     joint_paf = base_simulation.get_value('infected.incidence_rate.paf')
 
     # Validate the base case
-    assert np.allclose(incidence(base_simulation.population.population.index), from_yearly(base_rate, time_step))
-    assert np.allclose(joint_paf(base_simulation.population.population.index), 0)
+    assert np.allclose(incidence(base_simulation.population._population.index), from_yearly(base_rate, time_step))
+    assert np.allclose(joint_paf(base_simulation.population._population.index), 0)
 
     transition = RateTransition(mocker.MagicMock(state_id='susceptible'),
                                 mocker.MagicMock(state_id='infected'), rate_data_functions)
@@ -117,9 +117,9 @@ def test_risk_deletion(base_config, base_plugins, mocker):
     incidence = rf_simulation.get_value('infected.incidence_rate')
     joint_paf = rf_simulation.get_value('infected.incidence_rate.paf')
 
-    assert np.allclose(incidence(rf_simulation.population.population.index),
+    assert np.allclose(incidence(rf_simulation.population._population.index),
                        from_yearly(base_rate * (1 - risk_paf), time_step))
-    assert np.allclose(joint_paf(rf_simulation.population.population.index), risk_paf)
+    assert np.allclose(joint_paf(rf_simulation.population._population.index), risk_paf)
 
 
 def test_continuous_exposure_effect(mocker, base_config, base_plugins, continuous_risk):
@@ -147,8 +147,8 @@ def test_continuous_exposure_effect(mocker, base_config, base_plugins, continuou
 
     simulation.setup()
 
-    rates = pd.Series(0.01, index=simulation.population.population.index)
-    rr = pd.Series(1.01, index=simulation.population.population.index)
+    rates = pd.Series(0.01, index=simulation.population._population.index)
+    rr = pd.Series(1.01, index=simulation.population._population.index)
 
     assert np.all(exposure_function(rates, rr) == 0.01)
 
@@ -183,16 +183,16 @@ def test_categorical_exposure_effect(base_config, base_plugins, mocker):
     simulation.data.write("risk_factor.test_risk.distribution", "dichotomous")
     simulation.setup()
 
-    rates = pd.Series(0.01, index=simulation.population.population.index)
-    rr = pd.DataFrame({'cat1': 1.01, 'cat2': 1}, index=simulation.population.population.index)
+    rates = pd.Series(0.01, index=simulation.population._population.index)
+    rr = pd.DataFrame({'cat1': 1.01, 'cat2': 1}, index=simulation.population._population.index)
 
     assert np.all(exposure_function(rates, rr) == 0.01)
 
     test_risk_exposure.side_effect = lambda index: pd.Series(['cat1'] * len(index), index=index)
     simulation.step()
 
-    rates = pd.Series(0.01, index=simulation.population.population.index)
-    rr = pd.DataFrame({'cat1': 1.01, 'cat2': 1}, index=simulation.population.population.index)
+    rates = pd.Series(0.01, index=simulation.population._population.index)
+    rr = pd.DataFrame({'cat1': 1.01, 'cat2': 1}, index=simulation.population._population.index)
 
     assert np.allclose(exposure_function(rates, rr), 0.0101)
 
@@ -218,8 +218,8 @@ def test_CategoricalRiskComponent_dichotomous_case(base_config, base_plugins, di
                                                                              ('year', 'year_start', 'year_end')],
                                                           value_columns=None)
 
-    categories = simulation.values.get_value('test_risk.exposure')(simulation.population.population.index)
-    assert np.isclose(categories.value_counts()['cat1'] / len(simulation.population.population), 0.5, rtol=0.01)
+    categories = simulation.values.get_value('test_risk.exposure')(simulation.population._population.index)
+    assert np.isclose(categories.value_counts()['cat1'] / len(simulation.population._population), 0.5, rtol=0.01)
 
     expected_exposed_value = 0.01 * 1.01
     expected_unexposed_value = 0.01
@@ -254,10 +254,10 @@ def test_CategoricalRiskComponent_polytomous_case(base_config, base_plugins, pol
                                                                              ('year', 'year_start', 'year_end')],
                                                           value_columns=None)
 
-    categories = simulation.values.get_value('test_risk.exposure')(simulation.population.population.index)
+    categories = simulation.values.get_value('test_risk.exposure')(simulation.population._population.index)
 
     for category in ['cat1', 'cat2', 'cat3', 'cat4']:
-        assert np.isclose(categories.value_counts()[category] / len(simulation.population.population), 0.25, rtol=0.02)
+        assert np.isclose(categories.value_counts()[category] / len(simulation.population._population), 0.25, rtol=0.02)
 
     expected_exposed_value = 0.01 * np.array([1.02, 1.03, 1.01])
 
@@ -291,11 +291,11 @@ def test_ContinuousRiskComponent(continuous_risk, base_config, base_plugins):
 
     exposure = simulation.values.get_value('test_risk.exposure')
 
-    assert np.allclose(exposure(simulation.population.population.index), 130, rtol=0.001)
+    assert np.allclose(exposure(simulation.population._population.index), 130, rtol=0.001)
 
     expected_value = 0.01 * (1.01**((130 - 112) / 10))
 
-    assert np.allclose(incidence_rate(simulation.population.population.index),
+    assert np.allclose(incidence_rate(simulation.population._population.index),
                        from_yearly(expected_value, time_step), rtol=0.001)
 
 
@@ -317,7 +317,7 @@ def test_exposure_params_risk_effect_dichotomous(base_config, base_plugins, dich
 
     simulation.setup()
 
-    pop = simulation.population.population
+    pop = simulation.population._population
     exposure = simulation.values.get_value('test_risk.exposure')
     assert np.isclose(rf_exposed, exposure(pop.index).value_counts()['cat1']/len(pop), rtol=0.01)
 
@@ -336,7 +336,7 @@ def test_exposure_params_risk_effect_dichotomous(base_config, base_plugins, dich
 
     simulation.setup()
 
-    pop = simulation.population.population
+    pop = simulation.population._population
     rf_exposure = simulation.values.get_value('test_risk.exposure')(pop.index)
 
     # proportion of simulants exposed to each category of affected risk stays same
@@ -370,7 +370,7 @@ def test_RiskEffect_config_data(base_config, base_plugins):
     simulation.setup()
 
     # make sure our dummy exposure value is being properly used
-    exp = simulation.values.get_value('test_risk.exposure')(simulation.population.population.index)
+    exp = simulation.values.get_value('test_risk.exposure')(simulation.population._population.index)
     assert((exp == 'cat1').all())
 
     # This one should be affected by our DummyRiskEffect
@@ -389,5 +389,5 @@ def test_RiskEffect_config_data(base_config, base_plugins):
                                                                           ('year', 'year_start', 'year_end')],
                                                        value_columns=None)
 
-    assert np.allclose(rates(simulation.population.population.index), from_yearly(0.01, time_step)*50)
-    assert np.allclose(other_rates(simulation.population.population.index), from_yearly(0.01, time_step))
+    assert np.allclose(rates(simulation.population._population.index), from_yearly(0.01, time_step)*50)
+    assert np.allclose(other_rates(simulation.population._population.index), from_yearly(0.01, time_step))

--- a/tests/treatment/test_healthcare_access_module.py
+++ b/tests/treatment/test_healthcare_access_module.py
@@ -82,7 +82,7 @@ def test_adherence(base_config, get_annual_visits_mock):
 
     simulation.take_steps(number_of_steps=2)
 
-    df = simulation.population._population
+    df = simulation.get_population()
     df['fu_visit'] = df.healthcare_visits > 1
     t = df.groupby('adherence_category').fu_visit.count()
     assert t['non-adherent'] == 0, 'non-adherents should not show for follow-up visit'

--- a/tests/treatment/test_healthcare_access_module.py
+++ b/tests/treatment/test_healthcare_access_module.py
@@ -82,7 +82,7 @@ def test_adherence(base_config, get_annual_visits_mock):
 
     simulation.take_steps(number_of_steps=2)
 
-    df = simulation.population.population
+    df = simulation.population._population
     df['fu_visit'] = df.healthcare_visits > 1
     t = df.groupby('adherence_category').fu_visit.count()
     assert t['non-adherent'] == 0, 'non-adherents should not show for follow-up visit'

--- a/tests/validation_tests/rates.py
+++ b/tests/validation_tests/rates.py
@@ -39,7 +39,7 @@ def test_incidence_rate_recalculation(base_config):
 
     for step in range(360):
         sim.step()
-        cases = sim.population_.population.query('simple_disease == "sick"')
+        cases = sim.population.get_population().query('simple_disease == "sick"')
         new_cases.append(len(cases.index.difference(known_cases)))
         known_cases = cases.index
         susceptible.append((sim.get_population().simple_disease == 'healthy').sum())

--- a/tests/validation_tests/rates.py
+++ b/tests/validation_tests/rates.py
@@ -33,16 +33,16 @@ def test_incidence_rate_recalculation(base_config):
     recovery_rate = 72  # Average duration of 5 days
     sim = setup_simulation([TestPopulation(), make_model(base_config, incidence_rate, recovery_rate)], config)
 
-    susceptible = [(sim.population.population.simple_disease == 'healthy').sum()]
+    susceptible = [(sim.population._population.simple_disease == 'healthy').sum()]
     new_cases = []
     known_cases = pd.Index([])
 
     for step in range(360):
         sim.step()
-        cases = sim.population.population.query('simple_disease == "sick"')
+        cases = sim.population_.population.query('simple_disease == "sick"')
         new_cases.append(len(cases.index.difference(known_cases)))
         known_cases = cases.index
-        susceptible.append((sim.population.population.simple_disease == 'healthy').sum())
+        susceptible.append((sim.population._population.simple_disease == 'healthy').sum())
 
     susceptible = susceptible[:-1]
     incidence_rates = np.array(new_cases)/np.array(susceptible)
@@ -50,6 +50,6 @@ def test_incidence_rate_recalculation(base_config):
     assert np.isclose(np.mean(incidence_rates), from_yearly(0.01, pd.Timedelta(days=1)), rtol=0.05)
 
     expected_prevalence = incidence_rate * (1/recovery_rate)
-    actual_prevalence = (sim.population.population.simple_disease == 'sick').sum() / len(sim.population.population)
+    actual_prevalence = (sim.population._population.simple_disease == 'sick').sum() / len(sim.population._population)
 
     assert np.isclose(expected_prevalence, actual_prevalence)

--- a/tests/validation_tests/rates.py
+++ b/tests/validation_tests/rates.py
@@ -33,7 +33,7 @@ def test_incidence_rate_recalculation(base_config):
     recovery_rate = 72  # Average duration of 5 days
     sim = setup_simulation([TestPopulation(), make_model(base_config, incidence_rate, recovery_rate)], config)
 
-    susceptible = [(sim.population._population.simple_disease == 'healthy').sum()]
+    susceptible = [(sim.get_population().simple_disease == 'healthy').sum()]
     new_cases = []
     known_cases = pd.Index([])
 
@@ -42,7 +42,7 @@ def test_incidence_rate_recalculation(base_config):
         cases = sim.population_.population.query('simple_disease == "sick"')
         new_cases.append(len(cases.index.difference(known_cases)))
         known_cases = cases.index
-        susceptible.append((sim.population._population.simple_disease == 'healthy').sum())
+        susceptible.append((sim.get_population().simple_disease == 'healthy').sum())
 
     susceptible = susceptible[:-1]
     incidence_rates = np.array(new_cases)/np.array(susceptible)
@@ -50,6 +50,6 @@ def test_incidence_rate_recalculation(base_config):
     assert np.isclose(np.mean(incidence_rates), from_yearly(0.01, pd.Timedelta(days=1)), rtol=0.05)
 
     expected_prevalence = incidence_rate * (1/recovery_rate)
-    actual_prevalence = (sim.population._population.simple_disease == 'sick').sum() / len(sim.population._population)
+    actual_prevalence = (sim.get_population().simple_disease == 'sick').sum() / len(sim.get_population())
 
     assert np.isclose(expected_prevalence, actual_prevalence)


### PR DESCRIPTION
Actual changes are in distributions.py and transition.py to use the scalar table instead of the pd.Series. Other changes are all replacing the sim.population.population to sim.get_population()