### PR TITLE
filter causes without excess mortality or disability from their respe…

### DIFF
--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -13,7 +13,7 @@ from operator import gt, lt
 import pandas as pd
 from vivarium.framework.values import list_combiner, union_post_processor
 
-from vivarium_public_health.utilities import EntityString
+from vivarium_public_health.utilities import EntityString, is_non_zero
 
 
 class RiskAttributableDisease:
@@ -127,6 +127,7 @@ class RiskAttributableDisease:
         self.clock = builder.time.clock()
 
         disability_weight_data = builder.data.load(f"{self.cause}.disability_weight")
+        self.has_disability = is_non_zero(disability_weight_data)
         self.base_disability_weight = builder.lookup.build_table(
             disability_weight_data, key_columns=["sex"], parameter_columns=["age", "year"]
         )
@@ -152,6 +153,7 @@ class RiskAttributableDisease:
         )
 
         excess_mortality_data = self.load_excess_mortality_rate_data(builder)
+        self.has_excess_mortality = is_non_zero(excess_mortality_data)
         self.base_excess_mortality_rate = builder.lookup.build_table(
             excess_mortality_data, key_columns=["sex"], parameter_columns=["age", "year"]
         )

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -10,7 +10,6 @@ from typing import Callable, Dict
 
 import numpy as np
 import pandas as pd
-
 from vivarium.framework.state_machine import State, Transient, Transition
 from vivarium.framework.values import list_combiner, union_post_processor
 

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -10,6 +10,7 @@ from typing import Callable, Dict
 
 import numpy as np
 import pandas as pd
+
 from vivarium.framework.state_machine import State, Transient, Transition
 from vivarium.framework.values import list_combiner, union_post_processor
 
@@ -17,6 +18,7 @@ from vivarium_public_health.disease.transition import (
     ProportionTransition,
     RateTransition,
 )
+from vivarium_public_health.utilities import is_non_zero
 
 
 class BaseDiseaseState(State):
@@ -254,6 +256,7 @@ class DiseaseState(BaseDiseaseState):
         )
 
         disability_weight_data = self.load_disability_weight_data(builder)
+        self.has_disability = is_non_zero(disability_weight_data)
         self.base_disability_weight = builder.lookup.build_table(
             disability_weight_data, key_columns=["sex"], parameter_columns=["age", "year"]
         )
@@ -267,6 +270,7 @@ class DiseaseState(BaseDiseaseState):
         )
 
         excess_mortality_data = self.load_excess_mortality_rate_data(builder)
+        self.has_excess_mortality = is_non_zero(excess_mortality_data)
         self.base_excess_mortality_rate = builder.lookup.build_table(
             excess_mortality_data, key_columns=["sex"], parameter_columns=["age", "year"]
         )

--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -113,9 +113,11 @@ class DisabilityObserver:
 
     # noinspection PyMethodMayBeStatic
     def _get_cause_components(
-            self, builder: Builder
+        self, builder: Builder
     ) -> List[Union[DiseaseState, RiskAttributableDisease]]:
-        return builder.components.get_components_by_type((DiseaseState, RiskAttributableDisease))
+        return builder.components.get_components_by_type(
+            (DiseaseState, RiskAttributableDisease)
+        )
 
     # noinspection PyMethodMayBeStatic
     def _get_population_view(self, builder: Builder) -> PopulationView:

--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -93,9 +93,11 @@ class MortalityObserver:
 
     # noinspection PyMethodMayBeStatic
     def _get_cause_components(
-            self, builder: Builder
+        self, builder: Builder
     ) -> List[Union[DiseaseState, RiskAttributableDisease]]:
-        return builder.components.get_components_by_type((DiseaseState, RiskAttributableDisease))
+        return builder.components.get_components_by_type(
+            (DiseaseState, RiskAttributableDisease)
+        )
 
     # noinspection PyMethodMayBeStatic
     def _get_population_view(self, builder: Builder) -> PopulationView:

--- a/src/vivarium_public_health/utilities.py
+++ b/src/vivarium_public_health/utilities.py
@@ -10,7 +10,6 @@ vivarium_public_health components.
 from typing import Iterable, Union
 
 import pandas as pd
-
 from vivarium.framework.lookup import ScalarValue
 
 

--- a/src/vivarium_public_health/utilities.py
+++ b/src/vivarium_public_health/utilities.py
@@ -7,9 +7,11 @@ This module contains utility classes and functions for use across
 vivarium_public_health components.
 
 """
-from typing import Union
+from typing import Iterable, Union
 
 import pandas as pd
+
+from vivarium.framework.lookup import ScalarValue
 
 
 class EntityString(str):
@@ -80,3 +82,14 @@ def to_time_delta(span_in_days: Union[int, float, str]):
 def to_years(time: pd.Timedelta) -> float:
     """Converts a time delta to a float for years."""
     return time / pd.Timedelta(days=DAYS_PER_YEAR)
+
+
+def is_non_zero(data: Union[Iterable[ScalarValue], ScalarValue, pd.DataFrame]) -> bool:
+    if isinstance(data, pd.DataFrame):
+        attribute_sum = data.value.sum()
+    elif isinstance(data, Iterable):
+        attribute_sum = sum(data)
+    else:
+        attribute_sum = data
+
+    return attribute_sum != 0.0


### PR DESCRIPTION
…ctive observers

## Filter out irrelevant causes from Mortality and Disability observers
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: [MIC-2982](https://jira.ihme.washington.edu/browse/MIC-2982)

Filter out causes that have no excess mortality from the MortalityObserver
Filter out causes that have no disability from the DisabilityObserver

This has to happen in post_setup, because all DiseaseState components must be set-up prior to the observers

### Testing
Ran toy version of CIFF