### PR TITLE
clean up mortality component and improve documentation

### DIFF
--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -12,6 +12,7 @@ from operator import gt, lt
 
 import pandas as pd
 from vivarium.framework.values import list_combiner, union_post_processor
+
 from vivarium_public_health.disease.transition import TransitionString
 from vivarium_public_health.utilities import EntityString, is_non_zero
 

--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -145,7 +145,7 @@ class MortalityObserver:
                 cause_mask = pop_died["cause_of_death"] == cause
                 pop_died_of_cause = pop_died[group_mask & cause_mask]
                 new_observations = {
-                    f"death_due_to_{cause}_{label}": pop_died_of_cause.size,
+                    f"death_due_to_{cause}_{label}": pop_died_of_cause.index.size,
                     f"ylls_due_to_{cause}_{label}": pop_died_of_cause[
                         "years_of_life_lost"
                     ].sum(),

--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -32,6 +32,7 @@ class Source:
     the name of the column or pipeline being used as the source. If the source
     is of type clock, the name should be something descriptive and unique.
     """
+
     name: str
     type: SourceType
 
@@ -56,6 +57,7 @@ class StratificationLevel:
     stratification by time, and in particular stratification by year. By
     default, this will return all categories.
     """
+
     name: str
     sources: List[Source]
     categories: Set[str]

--- a/src/vivarium_public_health/population/mortality.py
+++ b/src/vivarium_public_health/population/mortality.py
@@ -3,11 +3,48 @@
 The Core Mortality Model
 ========================
 
-This module contains tools modeling all cause mortality and hooks for
-disease models to contribute cause-specific and excess mortality.
+Summary
+=======
+
+The mortality component models all cause mortality and allows for disease
+models to contribute cause specific mortality. At each timestep the currently
+"alive" population is subjected to a mortality event using the mortality rate to
+determine probabilities of death for each simulant. A weighted probable cause of
+death is used to choose the cause of death. The years of life lost are
+calculated by subtracting a simulant's age from the population TMRLE and the
+population is updated.
+
+Columns Created
+===============
+
+ - cause_of_death
+ - years_of_life_lost
+
+Pipelines Exposed
+=================
+
+ - cause_specific_mortality_rate
+ - mortality_rate
+ - affected_unmodeled.cause_specific_mortality_rate
+ - affected_unmodeled.cause_specific_mortality_rate.paf
+
+
+All cause mortality is read from the artifact (GBD). At setup cause specific
+mortality is initialized to an empty table. As disease models are registered,
+they affect cause specific mortality by means of
+the cause_specific_mortality_rate pipeline. This is population level data.
+
+If there are causes of death which are unmodeled, but may be impacted by some
+modeled entity, they can be specified using the configuration key
+"unmodeled_causes".
+
+The mortality component's mortality_rate pipeline reflects the
+cause deleted mortality rate (ACMR - CSMR). Then the impact of unmodeled causes
+on mortality is calculated, by subtracting the raw unmodeled csmr before adding
+back the modified unmodeled csmr.
 
 """
-from typing import Callable, Dict, List, Union
+from typing import Dict, List, Union
 
 import pandas as pd
 from vivarium.framework.engine import Builder
@@ -15,7 +52,6 @@ from vivarium.framework.event import Event
 from vivarium.framework.lookup import LookupTable
 from vivarium.framework.population import PopulationView, SimulantData
 from vivarium.framework.randomness import RandomnessStream
-from vivarium.framework.time import Time
 from vivarium.framework.values import Pipeline, list_combiner, union_post_processor
 
 
@@ -25,16 +61,14 @@ class Mortality:
 
     def __init__(self):
         self._randomness_stream_name = "mortality_handler"
-        self.cause_specific_mortality_rate_pipeline_name = "cause_specific_mortality_rate"
-        self.mortality_rate_pipeline_name = "mortality_rate"
+
         self.cause_of_death_column_name = "cause_of_death"
         self.years_of_life_lost_column_name = "years_of_life_lost"
+
+        self.cause_specific_mortality_rate_pipeline_name = "cause_specific_mortality_rate"
+        self.mortality_rate_pipeline_name = "mortality_rate"
         self.unmodeled_csmr_pipeline_name = "affected_unmodeled.cause_specific_mortality_rate"
         self.unmodeled_csmr_paf_pipeline_name = f"{self.unmodeled_csmr_pipeline_name}.paf"
-        self.all_cause_mortality_hazard_pipeline_name = "all_causes.mortality_hazard"
-        self.all_cause_mortality_hazard_paf_pipeline_name = (
-            f"{self.all_cause_mortality_hazard_pipeline_name}.paf"
-        )
 
     def __repr__(self) -> str:
         return f"Mortality()"
@@ -62,7 +96,7 @@ class Mortality:
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
         self.random = self._get_randomness_stream(builder)
-        self.clock = self._get_clock(builder)
+        self.clock = builder.time.clock()
 
         self.cause_specific_mortality_rate = self._get_cause_specific_mortality_rate(builder)
         self.mortality_rate = self._get_mortality_rate(builder)
@@ -73,8 +107,6 @@ class Mortality:
         self._raw_unmodeled_csmr = self._get_raw_unmodeled_csmr(builder)
         self.unmodeled_csmr = self._get_unmodeled_csmr(builder)
         self.unmodeled_csmr_paf = self._get_unmodeled_csmr_paf(builder)
-        self.mortality_hazard = self._get_mortality_hazard(builder)
-        self._mortality_hazard_paf = self._get_mortality_hazard_paf(builder)
 
         self.population_view = self._get_population_view(builder)
 
@@ -83,10 +115,6 @@ class Mortality:
 
     def _get_randomness_stream(self, builder) -> RandomnessStream:
         return builder.randomness.get_stream(self._randomness_stream_name)
-
-    # noinspection PyMethodMayBeStatic
-    def _get_clock(self, builder: Builder) -> Callable[[], Time]:
-        return builder.time.clock()
 
     def _get_cause_specific_mortality_rate(self, builder: Builder) -> Pipeline:
         return builder.value.register_value_producer(
@@ -150,20 +178,6 @@ class Mortality:
             preferred_post_processor=union_post_processor,
         )
 
-    def _get_mortality_hazard(self, builder: Builder) -> Pipeline:
-        return builder.value.register_value_producer(
-            self.all_cause_mortality_hazard_pipeline_name,
-            source=self._get_mortality_hazard_source,
-        )
-
-    def _get_mortality_hazard_paf(self, builder: Builder) -> Pipeline:
-        return builder.value.register_value_producer(
-            self.all_cause_mortality_hazard_paf_pipeline_name,
-            source=lambda index: [pd.Series(0, index=index)],
-            preferred_combiner=list_combiner,
-            preferred_post_processor=union_post_processor,
-        )
-
     def _get_population_view(self, builder: Builder) -> PopulationView:
         return builder.population.get_view(
             [
@@ -204,12 +218,13 @@ class Mortality:
 
     def on_time_step(self, event: Event) -> None:
         pop = self.population_view.get(event.index, query="alive =='alive'")
-        mortality_hazard = self.mortality_hazard(pop.index)
+        mortality_rates = self.mortality_rate(pop.index)
+        mortality_hazard = mortality_rates.sum(axis=1)
         deaths = self.random.filter_for_rate(
             pop.index, mortality_hazard, additional_key="death"
         )
         if not deaths.empty:
-            cause_of_death_weights = self.mortality_rate(deaths).divide(
+            cause_of_death_weights = mortality_rates.loc[deaths, :].divide(
                 mortality_hazard.loc[deaths], axis=0
             )
             cause_of_death = self.random.choice(
@@ -242,9 +257,3 @@ class Mortality:
         raw_csmr = self._raw_unmodeled_csmr(index)
         paf = self.unmodeled_csmr_paf(index)
         return raw_csmr * (1 - paf)
-
-    def _get_mortality_hazard_source(self, index: pd.Index) -> pd.Series:
-        mortality_rates = pd.DataFrame(self.mortality_rate(index))
-        mortality_hazard = mortality_rates.sum(axis=1)
-        paf = self._mortality_hazard_paf(index)
-        return mortality_hazard * (1 - paf)

--- a/tests/disease/test_special_disease.py
+++ b/tests/disease/test_special_disease.py
@@ -3,6 +3,7 @@ from operator import gt, lt
 import numpy as np
 import pandas as pd
 import pytest
+
 from vivarium_public_health.disease import RiskAttributableDisease
 from vivarium_public_health.disease.transition import TransitionString
 


### PR DESCRIPTION
## Simplify mortality component 
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: [MIC-3045](https://jira.ihme.washington.edu/browse/MIC-3045)

Simplify the mortality component. Removed two unnecessary pipelines that introduced unnecessary indirection and code opacity.
Added documentation. 

### Testing
Running on MNCH Child model