### PR TITLE
Bugfix/mortality observer totals

### DIFF
--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -162,8 +162,8 @@ class MortalityObserver:
         the_living = pop[(pop.alive == "alive") & pop.tracked]
         the_dead = pop[pop.alive == "dead"]
         metrics["years_of_life_lost"] = the_dead["years_of_life_lost"].sum()
-        metrics["total_population_living"] = the_living.index.size
-        metrics["total_population_dead"] = the_dead.index.size
+        metrics["total_population_living"] = len(the_living)
+        metrics["total_population_dead"] = len(the_dead.size)
         metrics.update(self.counts)
 
         return metrics

--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -162,8 +162,8 @@ class MortalityObserver:
         the_living = pop[(pop.alive == "alive") & pop.tracked]
         the_dead = pop[pop.alive == "dead"]
         metrics["years_of_life_lost"] = the_dead["years_of_life_lost"].sum()
-        metrics["total_population_living"] = the_living.size
-        metrics["total_population_dead"] = the_dead.size
+        metrics["total_population_living"] = the_living.index.size
+        metrics["total_population_dead"] = the_dead.index.size
         metrics.update(self.counts)
 
         return metrics

--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -163,7 +163,7 @@ class MortalityObserver:
         the_dead = pop[pop.alive == "dead"]
         metrics["years_of_life_lost"] = the_dead["years_of_life_lost"].sum()
         metrics["total_population_living"] = len(the_living)
-        metrics["total_population_dead"] = len(the_dead.size)
+        metrics["total_population_dead"] = len(the_dead)
         metrics.update(self.counts)
 
         return metrics


### PR DESCRIPTION
## Bugfix Mortality Observer Totals

- *Category*: Bugfix
- *JIRA issue*: [MIC-3089](https://jira.ihme.washington.edu/browse/MIC-3089)

Updated metrics call to use dataframe length to count total living and total deaths in simulation population instead of dataframe size which was producing incorrect results for the totals.

### Testing
Tested observer to make sure correct total counts were produced and successfully ran parallel runs on an editable install.
