### PR TITLE
Change 'remission' to 'value'

### DIFF
--- a/src/vivarium_public_health/mslt/delay.py
+++ b/src/vivarium_public_health/mslt/delay.py
@@ -143,7 +143,7 @@ class DelayedRisk:
         rem_df = pivot_load(builder,f'risk_factor.{self.name}.remission')
         # In the constant-prevalence case, assume there is no remission.
         if self.constant_prevalence:
-            rem_df['remission'] = 0.0
+            rem_df['value'] = 0.0
         rem_data = builder.lookup.build_table(rem_df, 
                                               key_columns=['sex'], 
                                               parameter_columns=['age','year'])


### PR DESCRIPTION
Extra 'remission' column was being created instead of 'value' column being overwritten. This resulted in a table of NaNs when multiplied by a pop column.