### PR TITLE
Define RiskAttributableDisease transitions as TransitionStrings

### DIFF
--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -12,9 +12,8 @@ from operator import gt, lt
 
 import pandas as pd
 from vivarium.framework.values import list_combiner, union_post_processor
-
-from vivarium_public_health.utilities import EntityString, is_non_zero
 from vivarium_public_health.disease.transition import TransitionString
+from vivarium_public_health.utilities import EntityString, is_non_zero
 
 
 class RiskAttributableDisease:
@@ -102,7 +101,9 @@ class RiskAttributableDisease:
             ]
         }
         self._state_names = [f"{self.cause.name}", f"susceptible_to_{self.cause.name}"]
-        self._transition_names = [TransitionString(f"susceptible_to_{self.cause.name}_TO_{self.cause.name}")]
+        self._transition_names = [
+            TransitionString(f"susceptible_to_{self.cause.name}_TO_{self.cause.name}")
+        ]
 
         self.excess_mortality_rate_pipeline_name = f"{self.cause.name}.excess_mortality_rate"
         self.excess_mortality_rate_paf_pipeline_name = (

--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -14,6 +14,7 @@ import pandas as pd
 from vivarium.framework.values import list_combiner, union_post_processor
 
 from vivarium_public_health.utilities import EntityString, is_non_zero
+from vivarium_public_health.disease.transition import TransitionString
 
 
 class RiskAttributableDisease:
@@ -101,7 +102,7 @@ class RiskAttributableDisease:
             ]
         }
         self._state_names = [f"{self.cause.name}", f"susceptible_to_{self.cause.name}"]
-        self._transition_names = [f"susceptible_to_{self.cause.name}_TO_{self.cause.name}"]
+        self._transition_names = [TransitionString(f"susceptible_to_{self.cause.name}_TO_{self.cause.name}")]
 
         self.excess_mortality_rate_pipeline_name = f"{self.cause.name}.excess_mortality_rate"
         self.excess_mortality_rate_paf_pipeline_name = (
@@ -323,7 +324,7 @@ class RiskAttributableDisease:
     def adjust_state_and_transitions(self):
         if self.recoverable:
             self._transition_names.append(
-                f"{self.cause.name}_TO_susceptible_to_{self.cause.name}"
+                TransitionString(f"{self.cause.name}_TO_susceptible_to_{self.cause.name}")
             )
 
     def load_cause_specific_mortality_rate_data(self, builder):

--- a/tests/disease/test_special_disease.py
+++ b/tests/disease/test_special_disease.py
@@ -141,9 +141,9 @@ def test_state_transition_names(disease, recoverable):
     model.adjust_state_and_transitions()
     states = [disease, f"susceptible_to_{disease}"]
     transitions = [
-        f"susceptible_to_{disease}_TO_{disease}",
+        TransitionString(f"susceptible_to_{disease}_TO_{disease}"),
     ]
     if recoverable:
-        transitions.append(f"{disease}_TO_susceptible_to_{disease}")
+        transitions.append(TransitionString(f"{disease}_TO_susceptible_to_{disease}"))
     assert set(model.state_names) == set(states)
     assert set(model.transition_names) == set(transitions)

--- a/tests/disease/test_special_disease.py
+++ b/tests/disease/test_special_disease.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from vivarium_public_health.disease import RiskAttributableDisease
+from vivarium_public_health.disease.transition import TransitionString
 
 
 @pytest.fixture

--- a/tests/disease/test_special_disease.py
+++ b/tests/disease/test_special_disease.py
@@ -3,7 +3,6 @@ from operator import gt, lt
 import numpy as np
 import pandas as pd
 import pytest
-
 from vivarium_public_health.disease import RiskAttributableDisease
 from vivarium_public_health.disease.transition import TransitionString
 
@@ -129,10 +128,7 @@ def test_mortality_rate_pandas_dataframe(disease_mock):
     assert np.all(expected == disease.adjust_mortality_rate(test_index, rates_df))
 
 
-test_data = [
-    ("disease_no_recovery", False),
-    ("disease_with_recovery", True),
-]
+test_data = [("disease_no_recovery", False), ("disease_with_recovery", True)]
 
 
 @pytest.mark.parametrize("disease, recoverable", test_data)
@@ -141,9 +137,7 @@ def test_state_transition_names(disease, recoverable):
     model.recoverable = recoverable
     model.adjust_state_and_transitions()
     states = [disease, f"susceptible_to_{disease}"]
-    transitions = [
-        TransitionString(f"susceptible_to_{disease}_TO_{disease}"),
-    ]
+    transitions = [TransitionString(f"susceptible_to_{disease}_TO_{disease}")]
     if recoverable:
         transitions.append(TransitionString(f"{disease}_TO_susceptible_to_{disease}"))
     assert set(model.state_names) == set(states)


### PR DESCRIPTION
## Title: Define RiskAttributableDisease transitions as TransitionStrings

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3038](https://jira.ihme.washington.edu/browse/MIC-3038)

### Testing
Successfully ran a single non-parallel run for South Asia. Ran test_state_transition_names with two test cases.