### PR TITLE
remove unneeded {disease_state}_event_time column from DiseaseState

### DIFF
--- a/src/vivarium_public_health/metrics/disease.py
+++ b/src/vivarium_public_health/metrics/disease.py
@@ -89,7 +89,7 @@ class DiseaseObserver:
         builder.population.initializes_simulants(self.on_initialize_simulants,
                                                  creates_columns=[self.previous_state_column])
 
-        columns_required = ['alive', f'{self.disease}', f'{self.disease}_event_time', self.previous_state_column]
+        columns_required = ['alive', f'{self.disease}', self.previous_state_column]
         if self.config.by_age:
             columns_required += ['age']
         if self.config.by_sex:


### PR DESCRIPTION
Tested by running very cursory simulation with `vivarium_ciff_sam` using the `child_wasting` model as a test case.