### PR TITLE
Feature/consistent data keys

### DIFF
--- a/src/vivarium_public_health/disease/model.py
+++ b/src/vivarium_public_health/disease/model.py
@@ -73,7 +73,7 @@ class DiseaseModel(Machine):
             if only_morbid:
                 csmr_data = 0
             else:
-                csmr_data = builder.data.load(f"{self.cause_type}.{self.cause}.cause_specific_mortality")
+                csmr_data = builder.data.load(f"{self.cause_type}.{self.cause}.cause_specific_mortality_rate")
         else:
             csmr_data = self._get_data_functions['cause_specific_mortality_rate'](self.cause, builder)
         return csmr_data

--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -102,9 +102,9 @@ class RiskAttributableDisease:
         self.clock = builder.time.clock()
 
         if builder.configuration[self.cause.name].mortality:
-            csmr_data = builder.data.load(f'cause.{self.cause.name}.cause_specific_mortality')
+            csmr_data = builder.data.load(f'cause.{self.cause.name}.cause_specific_mortality_rate')
             builder.value.register_value_modifier('csmr_data', lambda: csmr_data)
-            excess_mortality_data = builder.data.load(f'{self.cause}.excess_mortality')
+            excess_mortality_data = builder.data.load(f'{self.cause}.excess_mortality_rate')
             builder.value.register_value_modifier('mortality_rate', self.mortality_rates)
             self._excess_mortality_rate = builder.value.register_value_producer(
                 f'{self.cause.name}.excess_mortality_rate', source=builder.lookup.build_table(excess_mortality_data)

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -127,7 +127,7 @@ class SusceptibleState(BaseDiseaseState):
         if source_data_type == 'rate':
             if get_data_functions is None:
                 get_data_functions = {
-                    'incidence_rate': lambda cause, builder: builder.data.load(f"{self.cause_type}.{cause}.incidence")
+                    'incidence_rate': lambda cause, builder: builder.data.load(f"{self.cause_type}.{cause}.incidence_rate")
                 }
             elif 'incidence_rate' not in get_data_functions:
                 raise ValueError('You must supply an incidence rate function.')
@@ -147,7 +147,7 @@ class RecoveredState(BaseDiseaseState):
         if source_data_type == 'rate':
             if get_data_functions is None:
                 get_data_functions = {
-                    'incidence_rate': lambda cause, builder: builder.data.load(f"{self.cause_type}.{cause}.incidence")
+                    'incidence_rate': lambda cause, builder: builder.data.load(f"{self.cause_type}.{cause}.incidence_rate")
                 }
             elif 'incidence_rate' not in get_data_functions:
                 raise ValueError('You must supply an incidence rate function.')
@@ -254,7 +254,7 @@ class DiseaseState(BaseDiseaseState):
         if source_data_type == 'rate':
             if get_data_functions is None:
                 get_data_functions = {
-                    'remission_rate': lambda cause, builder: builder.data.load(f"{self.cause_type}.{cause}.remission")
+                    'remission_rate': lambda cause, builder: builder.data.load(f"{self.cause_type}.{cause}.remission_rate")
                 }
             elif 'remission_rate' not in get_data_functions:
                 raise ValueError('You must supply a remission rate function.')
@@ -337,7 +337,7 @@ class MortalityEffect:
     def setup(self, builder):
         get_excess_mortality_func = self._state._get_data_functions.get(
             'excess_mortality_rate',
-            lambda cause, builder: builder.data.load(f"{self._state.cause_type}.{cause}.excess_mortality")
+            lambda cause, builder: builder.data.load(f"{self._state.cause_type}.{cause}.excess_mortality_rate")
         )
 
         self.base_excess_mortality_rate = builder.lookup.build_table(

--- a/src/vivarium_public_health/mslt/delay.py
+++ b/src/vivarium_public_health/mslt/delay.py
@@ -162,7 +162,7 @@ class DelayedRisk:
         dis_rr_data = builder.data.load(f'risk_factor.{self.name}.disease_relative_risk')
 
         # Check that the relative risk table includes required columns.
-        key_columns = ['age_start', 'age_end', 'sex',
+        key_columns = ['age_group_start', 'age_group_end', 'sex',
                        'year_start', 'year_end']
         if set(key_columns) & set(dis_rr_data.columns) != set(key_columns):
             # Fallback option, handle tables that do not define bin edges.

--- a/src/vivarium_public_health/population/mortality.py
+++ b/src/vivarium_public_health/population/mortality.py
@@ -19,7 +19,7 @@ class Mortality:
         return 'mortality'
 
     def setup(self, builder):
-        all_cause_mortality_data = builder.data.load("cause.all_causes.cause_specific_mortality")
+        all_cause_mortality_data = builder.data.load("cause.all_causes.cause_specific_mortality_rate")
         self.all_cause_mortality_rate = builder.lookup.build_table(all_cause_mortality_data)
         self.cause_specific_mortality_rate = builder.value.register_value_producer(
             'cause_specific_mortality_rate', source=builder.lookup.build_table(0)

--- a/src/vivarium_public_health/risks/data_transformations.py
+++ b/src/vivarium_public_health/risks/data_transformations.py
@@ -310,7 +310,7 @@ def get_population_attributable_fraction_data(builder, risk: EntityString,
 def validate_distribution_data_source(builder, risk: EntityString):
     """Checks that the exposure distribution specification is valid."""
     exposure_type = builder.configuration[risk.name]['exposure']
-    rebin = builder.configuration[risk.name]['rebin']
+    rebin = builder.configuration[risk.name]['rebinned_exposed']
     category_thresholds = builder.configuration[risk.name]['category_thresholds']
 
     if risk.type == 'alternative_risk_factor':

--- a/src/vivarium_public_health/testing/mock_artifact.py
+++ b/src/vivarium_public_health/testing/mock_artifact.py
@@ -18,10 +18,10 @@ from .utils import make_uniform_pop_data
 MOCKERS = {
         'cause': {
             'prevalence': 0,
-            'cause_specific_mortality': 0,
-            'excess_mortality': 0,
-            'remission': 0,
-            'incidence': 0.001,
+            'cause_specific_mortality_rate': 0,
+            'excess_mortality_rate': 0,
+            'remission_rate': 0,
+            'incidence_rate': 0.001,
             'disability_weight': pd.DataFrame({'value': [0]}),
             'restrictions': lambda *args, **kwargs: {'yld_only': False}
         },
@@ -49,10 +49,10 @@ MOCKERS = {
         },
         'sequela': {
             'prevalence': 0,
-            'cause_specific_mortality': 0,
-            'excess_mortality': 0,
-            'remission': 0,
-            'incidence': 0.001,
+            'cause_specific_mortality_rate': 0,
+            'excess_mortality_rate': 0,
+            'remission_rate': 0,
+            'incidence_rate': 0.001,
             'disability_weight': pd.DataFrame({'value': [0]}),
         },
         'etiology': {
@@ -62,7 +62,7 @@ MOCKERS = {
         'healthcare_entity': {
             'cost': build_table([0, 'outpatient_visits'], 1990, 2017,
                                 ("age", "sex", "year", "value", "healthcare_entity")),
-            'utilization': 0,
+            'utilization_rate': 0,
         },
         'population': {
             'structure': make_uniform_pop_data(),

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -252,7 +252,7 @@ def test_incidence(base_config, base_plugins, disease):
     healthy = BaseDiseaseState('healthy')
     sick = BaseDiseaseState('sick')
 
-    key = f"sequela.acute_myocardial_infarction_first_2_days.incidence"
+    key = f"sequela.acute_myocardial_infarction_first_2_days.incidence_rate"
     transition = RateTransition(
         input_state=healthy, output_state=sick,
         get_data_functions={
@@ -287,7 +287,7 @@ def test_risk_deletion(base_config, base_plugins, disease):
 
     healthy = BaseDiseaseState('healthy')
     sick = BaseDiseaseState('sick')
-    key = "sequela.acute_myocardial_infarction_first_2_days.incidence"
+    key = "sequela.acute_myocardial_infarction_first_2_days.incidence_rate"
     transition = RateTransition(
         input_state=healthy, output_state=sick,
         get_data_functions={

--- a/tests/metrics/test_disability.py
+++ b/tests/metrics/test_disability.py
@@ -31,7 +31,7 @@
 #                                                                 ['age', 'year', 'sex', 'value']),
 #                         'disability_weight': lambda _, __: 0.0,
 #                         'dwell_time': lambda _, __: pd.Timedelta(days=1),
-#                         'excess_mortality': lambda _, __: build_table(0, year_start-1, year_end)}
+#                         'excess_mortality_rate': lambda _, __: build_table(0, year_start-1, year_end)}
 #
 #     asymptomatic_disease_state = ExcessMortalityState('asymptomatic', get_data_functions=asymp_data_funcs)
 #     asymptomatic_disease_model = DiseaseModel('asymptomatic',
@@ -47,7 +47,7 @@
 #                                                                   ['age', 'year', 'sex', 'value']),
 #                           'disability_weight': lambda _, __: 0.2,
 #                           'dwell_time': lambda _, __: pd.Timedelta(days=1),
-#                           'excess_mortality': lambda _, __: build_table(0, year_start-1, year_end)}
+#                           'excess_mortality_rate': lambda _, __: build_table(0, year_start-1, year_end)}
 #         flu = ExcessMortalityState('flu', get_data_functions=flu_data_funcs)
 #         flu_model = DiseaseModel('flu', states=[flu],
 #                                  initial_state=flu,
@@ -59,7 +59,7 @@
 #                                                                     ['age', 'year', 'sex', 'value']),
 #                             'disability_weight': lambda _, __: 0.4,
 #                             'dwell_time': lambda _, __: pd.Timedelta(days=1),
-#                             'excess_mortality': lambda _, __: build_table(0, year_start-1, year_end)}
+#                             'excess_mortality_rate': lambda _, __: build_table(0, year_start-1, year_end)}
 #         mumps = ExcessMortalityState('mumps', get_data_functions=mumps_data_funcs)
 #         mumps_model = DiseaseModel('mumps', states=[mumps],
 #                                    initial_state=mumps,
@@ -71,7 +71,7 @@
 #                                                                      ['age', 'year', 'sex', 'value']),
 #                              'disability_weight': lambda _, __: 0.4,
 #                              'dwell_time': lambda _, __: pd.Timedelta(days=1),
-#                              'excess_mortality': lambda _, __: build_table(0.005, year_start-1, year_end)}
+#                              'excess_mortality_rate': lambda _, __: build_table(0.005, year_start-1, year_end)}
 #         deadly = ExcessMortalityState('deadly', get_data_functions=deadly_data_funcs)
 #         healthy = DiseaseState('healthy', get_data_functions=deadly_data_funcs)
 #         deadly_model = DiseaseModel('deadly', initial_state=healthy,

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -384,17 +384,17 @@
 #
 # def test_RiskEffect_excess_mortality(base_config, base_plugins):
 #     dummy_risk = Risk("risk_factor.test_risk")
-#     dummy_effect = RiskEffect("risk_factor.test_risk", "cause.test_cause.excess_mortality")
+#     dummy_effect = RiskEffect("risk_factor.test_risk", "cause.test_cause.excess_mortality_rate")
 #     time_step = pd.Timedelta(days=base_config.time.step_size)
 #
 #     base_config.update({'test_risk': {'exposure': 1}}, layer='override')
-#     base_config.update({'effect_of_test_risk_on_test_cause': {'excess_mortality': 50}})
+#     base_config.update({'effect_of_test_risk_on_test_cause': {'excess_mortality_rate': 50}})
 #
 #     simulation = initialize_simulation([TestPopulation(), dummy_risk, dummy_effect],
 #                                        input_config=base_config, plugin_config=base_plugins)
 #     simulation.setup()
 #
-#     em = simulation.values.register_rate_producer('test_cause.excess_mortality',
+#     em = simulation.values.register_rate_producer('test_cause.excess_mortality_rate',
 #                                                   source=lambda index: pd.Series(0.1, index=index))
 #
 #     assert np.allclose(from_yearly(0.1, time_step)*50, em(simulation.get_population().index))


### PR DESCRIPTION
this is the changes to data keys to always use rate to be consistent. also 2 tiny little fixes to config things where we were previously using a bad key and where the get_values call changed

tests break because of misaligned branches but pass locally + I can build an artifact and run a sim with this (and the currently PR'ed changes in vivarium + vivarium_inputs)