### PR TITLE
Feature/mort by sex

### DIFF
--- a/src/vivarium_public_health/metrics/utilities.py
+++ b/src/vivarium_public_health/metrics/utilities.py
@@ -6,3 +6,6 @@ def get_age_bins(builder):
         age_bins = age_bins[age_bins.age_group_start < exit_age]
         age_bins.loc[age_bins.age_group_end > exit_age, 'age_group_end'] = exit_age
     return age_bins
+
+def get_sexes():
+    return ['Male', 'Female']

--- a/src/vivarium_public_health/metrics/utilities.py
+++ b/src/vivarium_public_health/metrics/utilities.py
@@ -7,5 +7,6 @@ def get_age_bins(builder):
         age_bins.loc[age_bins.age_group_end > exit_age, 'age_group_end'] = exit_age
     return age_bins
 
+
 def get_sexes():
     return ['Male', 'Female']


### PR DESCRIPTION
I did this the fast way, not the way I'd like. This splits by sex by default. I would like for this observer (and my  BMI ones) to have switches for year, age and sex that you can turn on and off but that will take a bit of work because of the way the work is split across functions here. I just need by sex to work for now. Also, perhaps the observer should only report back age groups that cover ages in the sim (meaning excluding younger ages if the start age is, say 20).

I split get_sexes into a utility function as well. I don't anticpate sexes changing but I wanted them somewhere where we could change them if needed, or pull them from inputs or wherever