### PR TITLE
include alternative risk factors for categorical filtering

### DIFF
--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -125,9 +125,8 @@ class RiskAttributableDisease:
         self.population_view.update(pop)
 
     def get_exposure_filter(self, distribution, exposure_pipeline, threshold):
-
-        if distribution in ['dichotomous', 'ordered_polytomous', 'unordered_polytomous']:
-
+        # alternative risk factors are modeled ensemble but processed into categorical exposure
+        if (distribution in ['dichotomous', 'ordered_polytomous', 'unordered_polytomous'] or self.risk.type == 'alternative_risk_factor'):
             def categorical_filter(index):
                 exposure = exposure_pipeline(index)
                 return exposure.isin(threshold)


### PR DESCRIPTION
alternative risk factors from the mapping extension list a distribution of "ensemble" but they get processed into categories, so they need to be included in the categorical filtering rather than continuous.

I'm not sure if there is a plan for more of these alt rfs. If there is, maybe we should call on stunting/wasting/underweight by name