### PR TITLE
Feature/reset indices

### DIFF
--- a/src/vivarium_public_health/dataset_manager/dataset_manager.py
+++ b/src/vivarium_public_health/dataset_manager/dataset_manager.py
@@ -111,6 +111,7 @@ class ArtifactManager:
             if the data is a dataframe.
         """
         data = self.artifact.load(entity_key)
+        # demog dimensions is a df but not multi-indexed because it has no columns beyond our indexing dimensions
         if isinstance(data, pd.DataFrame) and isinstance(data.index, pd.MultiIndex):
             data = data.reset_index()
         return filter_data(data, self.config_filter_term, **column_filters) if isinstance(data, pd.DataFrame) else data

--- a/src/vivarium_public_health/dataset_manager/dataset_manager.py
+++ b/src/vivarium_public_health/dataset_manager/dataset_manager.py
@@ -111,9 +111,7 @@ class ArtifactManager:
             if the data is a dataframe.
         """
         data = self.artifact.load(entity_key)
-        # demog dimensions and age bins are a df but not multi-indexed because they have no columns beyond our
-        # indexing dimensions
-        if isinstance(data, pd.DataFrame) and isinstance(data.index, pd.MultiIndex):
+        if isinstance(data, pd.DataFrame):  # could be metadata dict
             data = data.reset_index()
         return filter_data(data, self.config_filter_term, **column_filters) if isinstance(data, pd.DataFrame) else data
 

--- a/src/vivarium_public_health/dataset_manager/dataset_manager.py
+++ b/src/vivarium_public_health/dataset_manager/dataset_manager.py
@@ -111,7 +111,8 @@ class ArtifactManager:
             if the data is a dataframe.
         """
         data = self.artifact.load(entity_key)
-        # demog dimensions is a df but not multi-indexed because it has no columns beyond our indexing dimensions
+        # demog dimensions and age bins are a df but not multi-indexed because they have no columns beyond our
+        # indexing dimensions
         if isinstance(data, pd.DataFrame) and isinstance(data.index, pd.MultiIndex):
             data = data.reset_index()
         return filter_data(data, self.config_filter_term, **column_filters) if isinstance(data, pd.DataFrame) else data

--- a/src/vivarium_public_health/dataset_manager/dataset_manager.py
+++ b/src/vivarium_public_health/dataset_manager/dataset_manager.py
@@ -111,6 +111,8 @@ class ArtifactManager:
             if the data is a dataframe.
         """
         data = self.artifact.load(entity_key)
+        if isinstance(data, pd.DataFrame) and isinstance(data.index, pd.MultiIndex):
+            data = data.reset_index()
         return filter_data(data, self.config_filter_term, **column_filters) if isinstance(data, pd.DataFrame) else data
 
 

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -161,7 +161,7 @@ def _write_empty_dataframe(path: str, entity_key: 'EntityKey', data: pd.DataFram
 
     metadata = {'is_empty': True}
     with pd.HDFStore(path, complevel=9) as store:
-        store.put(entity_path, data, format='table', data_colmns=data.columns)
+        store.put(entity_path, data, format='table', data_columns=True)
         store.get_storer(entity_path).attrs.metadata = metadata  # NOTE: must use attrs. write this up
 
 

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -155,6 +155,10 @@ def _write_empty_dataframe(path: str, entity_key: 'EntityKey', data: pd.DataFram
     """Writes an empty pandas DataFrame to the hdf file at the given path, queryable by its index."""
     entity_path = entity_key.path
     data = data.reset_index()
+
+    if data.empty:
+        raise ValueError("Cannot write an empty dataframe that does not have an index.")
+
     metadata = {'is_empty': True}
     with pd.HDFStore(path, complevel=9) as store:
         store.put(entity_path, data, format='table', data_colmns=data.columns)

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -84,9 +84,9 @@ def load(path: str, entity_key: 'EntityKey', filter_terms: Optional[List[str]]) 
         else:
             filter_terms = _get_valid_filter_terms(filter_terms, node.table.colnames)
             data = pd.read_hdf(path, entity_key.path, where=filter_terms)
-            with pd.HDFStore(path, complevel=9) as store:
+            with pd.HDFStore(path, complevel=9, mode='r') as store:
                 metadata = store.get_storer(entity_key.path).metadata
-            if 'is_empty' in metadata and metadata['is_empty']: # undo transform performed on write
+            if 'is_empty' in metadata and metadata['is_empty']:  # undo transform performed on write
                 data = data.set_index(list(data.columns))
 
         return data

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -12,8 +12,6 @@ from tables.nodes import filenode
 if typing.TYPE_CHECKING:
     from vivarium_public_health.dataset_manager import EntityKey
 
-DEFAULT_COLUMNS = {"location", "draw"}
-
 
 def touch(path: str):
     """Creates an hdf file or wipes an existing file if necessary.
@@ -139,13 +137,10 @@ def _write_data_frame(path: str, entity_key: 'EntityKey', data: pd.DataFrame):
     if data.empty:
         raise ValueError("Cannot persist empty dataset")
 
-    # Even though these get called data_columns, it's more correct to think of them
-    # as the columns you can use to index into the raw data with. It's the subset of columns
-    # that you can filter by without reading in a whole dataset.
-    data_columns = DEFAULT_COLUMNS.intersection(data.columns)
-
+    # Our data is indexed (mostly -- demog dimensions isn't).
+    # The indices can be queried by name in table format.
     with pd.HDFStore(path, complevel=9) as store:
-        store.put(entity_path, data, format="table", data_columns=data_columns)
+        store.put(entity_path, data, format="table")
 
 
 def _get_keys(root: tables.node.Node, prefix: str='') -> List[str]:

--- a/src/vivarium_public_health/dataset_manager/hdf.py
+++ b/src/vivarium_public_health/dataset_manager/hdf.py
@@ -85,9 +85,9 @@ def load(path: str, entity_key: 'EntityKey', filter_terms: Optional[List[str]]) 
             filter_terms = _get_valid_filter_terms(filter_terms, node.table.colnames)
             data = pd.read_hdf(path, entity_key.path, where=filter_terms)
             with pd.HDFStore(path, complevel=9, mode='r') as store:
-                metadata = store.get_storer(entity_key.path).metadata
-            if 'is_empty' in metadata and metadata['is_empty']:  # undo transform performed on write
-                data = data.set_index(list(data.columns))
+                metadata = store.get_storer(entity_key.path).attrs.metadata  # NOTE: must use attrs. write this up
+            if 'is_empty' in metadata and metadata['is_empty']:
+                data = data.set_index(list(data.columns))  # undoing transform performed on write
 
         return data
 
@@ -148,7 +148,7 @@ def _write_data_frame(path: str, entity_key: 'EntityKey', data: pd.DataFrame):
         metadata = {'is_empty': False}
         with pd.HDFStore(path, complevel=9) as store:
             store.put(entity_path, data, format="table")
-            store.get_storer(entity_path).metadata = metadata
+            store.get_storer(entity_path).attrs.metadata = metadata  # NOTE: must use attrs. write this up
 
 
 def _write_empty_dataframe(path: str, entity_key: 'EntityKey', data: pd.DataFrame):
@@ -158,7 +158,7 @@ def _write_empty_dataframe(path: str, entity_key: 'EntityKey', data: pd.DataFram
     metadata = {'is_empty': True}
     with pd.HDFStore(path, complevel=9) as store:
         store.put(entity_path, data, format='table', data_colmns=data.columns)
-        store.get_storer(entity_path).metadata = metadata
+        store.get_storer(entity_path).attrs.metadata = metadata  # NOTE: must use attrs. write this up
 
 
 def _get_keys(root: tables.node.Node, prefix: str='') -> List[str]:

--- a/tests/dataset_manager/test_hdf.py
+++ b/tests/dataset_manager/test_hdf.py
@@ -147,6 +147,19 @@ def test_load_with_valid_filters(hdf_file_path, hdf_key):
             assert set(data.year) == {2006}
 
 
+def test_load_filter_empty_data_frame_index(hdf_file_path, hdf_key):
+    key = EntityKey('cause.test.prevalence')
+    data = pd.DataFrame(data={'age': range(10),
+                              'year': range(10),
+                              'draw': range(10)})
+    data = data.set_index(list(data.columns))
+
+    hdf._write_data_frame(hdf_file_path, key, data)
+    loaded_data = hdf.load(hdf_file_path, key, filter_terms=['year == 4'])
+    loaded_data = loaded_data.reset_index()
+    assert loaded_data.year.unique() == 4
+
+
 def test_remove(hdf_file_path, hdf_key):
     key = EntityKey(hdf_key)
     hdf.remove(hdf_file_path, key)

--- a/tests/dataset_manager/test_hdf.py
+++ b/tests/dataset_manager/test_hdf.py
@@ -181,6 +181,9 @@ def test_write_data_frame(hdf_file_path):
     data = build_table([lambda *args, **kwargs: random.choice([0, 1]), "Kenya", 1],
                        2005, 2010, columns=('age', 'year', 'sex', 'draw', 'location', 'value'))
 
+    non_val_columns = data.columns.difference({'value'})
+    data = data.set_index(list(non_val_columns))
+
     hdf._write_data_frame(hdf_file_path, key, data)
 
     written_data = pd.read_hdf(hdf_file_path, key.path)
@@ -188,7 +191,7 @@ def test_write_data_frame(hdf_file_path):
 
     filter_terms = ['draw == 0']
     written_data = pd.read_hdf(hdf_file_path, key.path, where=filter_terms)
-    assert written_data.equals(data[data['draw'] == 0])
+    assert written_data.equals(data.xs(0, level='draw', drop_level=False))
 
 
 def test_get_keys_private(hdf_file, hdf_keys):

--- a/tests/dataset_manager/test_hdf.py
+++ b/tests/dataset_manager/test_hdf.py
@@ -176,7 +176,20 @@ def test_write_empty_data_frame(hdf_file_path):
         hdf._write_data_frame(hdf_file_path, key, data)
 
 
-def test_write_data_frame(hdf_file_path):
+def test_write_empty_data_frame_index(hdf_file_path):
+    key = EntityKey('cause.test.prevalence')
+    data = pd.DataFrame(data={'age': range(10),
+                              'year': range(10),
+                              'draw': range(10)})
+    data = data.set_index(list(data.columns))
+
+    hdf._write_data_frame(hdf_file_path, key, data)
+    written_data = pd.read_hdf(hdf_file_path, key.path)
+    written_data = written_data.set_index(list(written_data))  # write resets index. only calling load undoes it
+    assert written_data.equals(data)
+
+
+def test_write_data_frame(hdf_fhtople_path):
     key = EntityKey('cause.test.prevalence')
     data = build_table([lambda *args, **kwargs: random.choice([0, 1]), "Kenya", 1],
                        2005, 2010, columns=('age', 'year', 'sex', 'draw', 'location', 'value'))

--- a/tests/dataset_manager/test_hdf.py
+++ b/tests/dataset_manager/test_hdf.py
@@ -189,7 +189,19 @@ def test_write_empty_data_frame_index(hdf_file_path):
     assert written_data.equals(data)
 
 
-def test_write_data_frame(hdf_fhtople_path):
+def test_write_load_empty_data_frame_index(hdf_file_path):
+    key = EntityKey('cause.test.prevalence')
+    data = pd.DataFrame(data={'age': range(10),
+                              'year': range(10),
+                              'draw': range(10)})
+    data = data.set_index(list(data.columns))
+
+    hdf._write_data_frame(hdf_file_path, key, data)
+    loaded_data = hdf.load(hdf_file_path, key, filter_terms=None)
+    assert loaded_data.equals(data)
+
+
+def test_write_data_frame(hdf_file_path):
     key = EntityKey('cause.test.prevalence')
     data = build_table([lambda *args, **kwargs: random.choice([0, 1]), "Kenya", 1],
                        2005, 2010, columns=('age', 'year', 'sex', 'draw', 'location', 'value'))


### PR DESCRIPTION
This resets indices in the last controller, the artifact manager.There is also a change to the function that writes to the HDF. We no longer write data_columns, we have indices now. 

I tested this by running simulate on the obesity yaml. The HDF write was tested in the vivarium_inputs PR by building artifacts for the smoke test configurations

EDIT:  We now support writing empty dataframes and loading them back to the same state. Re-tested on obesity.