### PR TITLE
Feature/aggregate multil loc artifacts

### DIFF
--- a/src/vivarium_public_health/dataset_manager/__init__.py
+++ b/src/vivarium_public_health/dataset_manager/__init__.py
@@ -1,4 +1,4 @@
 """This subpackage contains the data artifact and a vivarium plugin to manage it."""
-from .artifact import Artifact, EntityKey, ArtifactException, create_hdf_with_keyspace
+from .artifact import Artifact, EntityKey, ArtifactException
 from .dataset_manager import (ArtifactManager, ArtifactManagerInterface, parse_artifact_path_config,
                               filter_data, get_location_term, validate_filter_term)

--- a/src/vivarium_public_health/dataset_manager/__init__.py
+++ b/src/vivarium_public_health/dataset_manager/__init__.py
@@ -1,4 +1,4 @@
 """This subpackage contains the data artifact and a vivarium plugin to manage it."""
-from .artifact import Artifact, EntityKey, ArtifactException
+from .artifact import Artifact, EntityKey, ArtifactException, create_hdf_with_keyspace
 from .dataset_manager import (ArtifactManager, ArtifactManagerInterface, parse_artifact_path_config,
                               filter_data, get_location_term, validate_filter_term)

--- a/src/vivarium_public_health/dataset_manager/artifact.py
+++ b/src/vivarium_public_health/dataset_manager/artifact.py
@@ -101,7 +101,6 @@ class Artifact:
             pass
         else:
             self._keys.append(entity_key)
-
             new_keyspace = self._keys.copy()
             hdf.remove(self.path, EntityKey('metadata.keyspace'))
             hdf.write(self.path, EntityKey('metadata.keyspace'), new_keyspace)
@@ -128,6 +127,7 @@ class Artifact:
         if entity_key in self._cache:
             self._cache.pop(entity_key)
         new_keyspace = self._keys.copy()
+        hdf.remove(self.path, entity_key)
         hdf.remove(self.path, EntityKey('metadata.keyspace'))
         hdf.write(self.path, EntityKey('metadata.keyspace'), new_keyspace)
 

--- a/src/vivarium_public_health/dataset_manager/artifact.py
+++ b/src/vivarium_public_health/dataset_manager/artifact.py
@@ -31,7 +31,7 @@ class Artifact:
             A set of terms suitable for usage with the ``where`` kwarg for ``pd.read_hdf``
         """
 
-        Artifact.create_hdf_with_keyspace(path)
+        self.create_hdf_with_keyspace(path)
         self.path = path
         self._filter_terms = filter_terms
         self._cache = {}

--- a/src/vivarium_public_health/dataset_manager/artifact.py
+++ b/src/vivarium_public_health/dataset_manager/artifact.py
@@ -270,24 +270,36 @@ def _to_tree(keys: List[EntityKey]) -> Dict[str, Dict[str, List[str]]]:
 
 
 class Keys:
+    """A convenient wrapper around the keyspace which makes easier for Artifact
+     to maintain its keyspace when EntityKey is added or removed.
+     With the artifact_path, Keys object is initialized when the Artifact is
+     initialized """
 
     keyspace_node = EntityKey('metadata.keyspace')
 
-    def __init__(self, artifact_path):
+    def __init__(self, artifact_path: str):
         self.artifact_path = artifact_path
         self._keys = [str(k) for k in hdf.load(self.artifact_path, EntityKey('metadata.keyspace'), None)]
 
-    def append(self, new_key):
+    def append(self, new_key: EntityKey):
+        """ Whenever the artifact gets a new key and new data, append is called to
+        remove the old keyspace and to write the updated keyspace"""
+
         self._keys.append(str(new_key))
         hdf.remove(self.artifact_path, self.keyspace_node)
         hdf.write(self.artifact_path, self.keyspace_node, self._keys)
 
-    def remove(self, removing_key):
+    def remove(self, removing_key: EntityKey):
+        """ Whenever the artifact removes a key and data, remove is called to
+        remove the key from keyspace and write the updated keyspace."""
+
         self._keys.remove(str(removing_key))
         hdf.remove(self.artifact_path, self.keyspace_node)
         hdf.write(self.artifact_path, self.keyspace_node, self._keys)
 
-    def to_list(self):
+    def to_list(self) -> List[EntityKey]:
+        """A list of all the EntityKeys in the associated artifact."""
+
         return [EntityKey(k) for k in self._keys]
 
     def __contains__(self, item):

--- a/src/vivarium_public_health/dataset_manager/artifact.py
+++ b/src/vivarium_public_health/dataset_manager/artifact.py
@@ -7,19 +7,17 @@ convenient access and inspection.
 from collections import defaultdict
 import logging
 from typing import List, Dict, Any
+from pathlib import Path
 
 from vivarium_public_health.dataset_manager import hdf
 
 _log = logging.getLogger(__name__)
 
 
-def create_hdf_with_keyspace(path, append):
-    hdf.touch(path, append)
-    if not append:
+def create_hdf_with_keyspace(path):
+    if not Path(path).is_file():
+        hdf.touch(path)
         hdf.write(path, EntityKey('metadata.keyspace'), ['metadata.keyspace'])
-    else:
-        message = 'To append, you need to provide the existing artifact with the metadata. Try again without append tag'
-        assert 'metadata.keyspace' in hdf.get_keys(path), message
 
 
 class ArtifactException(Exception):
@@ -29,7 +27,7 @@ class ArtifactException(Exception):
 
 class Artifact:
     """An interface for interacting with ``vivarium`` hdf artifacts."""
-    def __init__(self, path: str, append=False, filter_terms: List[str]=None):
+    def __init__(self, path: str, filter_terms: List[str]=None):
         """
         Parameters
         ----------
@@ -39,7 +37,7 @@ class Artifact:
             A set of terms suitable for usage with the ``where`` kwarg for ``pd.read_hdf``
         """
 
-        create_hdf_with_keyspace(path, append)
+        create_hdf_with_keyspace(path)
         self.path = path
         self._filter_terms = filter_terms
         self._cache = {}

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -12,7 +12,6 @@ from tables.nodes import filenode
 if typing.TYPE_CHECKING:
     from vivarium_public_health.dataset_manager import EntityKey
 
-
 DEFAULT_COLUMNS = {"location", "draw"}
 
 

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -12,6 +12,7 @@ from tables.nodes import filenode
 if typing.TYPE_CHECKING:
     from vivarium_public_health.dataset_manager import EntityKey
 
+
 DEFAULT_COLUMNS = {"location", "draw"}
 
 

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -15,35 +15,24 @@ if typing.TYPE_CHECKING:
 DEFAULT_COLUMNS = {"location", "draw"}
 
 
-def touch(path: str, append: bool):
+def touch(path: str):
     """Creates an hdf file or wipes an existing file if necessary.
 
-    If the file exists and append is not true, the existing file
-    will be destroyed. If the file exists and append is true, touch
-    will do nothing.
+    If the hdf
 
     Parameters
     ----------
     path :
         The string path to the hdf file.
-    append :
-        Whether an existing artifact should be preserved and appended to
 
-    Raises
-    ------
-    FileNotFoundError
-        If attempting to append to a non-existent file."""
+    """
 
     path = Path(path)
+    if not path.suffix == '.hdf':
+        raise ValueError(f'You provided path: {str(path)} not valid for creating hdf file.')
 
-    if not path.is_file() and append:
-        raise FileNotFoundError("You indicated you want to append to "
-                                f"an existing artifact at {path} but no "
-                                "such artifact exists. remove --append if "
-                                "you wish to create a new artifact.")
-    elif not append:
-        with tables.open_file(str(path), mode='w'):
-            pass
+    with tables.open_file(str(path), mode='w'):
+        pass
 
 
 def write(path: str, entity_key: 'EntityKey', data: Any):

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -27,7 +27,7 @@ def touch(path: str):
 
     Raises
     ------
-    FileNotFoundError
+    ValueError
         If the non-proper path is given to create a hdf file."""
 
     path = Path(path)

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -18,14 +18,17 @@ DEFAULT_COLUMNS = {"location", "draw"}
 def touch(path: str):
     """Creates an hdf file or wipes an existing file if necessary.
 
-    If the hdf
+    If the given path is proper to create a hdf file, it creates a new hdf file.
 
     Parameters
     ----------
     path :
         The string path to the hdf file.
 
-    """
+    Raises
+    ------
+    FileNotFoundError
+        If the non-proper path is given to create a hdf file."""
 
     path = Path(path)
     if not path.suffix == '.hdf':

--- a/tests/dataset_manager/test_hdf.py
+++ b/tests/dataset_manager/test_hdf.py
@@ -77,31 +77,29 @@ def test_touch_no_file(mocker):
     path = Path('not/an/existing/path.hdf')
     tables_mock = mocker.patch("vivarium_public_health.dataset_manager.hdf.tables")
 
-    hdf.touch(path, False)
+    hdf.touch(path)
     tables_mock.open_file.assert_called_once_with(str(path), mode='w')
     tables_mock.reset_mock()
-
-    with pytest.raises(FileNotFoundError):
-        hdf.touch(path, True)
 
 
 def test_touch_exists_but_not_file(hdf_file_path):
     path = Path(hdf_file_path).parent
-
-    with pytest.raises(FileNotFoundError):
-        hdf.touch(path, True)
+    with pytest.raises(ValueError):
+        hdf.touch(path)
 
 
 def test_touch_existing_file(hdf_file_path, mocker):
     path = Path(hdf_file_path)
     tables_mock = mocker.patch("vivarium_public_health.dataset_manager.hdf.tables")
 
-    hdf.touch(path, False)
+    hdf.touch(path)
     tables_mock.open_file.assert_called_once_with(str(path), mode='w')
     tables_mock.reset_mock()
 
-    hdf.touch(path, True)
-    tables_mock.open_file.assert_not_called()
+    # should wipe out and make it again
+    hdf.touch(path)
+    tables_mock.open_file.assert_called_once_with(str(path), mode='w')
+    tables_mock.reset_mock()
 
 
 def test_write_df(hdf_file_path, mock_key, mocker):

--- a/tests/dataset_manager/test_hdf.py
+++ b/tests/dataset_manager/test_hdf.py
@@ -82,24 +82,25 @@ def test_touch_no_file(mocker):
     tables_mock.reset_mock()
 
 
-def test_touch_exists_but_not_file(hdf_file_path):
-    path = Path(hdf_file_path).parent
+def test_touch_exists_but_not_hdf_file_path(hdf_file_path):
+    dir_path = Path(hdf_file_path).parent
     with pytest.raises(ValueError):
-        hdf.touch(path)
+        hdf.touch(dir_path)
+    non_hdf_path = Path(hdf_file_path).parent / 'test.txt'
+    with pytest.raises(ValueError):
+        hdf.touch(non_hdf_path)
 
 
-def test_touch_existing_file(hdf_file_path, mocker):
-    path = Path(hdf_file_path)
-    tables_mock = mocker.patch("vivarium_public_health.dataset_manager.hdf.tables")
+def test_touch_existing_file(tmpdir):
+    path = f'{str(tmpdir)}/test.hdf'
 
     hdf.touch(path)
-    tables_mock.open_file.assert_called_once_with(str(path), mode='w')
-    tables_mock.reset_mock()
+    hdf.write(path, EntityKey('test.key'), 'data')
+    assert hdf.get_keys(path) == ['test.key']
 
     # should wipe out and make it again
     hdf.touch(path)
-    tables_mock.open_file.assert_called_once_with(str(path), mode='w')
-    tables_mock.reset_mock()
+    assert hdf.get_keys(path) == []
 
 
 def test_write_df(hdf_file_path, mock_key, mocker):


### PR DESCRIPTION
To support the artifact aggregation, metadata is added to the artifact. Instead of traversing the hdf file to get keys, now it will just read from the `medata.keyspace`.