### PR TITLE
use subview when calculating risk propensity

### DIFF
--- a/src/vivarium_public_health/risks/base_risk.py
+++ b/src/vivarium_public_health/risks/base_risk.py
@@ -148,7 +148,12 @@ class Risk:
     def _get_propensity_pipeline(self, builder: Builder) -> Pipeline:
         return builder.value.register_value_producer(
             self.propensity_pipeline_name,
-            source=lambda index: self.population_view.get(index)[self.propensity_column_name],
+            source=lambda index: (
+                self.population_view
+                .subview([self.propensity_column_name])
+                .get(index)
+                .squeeze()
+            ),
             requires_columns=[self.propensity_column_name]
         )
 


### PR DESCRIPTION
## Use subview to pull only needed columns
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-2824](https://jira.ihme.washington.edu/browse/MIC-2824)

When getting the propensity we were getting the full population view which included an unused column which hadn't been created yet. This avoids the error resulting from that by only pulling the subview with the columns required to calculate the propensity pipeline.

### Verification and Testing
Verified by running CIFF simulation without the previously found error.