### PR TITLE
no val column

### DIFF
--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -54,4 +54,4 @@ class RiskEffect:
                                               modifier=self.population_attributable_fraction)
 
     def adjust_target(self, index, target):
-        return self.exposure_effect(target, self.relative_risk(index).value)
+        return self.exposure_effect(target, self.relative_risk(index))


### PR DESCRIPTION
this was breaking things for eggs because we pivot categorical risk data so there's no longer a value column. I tested by running sanofi to make sure that this won't break things for cont risks