### PR TITLE
extend mortality component to account for unmodeled causes

### DIFF
--- a/src/vivarium_public_health/population/mortality.py
+++ b/src/vivarium_public_health/population/mortality.py
@@ -7,7 +7,7 @@ This module contains tools modeling all cause mortality and hooks for
 disease models to contribute cause-specific and excess mortality.
 
 """
-from typing import Callable
+from typing import Callable, Dict, List
 
 import pandas as pd
 from vivarium.framework.engine import Builder
@@ -16,20 +16,36 @@ from vivarium.framework.lookup import LookupTable
 from vivarium.framework.population import PopulationView, SimulantData
 from vivarium.framework.randomness import RandomnessStream
 from vivarium.framework.time import Time
-from vivarium.framework.utilities import rate_to_probability
-from vivarium.framework.values import Pipeline
+from vivarium.framework.values import Pipeline, list_combiner, union_post_processor
 
 
 class Mortality:
+
+    configuration_defaults = {"unmodeled_causes": []}
+
     def __init__(self):
         self._randomness_stream_name = "mortality_handler"
         self.cause_specific_mortality_rate_pipeline_name = "cause_specific_mortality_rate"
         self.mortality_rate_pipeline_name = "mortality_rate"
         self.cause_of_death_column_name = "cause_of_death"
         self.years_of_life_lost_column_name = "years_of_life_lost"
+        self.unmodeled_csmr_pipeline_name = "affected_unmodeled.cause_specific_mortality_rate"
+        self.unmodeled_csmr_paf_pipeline_name = f"{self.unmodeled_csmr_pipeline_name}.paf"
+        self.all_cause_mortality_hazard_pipeline_name = "all_causes.mortality_hazard"
+        self.all_cause_mortality_hazard_paf_pipeline_name = (
+            f"{self.all_cause_mortality_hazard_pipeline_name}.paf"
+        )
 
     def __repr__(self) -> str:
         return f"Mortality()"
+
+    ##########################
+    # Initialization methods #
+    ##########################
+
+    # noinspection PyMethodMayBeStatic
+    def _get_configuration_defaults(self) -> Dict[str, List]:
+        return {"unmodeled_causes": Mortality.configuration_defaults["unmodeled_causes"]}
 
     ##############
     # Properties #
@@ -47,10 +63,19 @@ class Mortality:
     def setup(self, builder: Builder) -> None:
         self.random = self._get_randomness_stream(builder)
         self.clock = self._get_clock(builder)
-        self.all_cause_mortality_rate = self._get_all_cause_mortality_rate(builder)
+
         self.cause_specific_mortality_rate = self._get_cause_specific_mortality_rate(builder)
         self.mortality_rate = self._get_mortality_rate(builder)
+
+        self.all_cause_mortality_rate = self._get_all_cause_mortality_rate(builder)
         self.life_expectancy = self._get_life_expectancy(builder)
+
+        self._raw_unmodeled_csmr = self._get_raw_unmodeled_csmr(builder)
+        self.unmodeled_csmr = self._get_unmodeled_csmr(builder)
+        self.unmodeled_csmr_paf = self._get_unmodeled_csmr_paf(builder)
+        self.mortality_hazard = self._get_mortality_hazard(builder)
+        self._mortality_hazard_paf = self._get_mortality_hazard_paf(builder)
+
         self.population_view = self._get_population_view(builder)
 
         self._register_simulant_initializer(builder)
@@ -62,13 +87,6 @@ class Mortality:
     # noinspection PyMethodMayBeStatic
     def _get_clock(self, builder: Builder) -> Callable[[], Time]:
         return builder.time.clock()
-
-    # noinspection PyMethodMayBeStatic
-    def _get_all_cause_mortality_rate(self, builder: Builder) -> LookupTable:
-        acmr_data = builder.data.load("cause.all_causes.cause_specific_mortality_rate")
-        return builder.lookup.build_table(
-            acmr_data, key_columns=["sex"], parameter_columns=["age", "year"]
-        )
 
     def _get_cause_specific_mortality_rate(self, builder: Builder) -> Pipeline:
         return builder.value.register_value_producer(
@@ -84,11 +102,67 @@ class Mortality:
         )
 
     # noinspection PyMethodMayBeStatic
+    def _get_all_cause_mortality_rate(self, builder: Builder) -> LookupTable:
+        acmr_data = builder.data.load("cause.all_causes.cause_specific_mortality_rate")
+        return builder.lookup.build_table(
+            acmr_data, key_columns=["sex"], parameter_columns=["age", "year"]
+        )
+
+    # noinspection PyMethodMayBeStatic
     def _get_life_expectancy(self, builder: Builder) -> LookupTable:
         life_expectancy_data = builder.data.load(
             "population.theoretical_minimum_risk_life_expectancy"
         )
         return builder.lookup.build_table(life_expectancy_data, parameter_columns=["age"])
+
+    # noinspection PyMethodMayBeStatic
+    def _get_raw_unmodeled_csmr(self, builder: Builder) -> LookupTable:
+        unmodeled_causes = builder.configuration.unmodeled_causes
+        raw_csmr = 0.0
+        for idx, cause in enumerate(unmodeled_causes):
+            csmr = f"cause.{cause}.cause_specific_mortality_rate"
+            if 0 == idx:
+                raw_csmr = builder.data.load(csmr)
+            else:
+                raw_csmr.loc[:, "value"] += builder.data.load(csmr).value
+
+        additional_parameters = (
+            {"key_columns": ["sex"], "parameter_columns": ["age", "year"]}
+            if unmodeled_causes
+            else {}
+        )
+
+        return builder.lookup.build_table(raw_csmr, **additional_parameters)
+
+    def _get_unmodeled_csmr(self, builder: Builder) -> Pipeline:
+        return builder.value.register_value_producer(
+            self.unmodeled_csmr_pipeline_name,
+            source=self._get_unmodeled_csmr_source,
+            requires_columns=["age", "sex"],
+        )
+
+    def _get_unmodeled_csmr_paf(self, builder: Builder) -> Pipeline:
+        unmodeled_csmr_paf = builder.lookup.build_table(0)
+        return builder.value.register_value_producer(
+            self.unmodeled_csmr_paf_pipeline_name,
+            source=lambda index: [unmodeled_csmr_paf(index)],
+            preferred_combiner=list_combiner,
+            preferred_post_processor=union_post_processor,
+        )
+
+    def _get_mortality_hazard(self, builder: Builder) -> Pipeline:
+        return builder.value.register_value_producer(
+            self.all_cause_mortality_hazard_pipeline_name,
+            source=self._get_mortality_hazard_source,
+        )
+
+    def _get_mortality_hazard_paf(self, builder: Builder) -> Pipeline:
+        return builder.value.register_value_producer(
+            self.all_cause_mortality_hazard_paf_pipeline_name,
+            source=lambda index: [pd.Series(0, index=index)],
+            preferred_combiner=list_combiner,
+            preferred_post_processor=union_post_processor,
+        )
 
     def _get_population_view(self, builder: Builder) -> PopulationView:
         return builder.population.get_view(
@@ -99,7 +173,6 @@ class Mortality:
                 "exit_time",
                 "age",
                 "sex",
-                "location",
             ]
         )
 
@@ -131,20 +204,25 @@ class Mortality:
 
     def on_time_step(self, event: Event) -> None:
         pop = self.population_view.get(event.index, query="alive =='alive'")
-        prob_df = rate_to_probability(pd.DataFrame(self.mortality_rate(pop.index)))
-        prob_df["no_death"] = 1 - prob_df.sum(axis=1)
-        prob_df["cause_of_death"] = self.random.choice(
-            prob_df.index, prob_df.columns, prob_df
+        mortality_hazard = self.mortality_hazard(pop.index)
+        deaths = self.random.filter_for_rate(
+            pop.index, mortality_hazard, additional_key="death"
         )
-        dead_pop = prob_df.query('cause_of_death != "no_death"').copy()
-
-        if not dead_pop.empty:
-            dead_pop["alive"] = pd.Series("dead", index=dead_pop.index)
-            dead_pop["exit_time"] = event.time
-            dead_pop["years_of_life_lost"] = self.life_expectancy(dead_pop.index)
-            self.population_view.update(
-                dead_pop[["alive", "exit_time", "cause_of_death", "years_of_life_lost"]]
+        if not deaths.empty:
+            cause_of_death_weights = self.mortality_rate(deaths).divide(
+                mortality_hazard.loc[deaths], axis=0
             )
+            cause_of_death = self.random.choice(
+                deaths,
+                cause_of_death_weights.columns,
+                cause_of_death_weights,
+                additional_key="cause_of_death",
+            )
+            pop.loc[deaths, "alive"] = "dead"
+            pop.loc[deaths, "exit_time"] = event.time
+            pop.loc[deaths, "years_of_life_lost"] = self.life_expectancy(deaths)
+            pop.loc[deaths, "cause_of_death"] = cause_of_death
+            self.population_view.update(pop)
 
     ##################################
     # Pipeline sources and modifiers #
@@ -152,6 +230,21 @@ class Mortality:
 
     def _calculate_mortality_rate(self, index: pd.Index) -> pd.DataFrame:
         acmr = self.all_cause_mortality_rate(index)
-        csmr = self.cause_specific_mortality_rate(index, skip_post_processor=True)
-        cause_deleted_mortality_rate = acmr - csmr
+        modeled_csmr = self.cause_specific_mortality_rate(index)
+        unmodeled_csmr_raw = self._raw_unmodeled_csmr(index)
+        unmodeled_csmr = self.unmodeled_csmr(index)
+        cause_deleted_mortality_rate = (
+            acmr - modeled_csmr - unmodeled_csmr_raw + unmodeled_csmr
+        )
         return pd.DataFrame({"other_causes": cause_deleted_mortality_rate})
+
+    def _get_unmodeled_csmr_source(self, index: pd.Index) -> pd.Series:
+        raw_csmr = self._raw_unmodeled_csmr(index)
+        paf = self.unmodeled_csmr_paf(index)
+        return raw_csmr * (1 - paf)
+
+    def _get_mortality_hazard_source(self, index: pd.Index) -> pd.Series:
+        mortality_rates = pd.DataFrame(self.mortality_rate(index))
+        mortality_hazard = mortality_rates.sum(axis=1)
+        paf = self._mortality_hazard_paf(index)
+        return mortality_hazard * (1 - paf)

--- a/src/vivarium_public_health/population/mortality.py
+++ b/src/vivarium_public_health/population/mortality.py
@@ -7,7 +7,7 @@ This module contains tools modeling all cause mortality and hooks for
 disease models to contribute cause-specific and excess mortality.
 
 """
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Union
 
 import pandas as pd
 from vivarium.framework.engine import Builder
@@ -102,21 +102,21 @@ class Mortality:
         )
 
     # noinspection PyMethodMayBeStatic
-    def _get_all_cause_mortality_rate(self, builder: Builder) -> LookupTable:
+    def _get_all_cause_mortality_rate(self, builder: Builder) -> Union[LookupTable, Pipeline]:
         acmr_data = builder.data.load("cause.all_causes.cause_specific_mortality_rate")
         return builder.lookup.build_table(
             acmr_data, key_columns=["sex"], parameter_columns=["age", "year"]
         )
 
     # noinspection PyMethodMayBeStatic
-    def _get_life_expectancy(self, builder: Builder) -> LookupTable:
+    def _get_life_expectancy(self, builder: Builder) -> Union[LookupTable, Pipeline]:
         life_expectancy_data = builder.data.load(
             "population.theoretical_minimum_risk_life_expectancy"
         )
         return builder.lookup.build_table(life_expectancy_data, parameter_columns=["age"])
 
     # noinspection PyMethodMayBeStatic
-    def _get_raw_unmodeled_csmr(self, builder: Builder) -> LookupTable:
+    def _get_raw_unmodeled_csmr(self, builder: Builder) -> Union[LookupTable, Pipeline]:
         unmodeled_causes = builder.configuration.unmodeled_causes
         raw_csmr = 0.0
         for idx, cause in enumerate(unmodeled_causes):

--- a/src/vivarium_public_health/treatment/scale_up.py
+++ b/src/vivarium_public_health/treatment/scale_up.py
@@ -102,7 +102,9 @@ class LinearScaleUp:
         self.is_intervention_scenario = self._get_is_intervention_scenario(builder)
         self.clock = self._get_clock(builder)
         self.scale_up_start_date, self.scale_up_end_date = self._get_scale_up_dates(builder)
-        self.scale_up_start_value, self.scale_up_end_value = self._get_scale_up_values(builder)
+        self.scale_up_start_value, self.scale_up_end_value = self._get_scale_up_values(
+            builder
+        )
 
         required_columns = self._get_required_columns()
         self.pipelines = self._get_required_pipelines(builder)
@@ -122,7 +124,7 @@ class LinearScaleUp:
 
     # noinspection PyMethodMayBeStatic
     def _get_scale_up_dates(self, builder: Builder) -> Tuple[datetime, datetime]:
-        scale_up_config = builder.configuration[self.configuration_key]['date']
+        scale_up_config = builder.configuration[self.configuration_key]["date"]
 
         def get_endpoint(endpoint_type: str) -> datetime:
             if scale_up_config[endpoint_type] == endpoint_type:
@@ -173,9 +175,8 @@ class LinearScaleUp:
         if not self.is_intervention_scenario or self.clock() < self.scale_up_start_date:
             progress = 0.0
         elif self.scale_up_start_date <= self.clock() < self.scale_up_end_date:
-            progress = (
-                (self.clock() - self.scale_up_start_date) /
-                (self.scale_up_end_date - self.scale_up_start_date)
+            progress = (self.clock() - self.scale_up_start_date) / (
+                self.scale_up_end_date - self.scale_up_start_date
             )
         else:
             progress = 1.0


### PR DESCRIPTION
## Add ability to account for unmodeled causes
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: [MIC-2914](https://jira.ihme.washington.edu/browse/MIC-2914)

Bring in the ability to account for csmr of unmodeled causes from CIFF
Reordered calls in `setup` to highlight the importance of `cause_specific_mortality_rate` and `mortality_rate`

### Testing
Ran CIFF model for a few time-steps with and without unmodeled causes.