### PR TITLE
Bugfix/sbachmei/mic 3304 register collect metrics listener

### DIFF
--- a/src/vivarium_public_health/metrics/disease.py
+++ b/src/vivarium_public_health/metrics/disease.py
@@ -181,7 +181,6 @@ class DiseaseObserver:
         pop = self.population_view.get(
             event.index, query='tracked == True and alive == "alive"'
         )
-        # SDB - Here, pop.ischemic_stroke != pop.previous_ischemic_stroke returns all False? This means no counts are updated.
         groups = self.stratifier.group(pop.index, self.config.include, self.config.exclude)
         for label, group_mask in groups:
             for transition in self.transitions:
@@ -194,7 +193,6 @@ class DiseaseObserver:
                     f"{self.disease}_{transition}_event_count_{label}": transition_mask.sum()
                 }
                 self.counts.update(new_observations)
-                print(transition_mask.sum())
 
     ##################################
     # Pipeline sources and modifiers #

--- a/src/vivarium_public_health/metrics/disease.py
+++ b/src/vivarium_public_health/metrics/disease.py
@@ -138,7 +138,7 @@ class DiseaseObserver:
         builder.event.register_listener("time_step__prepare", self.on_time_step_prepare)
 
     def _register_collect_metrics_listener(self, builder: Builder) -> None:
-        builder.event.register_listener("time_step", self.on_collect_metrics)
+        builder.event.register_listener("collect_metrics", self.on_collect_metrics)
 
     def _register_metrics_modifier(self, builder: Builder) -> None:
         builder.value.register_value_modifier(
@@ -181,7 +181,9 @@ class DiseaseObserver:
         pop = self.population_view.get(
             event.index, query='tracked == True and alive == "alive"'
         )
+        # SDB - Here, pop.ischemic_stroke != pop.previous_ischemic_stroke returns all False? This means no counts are updated.
         groups = self.stratifier.group(pop.index, self.config.include, self.config.exclude)
+        breakpoint()
         for label, group_mask in groups:
             for transition in self.transitions:
                 transition_mask = (
@@ -193,6 +195,9 @@ class DiseaseObserver:
                     f"{self.disease}_{transition}_event_count_{label}": transition_mask.sum()
                 }
                 self.counts.update(new_observations)
+                print(transition_mask.sum())
+        breakpoint()
+        print('')
 
     ##################################
     # Pipeline sources and modifiers #

--- a/src/vivarium_public_health/metrics/disease.py
+++ b/src/vivarium_public_health/metrics/disease.py
@@ -183,7 +183,6 @@ class DiseaseObserver:
         )
         # SDB - Here, pop.ischemic_stroke != pop.previous_ischemic_stroke returns all False? This means no counts are updated.
         groups = self.stratifier.group(pop.index, self.config.include, self.config.exclude)
-        breakpoint()
         for label, group_mask in groups:
             for transition in self.transitions:
                 transition_mask = (
@@ -196,8 +195,6 @@ class DiseaseObserver:
                 }
                 self.counts.update(new_observations)
                 print(transition_mask.sum())
-        breakpoint()
-        print('')
 
     ##################################
     # Pipeline sources and modifiers #


### PR DESCRIPTION
## Title: Incorrect register collect_metrics_listener 

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3304](https://jira.ihme.washington.edu/browse/MIC-3304)

The collect_metrics_listener was being registered during "time_step" instead
of on "collect_metrics". The symptom of this was the state counts were always
0.

### Testing
did a small test run with the cvd repo and am now seeing non-zero counts.

