### PR TITLE
handle case where sim starts in future year

### DIFF
--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -375,11 +375,15 @@ def get_live_births_per_year(builder):
                   .drop('parameter', 'columns')
                   .groupby(['year_start'])['value'].sum())
 
+    start_year = builder.configuration.time.start.year
+    if builder.configuration.interpolation.extrapolate and start_year > birth_data.index.max():
+        start_year = birth_data.index.max()
+
     if not builder.configuration.fertility.time_dependent_live_births:
-        birth_data = birth_data.at[builder.configuration.time.start.year]
+        birth_data = birth_data.at[start_year]
 
     if not builder.configuration.fertility.time_dependent_population_fraction:
-        population_data = population_data.at[builder.configuration.time.start.year]
+        population_data = population_data.at[start_year]
 
     live_birth_rate = initial_population_size / population_data * birth_data
 


### PR DESCRIPTION
this just carries out the last year of population & birth data into future years so I'm assuming order 0 interpolation which may be problematic whenever we add other orders but I'm not sure how else to do this since the interpolated table stuff requires a population index, which I don't have here and I thought we were trying not to use raw interpolation anywhere 