### PR TITLE
update vivarium pin to latest, unpin pandas and numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,9 @@ if __name__ == "__main__":
 
     install_requirements = [
         # TODO: update with newer version once released
-        'vivarium>=0.9.1',
-        # FIXME: Newer versions of numpy have conflicting dependencies with pytables.
-        'numpy<=1.15.4',
-        'pandas<0.25',
+        'vivarium>=0.9.3',
+        'numpy',
+        'pandas',
         'scipy',
         # FIXME: Requirement imposed by our standard data sources.
         'tables<=3.4.0',


### PR DESCRIPTION
Two tests fail that use randomness's updated interface with get_seed, which is still on develop. This release must be coordinated with that release