### PR TITLE
Feature/excess mortality effects

### DIFF
--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 
 from vivarium.framework.state_machine import State, Transient
+from vivarium.framework.values import list_combiner, joint_value_post_processor
 
 from vivarium_public_health.disease import RateTransition, ProportionTransition
 
@@ -340,11 +341,19 @@ class ExcessMortalityState(DiseaseState):
         super().setup(builder)
         get_excess_mortality_func = self._get_data_functions.get('excess_mortality', lambda cause, builder: builder.data.load(f"{self.cause_type}.{cause}.excess_mortality"))
 
-        self.excess_mortality_data = get_excess_mortality_func(self.cause, builder)
-        excess_mortality_source = builder.lookup.build_table(self.excess_mortality_data)
+        self.base_excess_mortality = builder.lookup.build_table(get_excess_mortality_func(self.cause, builder))
         self._mortality = builder.value.register_rate_producer(f'{self.state_id}.excess_mortality',
-                                                               source=excess_mortality_source)
+                                                               source=self.effective_excess_mortality)
+        self.joint_paf = builder.value.register_value_producer(f'{self.state_id}.excess_mortality.paf',
+                                                               source=lambda idx: [builder.lookup.build_table(0)(idx)],
+                                                               preferred_combiner=list_combiner,
+                                                               preferred_post_processor=joint_value_post_processor)
         builder.value.register_value_modifier('mortality_rate', modifier=self.mortality_rates)
+
+    def effective_excess_mortality(self, index):
+        base_excess_mort = self.base_excess_mortality(index)
+        joint_mediated_paf = self.joint_paf(index)
+        return pd.Series(base_excess_mort.values * (1 - joint_mediated_paf.values), index=index)
 
     def mortality_rates(self, index, rates_df):
         """Modifies the baseline mortality rate for a simulant if they are in this state.

--- a/src/vivarium_public_health/disease/transition.py
+++ b/src/vivarium_public_health/disease/transition.py
@@ -14,7 +14,7 @@ class RateTransition(Transition):
         rate_data, pipeline_name = self._get_rate_data(builder)
         self.base_rate = builder.lookup.build_table(rate_data)
         self.effective_rate = builder.value.register_rate_producer(pipeline_name, source=self.rates)
-        self.joint_paf = builder.value.register_value_producer(f'{self.output_state.state_id}.incidence_rate.paf',
+        self.joint_paf = builder.value.register_value_producer(f'{pipeline_name}.paf',
                                                                source=lambda index: [pd.Series(0, index=index)],
                                                                preferred_combiner=list_combiner,
                                                                preferred_post_processor=joint_value_post_processor)

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -23,6 +23,7 @@ class RiskEffect:
         'effect_of_risk_on_entity': {
             'incidence_rate': 'data',
             'exposure_parameters': 'data',
+            'excess_mortality': 'data',
         }
     }
 
@@ -88,11 +89,13 @@ class RiskEffect:
             else:
                 distribution = builder.data.load(f'{self.risk_type}.{self.risk}.distribution')
                 if distribution in ['normal', 'lognormal', 'ensemble']:
-                    paf_data = builder.data.load(f'{self.risk_type}.{self.risk}.population_attributable_fraction')
+                    paf_data = builder.data.load(f'{self.risk_type}.{self.risk}.population_attributable_fraction',
+                                                 mortality=(self.target == 'excess_mortality'))
 
                 else:
                     exposure = builder.data.load(f'{self.risk_type}.{self.risk}.exposure')
-                    rr = builder.data.load(f'{self.risk_type}.{self.risk}.relative_risk')
+                    rr = builder.data.load(f'{self.risk_type}.{self.risk}.relative_risk',
+                                           mortality=(self.target == 'excess_mortality'))
                     rr = rr[rr[filter_name] == filter_term]
                     paf_data = get_paf_data(exposure, rr)
 
@@ -110,7 +113,8 @@ class RiskEffect:
             if 'rr' in self._get_data_functions:
                 rr_data = self._get_data_functions['rr'](builder)
             else:
-                rr_data = builder.data.load(f"{self.risk_type}.{self.risk}.relative_risk")
+                rr_data = builder.data.load(f"{self.risk_type}.{self.risk}.relative_risk",
+                                            mortality=(self.target == 'excess_mortality'))
 
             row_filter = rr_data[f'{self.affected_entity_type}'] == self.affected_entity
             column_filter = ['parameter', 'sex', 'value', 'age_group_start', 'age_group_end', 'year_start', 'year_end']

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -83,20 +83,21 @@ class RiskEffect:
             paf_data = get_paf_data(exposure, rr)
         else:
             filter_name, filter_term = self.affected_entity_type, self.affected_entity
+            type_filter_col = 'mortality' if self.affected_measure == 'excess_mortality' else 'morbidity'
             if 'paf' in self._get_data_functions:
                 paf_data = self._get_data_functions['paf'](builder)
 
             else:
                 distribution = builder.data.load(f'{self.risk_type}.{self.risk}.distribution')
                 if distribution in ['normal', 'lognormal', 'ensemble']:
-                    paf_data = builder.data.load(f'{self.risk_type}.{self.risk}.population_attributable_fraction',
-                                                 mortality=(self.target == 'excess_mortality'))
+                    paf_data = builder.data.load(f'{self.risk_type}.{self.risk}.population_attributable_fraction')
+                    paf_data = paf_data[paf_data[type_filter_col] == 1].drop(type_filter_col, 'columns')
 
                 else:
                     exposure = builder.data.load(f'{self.risk_type}.{self.risk}.exposure')
-                    rr = builder.data.load(f'{self.risk_type}.{self.risk}.relative_risk',
-                                           mortality=(self.target == 'excess_mortality'))
+                    rr = builder.data.load(f'{self.risk_type}.{self.risk}.relative_risk')
                     rr = rr[rr[filter_name] == filter_term]
+                    rr = rr[rr[type_filter_col] == 1].drop(type_filter_col, 'columns')
                     paf_data = get_paf_data(exposure, rr)
 
             paf_data = paf_data[paf_data[filter_name] == filter_term]
@@ -113,8 +114,9 @@ class RiskEffect:
             if 'rr' in self._get_data_functions:
                 rr_data = self._get_data_functions['rr'](builder)
             else:
-                rr_data = builder.data.load(f"{self.risk_type}.{self.risk}.relative_risk",
-                                            mortality=(self.target == 'excess_mortality'))
+                rr_data = builder.data.load(f"{self.risk_type}.{self.risk}.relative_risk")
+                type_filter_col = 'mortality' if self.affected_measure == 'excess_mortality' else 'morbidity'
+                rr_data = rr_data[rr_data[type_filter_col] == 1].drop(type_filter_col, 'columns')
 
             row_filter = rr_data[f'{self.affected_entity_type}'] == self.affected_entity
             column_filter = ['parameter', 'sex', 'value', 'age_group_start', 'age_group_end', 'year_start', 'year_end']

--- a/tests/risks/conftest.py
+++ b/tests/risks/conftest.py
@@ -41,6 +41,10 @@ def continuous_risk():
         paf_data.append(build_table([1, cause], year_start, year_end, ['age', 'sex', 'year', 'value', 'cause']))
     rr_data = pd.concat(rr_data)
     paf_data = pd.concat(paf_data)
+    paf_data['morbidity'] = 1
+    paf_data['mortality'] = 1
+    rr_data['morbidity'] = 1
+    rr_data['mortality'] = 1
     risk_data['exposure'] = exposure_mean
     risk_data['exposure_standard_deviation'] = exposure_sd
     risk_data['relative_risk'] = rr_data
@@ -93,6 +97,10 @@ def dichotomous_risk():
         paf_data.append(build_table([1, cause], year_start, year_end, ['age', 'sex', 'year', 'value', 'cause']))
     rr_data = pd.concat(rr_data)
     paf_data = pd.concat(paf_data)
+    paf_data['morbidity'] = 1
+    paf_data['mortality'] = 1
+    rr_data['morbidity'] = 1
+    rr_data['mortality'] = 1
     risk_data['exposure'] = exposure_data
     risk_data['relative_risk'] = rr_data
     risk_data['population_attributable_fraction'] = paf_data
@@ -128,6 +136,10 @@ def polytomous_risk():
         paf_data.append(build_table([1, cause], year_start, year_end, ['age', 'sex', 'year', 'value', 'cause']))
     rr_data = pd.concat(rr_data)
     paf_data = pd.concat(paf_data)
+    paf_data['morbidity'] = 1
+    paf_data['mortality'] = 1
+    rr_data['morbidity'] = 1
+    rr_data['mortality'] = 1
     risk_data['exposure'] = exposure_data
     risk_data['relative_risk'] = rr_data
     risk_data['population_attributable_fraction'] = paf_data
@@ -168,7 +180,10 @@ def coverage_gap():
                     'year_end', 'sex'), var_name='population_attributable_fraction', value_name='value')
 
     paf_data['risk_factor'] = 'test_risk'
-
+    paf_data['morbidity'] = 1
+    paf_data['mortality'] = 1
+    rr_data['morbidity'] = 1
+    rr_data['mortality'] = 1
     cg_data['exposure'] = cg_exposure_data
     rr_data['risk_factor'] = 'test_risk'
     cg_data['relative_risk'] = rr_data

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -282,12 +282,8 @@ def test_ContinuousRiskComponent(continuous_risk, base_config, base_plugins):
     simulation.setup()
     affected_causes = risk_data['affected_causes']
 
-    incidence_rate = simulation.values.register_rate_producer(affected_causes[0]+'.incidence_rate')
-    incidence_rate.source = simulation.tables.build_table(build_table(0.01, year_start, year_end),
-                                                          key_columns=('sex',),
-                                                          parameter_columns=[('age', 'age_group_start', 'age_group_end'),
-                                                                             ('year', 'year_start', 'year_end')],
-                                                          value_columns=None)
+    incidence_rate = simulation.values.register_rate_producer(affected_causes[0]+'.incidence_rate',
+                                                              source=lambda index: pd.Series(0.01, index=index))
 
     exposure = simulation.values.get_value('test_risk.exposure')
 
@@ -374,20 +370,31 @@ def test_RiskEffect_config_data(base_config, base_plugins):
     assert((exp == 'cat1').all())
 
     # This one should be affected by our DummyRiskEffect
-    rates = simulation.values.register_rate_producer('test_cause.incidence_rate')
-    rates.source = simulation.tables.build_table(build_table(0.01, year_start, year_end),
-                                                 key_columns=('sex',),
-                                                 parameter_columns=[('age', 'age_group_start', 'age_group_end'),
-                                                                    ('year', 'year_start', 'year_end')],
-                                                 value_columns=None)
+    rates = simulation.values.register_rate_producer('test_cause.incidence_rate',
+                                                     source=lambda index: pd.Series(0.01, index=index))
 
     # This one should not
-    other_rates = simulation.values.register_rate_producer('some_other_cause.incidence_rate')
-    other_rates.source = simulation.tables.build_table(build_table(0.01, year_start, year_end),
-                                                       key_columns=('sex',),
-                                                       parameter_columns=[('age', 'age_group_start', 'age_group_end'),
-                                                                          ('year', 'year_start', 'year_end')],
-                                                       value_columns=None)
+    other_rates = simulation.values.register_rate_producer('some_other_cause.incidence_rate',
+                                                           source=lambda index: pd.Series(0.01, index=index))
 
     assert np.allclose(rates(simulation.population.population.index), from_yearly(0.01, time_step)*50)
     assert np.allclose(other_rates(simulation.population.population.index), from_yearly(0.01, time_step))
+
+
+def test_RiskEffect_excess_mortality(base_config, base_plugins):
+    dummy_risk = Risk("risk_factor.test_risk")
+    dummy_effect = RiskEffect("risk_factor.test_risk", "cause.test_cause.excess_mortality")
+    time_step = pd.Timedelta(days=base_config.time.step_size)
+
+    base_config.update({'test_risk': {'exposure': 1}}, layer='override')
+    base_config.update({'effect_of_test_risk_on_test_cause': {'excess_mortality': 50}})
+
+    simulation = initialize_simulation([TestPopulation(), dummy_risk, dummy_effect],
+                                       input_config=base_config, plugin_config=base_plugins)
+    simulation.setup()
+
+    em = simulation.values.register_rate_producer('test_cause.excess_mortality',
+                                                  source=lambda index: pd.Series(0.1, index=index))
+
+    assert np.allclose(from_yearly(0.1, time_step)*50, em(simulation.population.population.index))
+


### PR DESCRIPTION
adding ability to have risk effects target excess mortality - adding excess mortality paf pipeline for this. Also changed pulling pafs + rr in vivarium_inputs to return both mortality and morbidity data so changes to filter to desired one wherever used

