### PR TITLE
Feature/disease observer paf 1

### DIFF
--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -136,7 +136,9 @@ class RiskAttributableDisease:
         self.population_view.update(pop)
 
     def get_exposure_filter(self, distribution, exposure_pipeline, threshold):
+
         if distribution in ['dichotomous', 'ordered_polytomous', 'unordered_polytomous']:
+
             def categorical_filter(index):
                 exposure = exposure_pipeline(index)
                 return exposure.isin(threshold)

--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -129,10 +129,10 @@ class RiskAttributableDisease:
         sick = self.filter_by_exposure(pop.index)
         #  if this is recoverable, anyone who gets lower exposure in the event goes back in to susceptible status.
         if self.recoverable:
+            pop.loc[~sick & (pop[self.cause.name] != f'susceptible_to_{self.cause.name}'), self.susceptible_event_time_column] = event.time
             pop.loc[~sick, self.cause.name] = f'susceptible_to_{self.cause.name}'
-            pop.loc[~sick, self.susceptible_event_time_column] = event.time
+        pop.loc[sick & (pop[self.cause.name] != self.cause.name), self.diseased_event_time_column] = event.time
         pop.loc[sick, self.cause.name] = self.cause.name
-        pop.loc[sick, self.diseased_event_time_column] = event.time
         self.population_view.update(pop)
 
     def get_exposure_filter(self, distribution, exposure_pipeline, threshold):

--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -135,10 +135,10 @@ class RiskAttributableDisease:
         if self.recoverable:
             change_to_susceptible = (~sick) & (pop[self.cause.name] != f'susceptible_to_{self.cause.name}')
             pop.loc[change_to_susceptible, self.susceptible_event_time_column] = event.time
-            pop.loc[~sick, self.cause.name] = f'susceptible_to_{self.cause.name}'
+            pop.loc[change_to_susceptible, self.cause.name] = f'susceptible_to_{self.cause.name}'
         change_to_diseased = sick & (pop[self.cause.name] != self.cause.name)
         pop.loc[change_to_diseased, self.diseased_event_time_column] = event.time
-        pop.loc[sick, self.cause.name] = self.cause.name
+        pop.loc[change_to_diseased, self.cause.name] = self.cause.name
 
         self.population_view.update(pop)
 

--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -125,9 +125,8 @@ class RiskAttributableDisease:
         self.population_view.update(pop)
 
     def get_exposure_filter(self, distribution, exposure_pipeline, threshold):
-
-        if distribution in ['dichotomous', 'ordered_polytomous', 'unordered_polytomous']:
-
+        # alternative risk factors are modeled ensemble but processed into categorical exposure
+        if (distribution in ['dichotomous', 'ordered_polytomous', 'unordered_polytomous'] or self.risk.type == 'alternative_risk_factor'):
             def categorical_filter(index):
                 exposure = exposure_pipeline(index)
                 return exposure.isin(threshold)


### PR DESCRIPTION
This updates the risk attributable disease to produce columns necessary for use with the disease observer. All it needed was the disease event time column. I added a susceptible event time column as well because recovery is afforded by the model.

I tested this on the eggs yaml below but I removed all the promotion stuff. Dependencies are a pain, we really need that manager.

https://stash.ihme.washington.edu/projects/CSTE/repos/breastfeeding_promotion_and_eggs/browse/breastfeeding_promotion_and_eggs/model_specs/eggs.yaml
