### PR TITLE
only pivot on dimensions present in data

### DIFF
--- a/src/vivarium_public_health/risks/data_transformations.py
+++ b/src/vivarium_public_health/risks/data_transformations.py
@@ -15,6 +15,7 @@ from vivarium_public_health.utilities import EntityString, TargetString
 def pivot_categorical(data: pd.DataFrame) -> pd.DataFrame:
     """Pivots data that is long on categories to be wide."""
     key_cols = ['sex', 'age_group_start', 'age_group_end', 'year_start', 'year_end']
+    key_cols = [k for k in key_cols if k in data.columns]
     data = data.pivot_table(index=key_cols, columns='parameter', values='value').reset_index()
     data.columns.name = None
     return data


### PR DESCRIPTION
This addresses risk pivoting so data-free components will work with covariates that don't vary along both sex and age. 

Change is to subset pivot columns only to those present. I ran the test suite but not smoke tests