### PR TITLE
only apply squeeze to columns

### DIFF
--- a/src/vivarium_public_health/risks/base_risk.py
+++ b/src/vivarium_public_health/risks/base_risk.py
@@ -152,7 +152,7 @@ class Risk:
                 self.population_view
                 .subview([self.propensity_column_name])
                 .get(index)
-                .squeeze()
+                .squeeze(axis=1)
             ),
             requires_columns=[self.propensity_column_name]
         )


### PR DESCRIPTION
Without this we are squeezing to a scalar value if there is only one row in the index