### PR TITLE
don't use equality on floats in smooth ages

### DIFF
--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -8,6 +8,7 @@ it into different distributions for sampling.
 
 """
 from collections import namedtuple
+from math import isclose
 
 import numpy as np
 import pandas as pd
@@ -347,7 +348,7 @@ def _compute_ages(uniform_rv, start, height, slope, normalization):
     numpy.ndarray or float
         Smoothed ages from one half of the age bin distribution.
     """
-    if slope == 0:
+    if isclose(slope, 0, abs_tol=1e-09):
         return start + normalization / height * uniform_rv
     else:
         return start + height / slope * (np.sqrt(1 + 2 * normalization * slope / height ** 2 * uniform_rv) - 1)

--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -8,7 +8,6 @@ it into different distributions for sampling.
 
 """
 from collections import namedtuple
-from math import isclose
 
 import numpy as np
 import pandas as pd
@@ -348,7 +347,7 @@ def _compute_ages(uniform_rv, start, height, slope, normalization):
     numpy.ndarray or float
         Smoothed ages from one half of the age bin distribution.
     """
-    if isclose(slope, 0, abs_tol=1e-09):
+    if slope < np.finfo(np.float32).eps:
         return start + normalization / height * uniform_rv
     else:
         return start + height / slope * (np.sqrt(1 + 2 * normalization * slope / height ** 2 * uniform_rv) - 1)


### PR DESCRIPTION
When debugging that Windows issue on cervical cancer, I saw that we lost about 1/3 of our uniqueness in this step, because `slope` was about `2.19e-15`. This would treat numbers like that like we currently treat a 0 slope, and preserve the uniqueness. 

I don't know what the actual tolerance should be.