### PR TITLE
refactor final age bin rescale to simplify and remove warning

### DIFF
--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -417,12 +417,12 @@ def get_live_births_per_year(builder):
 def rescale_final_age_bin(builder, population_data):
     exit_age = builder.configuration.population.to_dict().get('exit_age', None)
     if exit_age:
-        cut_bin = population_data[(population_data.age_start < exit_age)
-                                  & (population_data.age_end >= exit_age)]
-        cut_bin.value *= (exit_age - cut_bin.age_start) / (cut_bin.age_end - cut_bin.age_start)
-        cut_bin.loc[:, 'age_end'] = exit_age
-        population_data = population_data[population_data.age_end < exit_age]
-        population_data = pd.concat([population_data, cut_bin], ignore_index=True)
+        population_data = population_data.loc[population_data['age_start'] < exit_age]
+        cut_bin_idx = (exit_age <= population_data['age_end'])
+        population_data.loc[cut_bin_idx, 'value'] *= ((exit_age - population_data.loc[cut_bin_idx, 'age_start'])
+                                                      / (population_data.loc[cut_bin_idx, 'age_end']
+                                                         - population_data.loc[cut_bin_idx, 'age_start']))
+        population_data.loc[cut_bin_idx, 'age_end'] = exit_age
     return population_data
 
 

--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -419,9 +419,9 @@ def rescale_final_age_bin(builder, population_data):
     if exit_age:
         population_data = population_data.loc[population_data['age_start'] < exit_age]
         cut_bin_idx = (exit_age <= population_data['age_end'])
-        population_data.loc[cut_bin_idx, 'value'] *= ((exit_age - population_data.loc[cut_bin_idx, 'age_start'])
-                                                      / (population_data.loc[cut_bin_idx, 'age_end']
-                                                         - population_data.loc[cut_bin_idx, 'age_start']))
+        cut_age_start = population_data.loc[cut_bin_idx, 'age_start']
+        cut_age_end = population_data.loc[cut_bin_idx, 'age_end']
+        population_data.loc[cut_bin_idx, 'value'] *= ((exit_age - cut_age_start) / (cut_age_end - cut_age_start))
         population_data.loc[cut_bin_idx, 'age_end'] = exit_age
     return population_data
 


### PR DESCRIPTION
This function is responsible for excluding simulants out of scope due to exit_age and scaling the value of simulants who cross the exit_age threshold. I refactored it just a bit to remove SettingWithCopyWarnings