### PR TITLE
filter to only use combined sex birth data

### DIFF
--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -367,6 +367,8 @@ def get_live_births_per_year(builder):
     birth_data = builder.data.load("covariate.live_births_by_sex.estimate",
                                    future=builder.configuration.input_data.forecast)
 
+    birth_data = birth_data[birth_data.sex == 'Both']
+
     validate_crude_birth_rate_data(builder, population_data.year_end.max())
     population_data = rescale_final_age_bin(builder, population_data)
    


### PR DESCRIPTION
Make sure live births by sex data is filtered to combined both sexes. Non-forecasting data returns male, female, and both so we were double counting births