### PR TITLE
constrain propensity to valid range

### DIFF
--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -29,9 +29,9 @@ class EnsembleSimulation:
     def ppf(self, q):
         if not q.empty:
             # We limit valid propensity to [0.001 0.999]. Beyond that bound values return NaN and then become zero,
-            # which is nonsensical.
-            q[q > 0.999] = 0.998
-            q[q < 0.001] = 0.0011
+            # which is nonsensical. We avoid the inclusive limit to protect ourselves from a math error.
+            q[q >= 0.999] = 0.998
+            q[q <= 0.001] = 0.0011
             weights = self.weights(q.index)
             parameters = {name: parameter(q.index) for name, parameter in self.parameters.items()}
             x = EnsembleDistribution(weights, parameters).ppf(q)

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -28,6 +28,10 @@ class EnsembleSimulation:
 
     def ppf(self, q):
         if not q.empty:
+            # We limit valid propensity to (0.001 0.999). Beyond that bound values return NaN and then become zero,
+            # which is nonsensical.
+            q[q > 0.999] = 0.998
+            q[q < 0.001] = 0.0011
             weights = self.weights(q.index)
             parameters = {name: parameter(q.index) for name, parameter in self.parameters.items()}
             x = EnsembleDistribution(weights, parameters).ppf(q)

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -28,7 +28,7 @@ class EnsembleSimulation:
 
     def ppf(self, q):
         if not q.empty:
-            # We limit valid propensity to (0.001 0.999). Beyond that bound values return NaN and then become zero,
+            # We limit valid propensity to [0.001 0.999]. Beyond that bound values return NaN and then become zero,
             # which is nonsensical.
             q[q > 0.999] = 0.998
             q[q < 0.001] = 0.0011


### PR DESCRIPTION
This turned up in the obesity sim -- we noticed BMIs of zero. Turns out we sample propensities that fall outside of the range we consider valid for returning values from .ppf(). Those propensities result in returned values of NaN that then get set to zero, which doesn't make sense. 

My only issue is that those constants feel magical.