### PR TITLE
import error from correct name

### DIFF
--- a/ci/travis-before-install.sh
+++ b/ci/travis-before-install.sh
@@ -29,7 +29,7 @@ upstream_branch_exists="$(git ls-remote --heads https://github.com/ihmeuw/vivari
 
 # if there is a match for upstream, use that, else fall back to develop
 # this is redundant only for a PR into develop.
-if [ -z "${upstream_branch}" ]  # checks if empty
+if [ -z "${upstream_branch_exists}" ]  # checks if empty
 then
     branch=develop
 else

--- a/ci/travis-before-install.sh
+++ b/ci/travis-before-install.sh
@@ -25,19 +25,19 @@ echo branch ${branch}
 # Look for branch of same name in upstream repositories
 # when this is develop it should be present.
 # When it isn't develop, this may or may not exist
-upstream_branch="$(git ls-remote --heads https://github.com/ihmeuw/vivarium.git ${branch})"
+upstream_branch_exists="$(git ls-remote --heads https://github.com/ihmeuw/vivarium.git ${branch})"
 
 # if there is a match for upstream, use that, else fall back to develop
 # this is redundant only for a PR into develop.
 if [ -z "${upstream_branch}" ]  # checks if empty
 then
-    upstream_branch=develop
+    branch=develop
 else
     echo upstream branch found ${upstream_branch}
 fi
 
 # clone and install upstream stuff
-git clone --branch=$upstream_branch https://github.com/ihmeuw/vivarium.git
+git clone --branch=$branch https://github.com/ihmeuw/vivarium.git
 pushd vivarium
 pip install .
 popd

--- a/ci/travis-before-install.sh
+++ b/ci/travis-before-install.sh
@@ -22,26 +22,22 @@ pip install --upgrade pip setuptools
 branch=$TRAVIS_BRANCH
 echo branch ${branch}
 
-# Look for branch of same name in upstream repositories
-# when this is develop it should be present.
-# When it isn't develop, this may or may not exist
+# Look for branch in upstream repositories
+# branch is the "target", either same name for push or target for PR
 upstream_branch_exists="$(git ls-remote --heads https://github.com/ihmeuw/vivarium.git ${branch})"
 
-# if there is a match for upstream, use that, else fall back to develop
-# this is redundant only for a PR into develop.
-if [ -z "${upstream_branch_exists}" ]  # checks if empty
+# if there is a match for upstream, use that
+if [ ! -z "${upstream_branch_exists}" ]  # checks if not-empty
 then
-    branch=develop
-else
-    echo upstream branch found ${upstream_branch}
+    echo upstream branch found for ${branch}
+    # clone and install upstream stuff if target branch exists
+    git clone --branch=$branch https://github.com/ihmeuw/vivarium.git
+    pushd vivarium
+    pip install .
+    popd
 fi
 
-# clone and install upstream stuff
-git clone --branch=$branch https://github.com/ihmeuw/vivarium.git
-pushd vivarium
-pip install .
 popd
 
-popd  # is this right ?
-
+# If no upstream match was found, this will install last release
 pip install .[test,docs]

--- a/ci/travis-before-install.sh
+++ b/ci/travis-before-install.sh
@@ -35,6 +35,8 @@ then
     pushd vivarium
     pip install .
     popd
+else
+    echo no upstream branch found
 fi
 
 popd

--- a/src/vivarium_public_health/disease/model.py
+++ b/src/vivarium_public_health/disease/model.py
@@ -3,7 +3,7 @@ import numbers
 import pandas as pd
 import numpy as np
 
-from vivarium import VivariumError
+from vivarium.exceptions import VivariumError
 from vivarium.framework.state_machine import Machine
 
 from vivarium_public_health.disease import (SusceptibleState, ExcessMortalityState, TransientDiseaseState,


### PR DESCRIPTION
the CI script's new behavior: For push, it will look for branch of the same name in upstream repos. For PR, it will look for branch of same name as the PR target in upstream repos. In both cases if nothing is found, the most recent release will be installed.

Also added some comments and improved the script reporting to stdout

I pushed a branch of the same name to Vivarium to test it out as well. The push test currently fails because I removed the branch so the test is run on the most recent release of Vivarium, which does not have the exception moved.