### PR TITLE
update test to not pass columns not in pop view to update

### DIFF
--- a/tests/population/test_base_population.py
+++ b/tests/population/test_base_population.py
@@ -74,7 +74,7 @@ def test_BasePopulation(config, base_plugins, generate_population_mock):
     sims = make_full_simulants()
     start_population_size = len(sims)
 
-    generate_population_mock.return_value = sims
+    generate_population_mock.return_value = sims.drop(columns=['tracked'])
 
     base_pop = bp.BasePopulation()
 


### PR DESCRIPTION
this just fixes one test that was hitting the error I added in vivarium pop view update because the mocked return value had an extra column