### PR TITLE
Mic966 intervention start

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
         long_description = f.read()
 
     install_requirements = [
-        'vivarium<0.8.20',
+        'vivarium==0.8.20',
         # FIXME: Newer versions of numpy have conflicting dependencies
         # with pytables.
         'numpy<=1.15.4',

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,11 @@ if __name__ == "__main__":
         long_description = f.read()
 
     install_requirements = [
-        'vivarium>=0.8.19',
+        'vivarium<0.8.20',
         # FIXME: Newer versions of numpy have conflicting dependencies
         # with pytables.
         'numpy<=1.15.4',
-        'pandas',
+        'pandas<0.25',
         'scipy',
         # FIXME: Requirement imposed by our standard data sources.
         'tables<=3.4.0',

--- a/src/vivarium_public_health/treatment/mass_treatment_campaign.py
+++ b/src/vivarium_public_health/treatment/mass_treatment_campaign.py
@@ -3,18 +3,9 @@ import pandas as pd
 from .base_treatment import Treatment
 from .schedule import TreatmentSchedule
 
-from pudb import set_trace
-
 class MassTreatmentCampaign:
 
     configuration_defaults = {
-        'time': {
-            "intervention_start_date": {
-                "year": 2030,
-                "month": 1,
-                "day": 1
-            }
-        },
         'treatment': {
             'doses': ['first', 'second', 'booster', 'catchup'],
             'dose_response': {
@@ -57,6 +48,11 @@ class MassTreatmentCampaign:
                 'booster': 0.9,
                 'catchup': 0.1,
             },
+            "intervention_start_date": {
+                "year": 2030,
+                "month": 1,
+                "day": 1
+            }
         }
     }
 
@@ -67,14 +63,12 @@ class MassTreatmentCampaign:
         self.schedule = TreatmentSchedule(treatment_name)
 
     def setup(self, builder):
-        #set_trace()
         builder.components.add_components([self.treatment, self.schedule])
         self.config = builder.configuration[self.treatment_name]
         self.clock = builder.time.clock()
 
         self.start_date = pd.Timestamp(**builder.configuration.time['start'].to_dict())
-        self.intervention_date = pd.Timestamp(
-                **MassTreatmentCampaign.configuration_defaults['time']['intervention_start_date'])
+        self.intervention_date = pd.Timestamp(**self.config['intervention_start_date'].to_dict())
         self.end_date = pd.Timestamp(**builder.configuration.time['end'].to_dict())
 
         columns = [f'{self.treatment.name}_current_dose',

--- a/src/vivarium_public_health/treatment/mass_treatment_campaign.py
+++ b/src/vivarium_public_health/treatment/mass_treatment_campaign.py
@@ -67,9 +67,7 @@ class MassTreatmentCampaign:
         self.config = builder.configuration[self.treatment_name]
         self.clock = builder.time.clock()
 
-        self.start_date = pd.Timestamp(**builder.configuration.time['start'].to_dict())
         self.intervention_date = pd.Timestamp(**self.config['intervention_start_date'].to_dict())
-        self.end_date = pd.Timestamp(**builder.configuration.time['end'].to_dict())
 
         columns = [f'{self.treatment.name}_current_dose',
                    f'{self.treatment.name}_current_dose_event_time',


### PR DESCRIPTION
Add "intervention_start_date" to vph v0.8.

Is there a sensible default for mass_treatment_campaign.py configuration_defaults? Currently set to 1/1/2030