### PR TITLE
Bugfix/sim dist get params

### DIFF
--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -72,7 +72,7 @@ class SimulationDistribution:
     def ppf(self, q):
         if not q.empty:
             x = self.distribution(parameters=self.parameters(q.index)).ppf(q)
-            x[x.x.isnull()] = 0
+            x[x.isnull()] = 0
         else:
             x = pd.Series([])
         return x

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -71,7 +71,7 @@ class SimulationDistribution:
 
     def ppf(self, q):
         if not q.empty:
-            x = self.distribution(params=self.parameters(q.index)).ppf(q)
+            x = self.distribution(parameters=self.parameters(q.index)).ppf(q)
             x[x.x.isnull()] = 0
         else:
             x = pd.Series([])

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -67,7 +67,7 @@ class SimulationDistribution:
         index = ['sex', 'age_group_start', 'age_group_end', 'year_start', 'year_end']
         mean = mean.set_index(index)['value']
         sd = sd.set_index(index)['value']
-        return self.distribution.get_params(mean, sd).reset_index()
+        return self.distribution.get_parameters(mean, sd).reset_index()
 
     def ppf(self, q):
         if not q.empty:

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -67,7 +67,7 @@ class SimulationDistribution:
         index = ['sex', 'age_group_start', 'age_group_end', 'year_start', 'year_end']
         mean = mean.set_index(index)['value']
         sd = sd.set_index(index)['value']
-        return self.distribution.get_parameters(mean, sd).reset_index()
+        return self.distribution.get_parameters(mean=mean, sd=sd).reset_index()
 
     def ppf(self, q):
         if not q.empty:


### PR DESCRIPTION
SimulationDistribution was still trying to use an old version of RiskDistributions with the wrong method names & missing keyword args