### PR TITLE
bugfixes: mort metrics + birth rate test data

### DIFF
--- a/src/vivarium_public_health/population/mortality.py
+++ b/src/vivarium_public_health/population/mortality.py
@@ -26,7 +26,6 @@ class Mortality:
         self.death_emitter = builder.event.get_emitter('deaths')
         self.random = builder.randomness.get_stream('mortality_handler')
         self.clock = builder.time.clock()
-        builder.value.register_value_modifier('metrics', modifier=self.metrics)
 
         self.population_view = builder.population.get_view(
             ['cause_of_death', 'alive', 'exit_time', 'age', 'sex', 'location', 'years_of_life_lost'])

--- a/tests/population/test_add_new_birth_cohort.py
+++ b/tests/population/test_add_new_birth_cohort.py
@@ -24,12 +24,9 @@ def config(base_config):
 
 
 def crude_birth_rate_data(live_births=500):
-    data = (build_table([live_births], 1990, 2017, ('age', 'year', 'sex', 'mean_value'))
-            .query('age_group_start == 25')
+    return (build_table([live_births], 1990, 2017, ('age', 'year', 'sex', 'mean_value'))
+            .query('age_group_start == 25 and sex == "Both"')
             .drop(['age_group_start', 'age_group_end'], 'columns'))
-    data = data.groupby(['year_start', 'year_end']).sum().reset_index()
-    data['sex'] = 'Both'
-    return data
 
 
 def test_FertilityDeterministic(config):
@@ -116,7 +113,7 @@ def test_FertilityCrudeBirthRate_extrapolate(config, base_plugins):
         pop_end = len(simulation.get_population())
         birth_rate.append((pop_end - pop_start)/pop_size)
 
-    given_birth_rate = 2*live_births_by_sex / true_pop_size
+    given_birth_rate = live_births_by_sex / true_pop_size
     np.testing.assert_allclose(birth_rate, given_birth_rate, atol=0.01)
 
 

--- a/tests/population/test_add_new_birth_cohort.py
+++ b/tests/population/test_add_new_birth_cohort.py
@@ -24,9 +24,12 @@ def config(base_config):
 
 
 def crude_birth_rate_data(live_births=500):
-    return (build_table(['mean_value', live_births], 1990, 2017, ('age', 'year', 'sex', 'parameter', 'mean_value'))
-            .query('age_group_start == 25 and sex != "Both"')
+    data = (build_table([live_births], 1990, 2017, ('age', 'year', 'sex', 'mean_value'))
+            .query('age_group_start == 25')
             .drop(['age_group_start', 'age_group_end'], 'columns'))
+    data = data.groupby(['year_start', 'year_end']).sum().reset_index()
+    data['sex'] = 'Both'
+    return data
 
 
 def test_FertilityDeterministic(config):


### PR DESCRIPTION
2 bugfixes:

1. Update birth rate test data to only include both since we filter on that now
2. remove reference to metrics from mortality