### PR TITLE
Feature/age filter metrics

### DIFF
--- a/src/vivarium_public_health/metrics/utilities.py
+++ b/src/vivarium_public_health/metrics/utilities.py
@@ -142,6 +142,7 @@ def get_age_bins(builder) -> pd.DataFrame:
     age_start = builder.configuration.population.age_start
     min_bin_start = age_bins.age_group_start[np.asscalar(np.digitize(age_start, age_bins.age_group_end))]
     age_bins = age_bins[age_bins.age_group_start >= min_bin_start]
+    age_bins.loc[age_bins.age_group_start < age_start, 'age_group_start'] = age_start
 
     exit_age = builder.configuration.population.exit_age
     if exit_age:

--- a/src/vivarium_public_health/metrics/utilities.py
+++ b/src/vivarium_public_health/metrics/utilities.py
@@ -140,7 +140,7 @@ def get_age_bins(builder) -> pd.DataFrame:
 
     # Works based on the fact that currently only models with age_start = 0 can include fertility
     age_start = builder.configuration.population.age_start
-    min_bin_start = np.asscalar(np.digitize(age_start, age_bins.age_group_end))
+    min_bin_start = age_bins.age_group_start[np.asscalar(np.digitize(age_start, age_bins.age_group_end))]
     age_bins = age_bins[age_bins.age_group_start >= min_bin_start]
 
     exit_age = builder.configuration.population.exit_age

--- a/src/vivarium_public_health/metrics/utilities.py
+++ b/src/vivarium_public_health/metrics/utilities.py
@@ -137,6 +137,12 @@ def get_age_bins(builder) -> pd.DataFrame:
 
     """
     age_bins = builder.data.load('population.age_bins')
+
+    # Works based on the fact that currently only models with age_start = 0 can include fertility
+    age_start = builder.configuration.population.age_start
+    min_bin_start = np.asscalar(np.digitize(age_start, age_bins.age_group_end))
+    age_bins = age_bins[age_bins.age_group_start >= min_bin_start]
+
     exit_age = builder.configuration.population.exit_age
     if exit_age:
         age_bins = age_bins[age_bins.age_group_start < exit_age]

--- a/tests/metrics/test_utilities.py
+++ b/tests/metrics/test_utilities.py
@@ -43,6 +43,16 @@ def observer_config(request):
     return c
 
 
+@pytest.fixture()
+def builder(mocker):
+    builder = mocker.MagicMock()
+    df = pd.DataFrame({'age_group_start': [0, 1, 4],
+                       'age_group_name': ['youngest', 'younger', 'young'],
+                       'age_group_end': [1, 4, 6]})
+    builder.data.load.return_value = df
+    return builder
+
+
 @pytest.mark.parametrize('reference, test', product([QueryString(''), QueryString('abc')], [QueryString(''), '']))
 def test_query_string_empty(reference, test):
     result = str(reference)
@@ -580,21 +590,14 @@ def test_get_years_lived_with_disability(ages_and_bins, sexes, observer_config):
                                                                         (1, 4, {4}),
                                                                         (1, 3, {3}),
                                                                         (0, 6, {1, 4, 6})])
-def test_get_age_bins(mocker, base_config, age_start, exit_age, result_age_end_values):
+def test_get_age_bins(builder, base_config, age_start, exit_age, result_age_end_values):
     base_config.update({
         'population': {
             'age_start': age_start,
             'exit_age': exit_age
         }
     }, **metadata(__file__))
-
-    builder = mocker.MagicMock()
     builder.configuration = base_config
-    df = pd.DataFrame({'age_group_start': [0, 1, 4],
-                       'age_group_name': ['youngest', 'younger', 'young'],
-                       'age_group_end': [1, 4, 6]})
-    builder.data.load.return_value = df
-
     df = get_age_bins(builder)
     assert set(df.age_group_end) == result_age_end_values
 

--- a/tests/metrics/test_utilities.py
+++ b/tests/metrics/test_utilities.py
@@ -585,12 +585,13 @@ def test_get_years_lived_with_disability(ages_and_bins, sexes, observer_config):
     assert np.isclose(values.pop(), 2 * expected_value)
 
 
-@pytest.mark.parametrize('age_start, exit_age, result_age_end_values', [(2, 5, {4, 5}),
-                                                                        (0, None, {1, 4, 6}),
-                                                                        (1, 4, {4}),
-                                                                        (1, 3, {3}),
-                                                                        (0, 6, {1, 4, 6})])
-def test_get_age_bins(builder, base_config, age_start, exit_age, result_age_end_values):
+@pytest.mark.parametrize('age_start, exit_age, result_age_end_values, result_age_start_values',
+                         [(2, 5, {4, 5}, {2, 4}),
+                          (0, None, {1, 4, 6}, {0, 1, 4}),
+                          (1, 4, {4}, {1}),
+                          (1, 3, {3}, {1}),
+                          (0.8, 6, {1, 4, 6}, {0.8, 1, 4})])
+def test_get_age_bins(builder, base_config, age_start, exit_age, result_age_end_values, result_age_start_values):
     base_config.update({
         'population': {
             'age_start': age_start,
@@ -600,4 +601,5 @@ def test_get_age_bins(builder, base_config, age_start, exit_age, result_age_end_
     builder.configuration = base_config
     df = get_age_bins(builder)
     assert set(df.age_group_end) == result_age_end_values
+    assert set(df.age_group_start) == result_age_start_values
 


### PR DESCRIPTION
Previously, observers if stratified by age only reported age groups up to exit_age. This makes it so that the age groups are also bounded on the lower edge - age_groups below the specified age_start will no longer be included. Also added a test to show that both the age_start and exit_age restrictions work and that the age_group_end of the oldest age group is capped to exit_age if it straddles the exit_age