### PR TITLE
fix pandas warning in application of risk effect

### DIFF
--- a/src/vivarium_public_health/risks/data_transformations.py
+++ b/src/vivarium_public_health/risks/data_transformations.py
@@ -274,7 +274,9 @@ def get_exposure_effect(builder, risk: EntityString):
     else:
         def exposure_effect(rates, rr):
             exposure = risk_exposure(rr.index)
-            return rates * (rr.lookup(exposure.index, exposure))
+            df = pd.concat([exposure, rr], axis=1)
+            effect = rates * df.apply(lambda x: x[x[risk.name]], axis=1)
+            return effect
 
     return exposure_effect
 

--- a/src/vivarium_public_health/risks/data_transformations.py
+++ b/src/vivarium_public_health/risks/data_transformations.py
@@ -273,7 +273,7 @@ def get_exposure_effect(builder, risk: EntityString):
             return rates * relative_risk
     else:
         def exposure_effect(rates, rr):
-            exposure = risk_exposure(rr.index)
+            exposure = pd.Series(risk_exposure(rr.index), name=risk.name)
             df = pd.concat([exposure, rr], axis=1)
             effect = rates * df.apply(lambda x: x[x[risk.name]], axis=1)
             return effect


### PR DESCRIPTION
Verified that functionality is the same using `vivarium_ciff_sam`. Also verified that `lookup` is not used anywhere else in the repo