### PR TITLE
fix issue due applying mapper to empty data frame producing data fram…

### DIFF
--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -85,11 +85,11 @@ class StratificationLevel:
         categories = self.categories
         mapper = self.mapper if self.mapper else self._default_mapper
 
-        def wrapped_mapper(row: pd.Series) -> str:
+        def wrapped_mapper(row: pd.Series) -> pd.Series:
             category = mapper(row)
             if category not in categories:
                 raise ValueError(f"Invalid value '{category}' found in {name}.")
-            return category
+            return pd.Series(category)
 
         self.mapper = wrapped_mapper
 
@@ -351,6 +351,7 @@ class ResultsStratifier:
         stratification_groups = [
             sources[[source.name for source in stratification_level.sources]]
             .apply(stratification_level.mapper, axis=1)
+            .squeeze(axis=1)
             .rename(stratification_level.name)
             for stratification_level in self.stratification_levels.values()
         ]


### PR DESCRIPTION
…e rather than series

## Fix issue due applying mapper to empty DataFrame producing DataFrame rather than Series
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-3095](https://jira.ihme.washington.edu/browse/MIC-3095)

When the mapper returns a str, applying the mapper produces a result of ambiguous type. If the DataFrame it is being applied to is non-empty it produces a Series, but if it is empty, it produces a DataFrame.

Fixed this by making the mapper return a Series, so applying it always returns a DataFrame with one column, and then squeezing it back to a Series

### Testing
Tested by running in the MNCH Child Sim with and without an empty population.