### PR TITLE
rename joint_value_post_processor to union_post_processor

### DIFF
--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -11,7 +11,7 @@ from operator import lt, gt
 import re
 
 import pandas as pd
-from vivarium.framework.values import list_combiner, joint_value_post_processor
+from vivarium.framework.values import list_combiner, union_post_processor
 
 from vivarium_public_health.utilities import EntityString
 
@@ -133,7 +133,7 @@ class RiskAttributableDisease:
             f'{self.cause.name}.excess_mortality_rate.population_attributable_fraction',
             source=lambda idx: [paf(idx)],
             preferred_combiner=list_combiner,
-            preferred_post_processor=joint_value_post_processor
+            preferred_post_processor=union_post_processor
         )
         builder.value.register_value_modifier('mortality_rate',
                                               modifier=self.adjust_mortality_rate,

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -9,7 +9,7 @@ This module contains tools to manage standard disease states.
 import pandas as pd
 import numpy as np
 from vivarium.framework.state_machine import State, Transient
-from vivarium.framework.values import list_combiner, joint_value_post_processor
+from vivarium.framework.values import list_combiner, union_post_processor
 
 from vivarium_public_health.disease import RateTransition, ProportionTransition
 
@@ -232,7 +232,7 @@ class DiseaseState(BaseDiseaseState):
             f'{self.state_id}.excess_mortality_rate.population_attributable_fraction',
             source=lambda idx: [paf(idx)],
             preferred_combiner=list_combiner,
-            preferred_post_processor=joint_value_post_processor
+            preferred_post_processor=union_post_processor
         )
         builder.value.register_value_modifier('mortality_rate',
                                               modifier=self.adjust_mortality_rate,

--- a/src/vivarium_public_health/disease/transition.py
+++ b/src/vivarium_public_health/disease/transition.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from vivarium.framework.state_machine import Transition
 from vivarium.framework.utilities import rate_to_probability
-from vivarium.framework.values import list_combiner, joint_value_post_processor
+from vivarium.framework.values import list_combiner, union_post_processor
 
 
 class RateTransition(Transition):
@@ -29,7 +29,7 @@ class RateTransition(Transition):
         self.joint_paf = builder.value.register_value_producer(f'{pipeline_name}.paf',
                                                                source=lambda index: [paf(index)],
                                                                preferred_combiner=list_combiner,
-                                                               preferred_post_processor=joint_value_post_processor)
+                                                               preferred_post_processor=union_post_processor)
 
         self.population_view = builder.population.get_view(['alive'])
 

--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -10,7 +10,7 @@ in the simulation.
 from collections import Counter
 
 import pandas as pd
-from vivarium.framework.values import list_combiner, joint_value_post_processor, rescale_post_processor
+from vivarium.framework.values import list_combiner, union_post_processor, rescale_post_processor
 
 from vivarium_public_health.disease import DiseaseState, RiskAttributableDisease
 from .utilities import get_age_bins, get_years_lived_with_disability
@@ -106,4 +106,4 @@ class DisabilityObserver:
 
 
 def _disability_post_processor(value, step_size):
-    return rescale_post_processor(joint_value_post_processor(value, step_size), step_size)
+    return rescale_post_processor(union_post_processor(value, step_size), step_size)

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from risk_distributions import EnsembleDistribution, Normal, LogNormal
 
-from vivarium.framework.values import list_combiner, joint_value_post_processor
+from vivarium.framework.values import list_combiner, union_post_processor
 from vivarium_public_health.risks.data_transformations import get_distribution_data
 
 
@@ -161,7 +161,7 @@ class DichotomousDistribution:
         self.joint_paf = builder.value.register_value_producer(f'{self.risk}.exposure_parameters.paf',
                                                                source=lambda index: [builder.lookup.build_table(0)(index)],
                                                                preferred_combiner=list_combiner,
-                                                               preferred_post_processor=joint_value_post_processor)
+                                                               preferred_post_processor=union_post_processor)
 
     def exposure(self, index):
         base_exposure = self._base_exposure(index).values


### PR DESCRIPTION
We need this change to track with the current planned release of Vivarium, which renames the joint_value_post_processor