### PR TITLE
Implement ResultsStratifier, update tests

### DIFF
--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -77,7 +77,7 @@ class ResultsStratifier:
 
         Returns
         ------
-        pd.Series
+        pandas.Series
             A pd.Series with age group name string corresponding to the pop passed into the function
         """
         bins = self.age_bins.age_start.to_list() + [self.age_bins.age_end.iloc[-1]]
@@ -96,7 +96,7 @@ class ResultsStratifier:
 
         Returns
         ------
-        pd.Series
+        pandas.Series
             A pd.Series with years corresponding to the pop passed into the function
         """
         return pop.squeeze(axis=1).dt.year

--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -77,7 +77,8 @@ class ResultsStratifier:
 
         Returns
         ------
-        A pd.Series with age group name string corresponding to the pop passed into the function
+        result
+            A pd.Series with age group name string corresponding to the pop passed into the function
         """
         bins = self.age_bins.age_start.to_list() + [self.age_bins.age_end.iloc[-1]]
         labels = self.age_bins["age_group_name"].to_list()
@@ -95,7 +96,8 @@ class ResultsStratifier:
 
         Returns
         ------
-        A pd.Series with years corresponding to the pop passed into the function
+        result
+            A pd.Series with years corresponding to the pop passed into the function
         """
         return pop.squeeze(axis=1).dt.year
 

--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -21,13 +21,13 @@ class ResultsStratifier:
     }
 
     def setup(self, builder: Builder):
-        self.config = builder.configuration.stratification
         self.age_bins = self.get_age_bins(builder)
-
         self.start_year = builder.configuration.time.start.year
         self.end_year = builder.configuration.time.end.year
 
-        builder.results.set_default_stratifications(self.config.stratification.default)
+        builder.results.set_default_stratifications(
+            builder.configuration.stratification.default
+        )
         self.register_stratifications(builder)
 
     def register_stratifications(self, builder: Builder) -> None:
@@ -80,9 +80,9 @@ class ResultsStratifier:
         pandas.Series
             A pd.Series with age group name string corresponding to the pop passed into the function
         """
-        bins = self.age_bins.age_start.to_list() + [self.age_bins.age_end.iloc[-1]]
+        bins = self.age_bins["age_start"].to_list() + [self.age_bins["age_end"].iloc[-1]]
         labels = self.age_bins["age_group_name"].to_list()
-        age_group = pd.cut(pop["age"], bins, labels=labels).rename("age_group")
+        age_group = pd.cut(pop.squeeze(axis=1), bins, labels=labels).rename("age_group")
         return age_group
 
     @staticmethod
@@ -102,7 +102,7 @@ class ResultsStratifier:
         return pop.squeeze(axis=1).dt.year
 
     @staticmethod
-    def get_age_bins(builder: Builder):
+    def get_age_bins(builder: Builder) -> pd.DataFrame:
         raw_age_bins = builder.data.load("population.age_bins")
         age_start = builder.configuration.population.age_start
         exit_age = builder.configuration.population.exit_age

--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -77,7 +77,7 @@ class ResultsStratifier:
 
         Returns
         ------
-        result
+        pd.Series
             A pd.Series with age group name string corresponding to the pop passed into the function
         """
         bins = self.age_bins.age_start.to_list() + [self.age_bins.age_end.iloc[-1]]
@@ -96,7 +96,7 @@ class ResultsStratifier:
 
         Returns
         ------
-        result
+        pd.Series
             A pd.Series with years corresponding to the pop passed into the function
         """
         return pop.squeeze(axis=1).dt.year

--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -4,198 +4,103 @@ Results Stratifier
 ==================
 
 This module contains tools for stratifying observed quantities
-by specified characteristics.
-
+by specified characteristics through the vivarium results interface.
 """
-import itertools
-from dataclasses import dataclass
-from enum import Enum
-from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple
 
 import pandas as pd
 from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
-from vivarium.framework.population import PopulationView, SimulantData
-
-
-class SourceType(Enum):
-    COLUMN = "column"
-    PIPELINE = "pipeline"
-    CLOCK = "clock"
-
-
-@dataclass
-class Source:
-    """
-    A source of information about simulants used to determine which category
-    they belong to for a given stratification level. The source name should be
-    the name of the column or pipeline being used as the source. If the source
-    is of type clock, the name should be something descriptive and unique.
-
-    """
-
-    name: str
-    type: SourceType
-
-
-@dataclass
-class StratificationLevel:
-    """
-    A level of stratification. Each StratificationLevel represents a set of
-    mutually exclusive and collectively exhaustive categories into which
-    simulants can be assigned.
-
-    The mapper is a function which is applied to the list of sources and
-    assigns each simulant to specific category. It will throw an error if its
-    output is not one of the stratification's categories. By default, the
-    mapper assumes the StratificationLevel has a single source and returns its
-    value as the category.
-
-    A current category getter can be defined if it is known that certain
-    categories are not possible during specific times. Removing these
-    categories from iteration can provide a performance improvement in these
-    cases. The primary use case for the current category getter is for
-    stratification by time, and in particular stratification by year. By
-    default, this will return all categories.
-
-    """
-
-    name: str
-    sources: List[Source]
-    categories: Set[str]
-    mapper: Callable[[pd.Series], str] = None
-    current_categories_getter: Callable[[], Set[str]] = None
-
-    def __post_init__(self):
-        self._set_mapper()
-        self._set_current_categories_getter()
-
-    @property
-    def current_categories(self) -> Set[str]:
-        return self.current_categories_getter()
-
-    def _set_mapper(self) -> None:
-        """
-        Sets the mapper to be the identity mapper if no mapper has been
-        provided. Additionally, wraps the mapper so that it will throw a
-        ValueError if the mapper produces an output that is not in the set of
-        this StratificationLevel's categories.
-        """
-        name = self.name
-        categories = self.categories
-        mapper = self.mapper if self.mapper else self._default_mapper
-
-        def wrapped_mapper(row: pd.Series) -> pd.Series:
-            category = mapper(row)
-            if category not in categories:
-                raise ValueError(f"Invalid value '{category}' found in {name}.")
-            return pd.Series(category)
-
-        self.mapper = wrapped_mapper
-
-    def _set_current_categories_getter(self) -> None:
-        self.current_categories_getter = (
-            self.current_categories_getter
-            if self.current_categories_getter
-            else self._default_current_categories_getter
-        )
-
-    ###############################
-    # Default getters and mappers #
-    ###############################
-
-    # noinspection PyMethodMayBeStatic
-    def _default_mapper(self, row: pd.Series) -> str:
-        return str(row[0])
-
-    def _default_current_categories_getter(self) -> Set[str]:
-        return self.categories
 
 
 class ResultsStratifier:
-    """Centralized component for handling results stratification.
-
-    This component manages the assignment of simulants to groups for the
-    purpose of stratification. Each observer component will get a reference to
-    this component so that it can properly stratify its output.
-
-    """
-
     name = "results_stratifier"
 
     configuration_defaults = {
-        "observers": {
+        "stratification": {
             "default": [],
         }
     }
 
-    def __init__(self):
-        self.metrics_pipeline_name = "metrics"
-        self.tmrle_key = "population.theoretical_minimum_risk_life_expectancy"
+    def setup(self, builder: Builder):
+        self.config = builder.configuration.stratification
+        self.age_bins = self.get_age_bins(builder)
 
-    #################
-    # Setup methods #
-    #################
+        self.start_year = builder.configuration.time.start.year
+        self.end_year = builder.configuration.time.end.year
 
-    # noinspection PyAttributeOutsideInit
-    def setup(self, builder: Builder) -> None:
-        """Perform this component's setup."""
-        self.clock = builder.time.clock()
-        self.default_stratification_levels = self._get_default_stratification_levels(builder)
-        self.pipelines = {}
-        self.columns_required = {"tracked"}
-        self.clock_sources = set()
-        self.stratification_levels: Dict[str, StratificationLevel] = {}
-        self.stratification_groups: Optional[pd.DataFrame] = None
-
-        self.age_bins = self._get_age_bins(builder)
-
+        builder.results.set_default_stratifications(self.config.stratification.default)
         self.register_stratifications(builder)
-        self.population_view = self._get_population_view(builder)
-
-        self._register_simulant_initializer(builder)
-        self._register_timestep_prepare_listener(builder)
-
-    # noinspection PyMethodMayBeStatic
-    def _get_default_stratification_levels(self, builder: Builder) -> Set[str]:
-        return set(builder.configuration.observers.default)
 
     def register_stratifications(self, builder: Builder) -> None:
-        """Register each desired stratification with calls to _setup_stratification"""
-
-        start_year = builder.configuration.time.start.year
-        end_year = builder.configuration.time.end.year
-
-        self.setup_stratification(
-            builder,
-            name=ResultsStratifier.YEAR,
-            sources=[ResultsStratifier.YEAR_SOURCE],
-            categories={str(year) for year in range(start_year, end_year + 1)},
-            mapper=self.year_stratification_mapper,
-            current_category_getter=self.year_current_categories_getter,
+        builder.results.register_stratification(
+            "age_group",
+            self.age_bins["age_group_name"].to_list(),
+            self.map_age_groups,
+            is_vectorized=True,
+            requires_columns=["age"],
+        )
+        builder.results.register_stratification(
+            "current_year",
+            [str(year) for year in range(self.start_year, self.end_year + 1)],
+            self.map_year,
+            is_vectorized=True,
+            requires_columns=["current_time"],
+        )
+        builder.results.register_stratification(
+            "event_year",
+            [str(year) for year in range(self.start_year, self.end_year + 1)],
+            self.map_year,
+            is_vectorized=True,
+            requires_columns=["event_time"],
+        )
+        builder.results.register_stratification(
+            "entrance_year",
+            [str(year) for year in range(self.start_year, self.end_year + 1)],
+            self.map_year,
+            is_vectorized=True,
+            requires_columns=["entrance_time"],
+        )
+        builder.results.register_stratification(
+            "exit_year",
+            [str(year) for year in range(self.start_year, self.end_year + 1)],
+            self.map_year,
+            is_vectorized=True,
+            requires_columns=["exit_time"],
         )
 
-        self.setup_stratification(
-            builder,
-            name=ResultsStratifier.SEX,
-            sources=[ResultsStratifier.SEX_SOURCE],
-            categories=ResultsStratifier.SEX_CATEGORIES,
-        )
+    def map_age_groups(self, pop: pd.DataFrame) -> pd.Series:
+        """Map age with age group name strings
 
-        self.setup_stratification(
-            builder,
-            name=ResultsStratifier.AGE,
-            sources=[ResultsStratifier.AGE_SOURCE],
-            categories={age_bin for age_bin in self.age_bins["age_group_name"]},
-            mapper=self.age_stratification_mapper,
-        )
+        Parameters
+        ----------
+        pop
+            A DataFrame with one column, an age to be mapped to an age group name string
 
-    # noinspection PyMethodMayBeStatic
-    def _get_population_view(self, builder: Builder) -> PopulationView:
-        return builder.population.get_view(list(self.columns_required))
+        Returns
+        ------
+        A pd.Series with age group name string corresponding to the pop passed into the function
+        """
+        bins = self.age_bins.age_start.to_list() + [self.age_bins.age_end.iloc[-1]]
+        labels = self.age_bins["age_group_name"].to_list()
+        age_group = pd.cut(pop["age"], bins, labels=labels).rename("age_group")
+        return age_group
 
-    # noinspection PyMethodMayBeStatic
-    def _get_age_bins(self, builder: Builder) -> pd.DataFrame:
+    @staticmethod
+    def map_year(pop: pd.DataFrame) -> pd.Series:
+        """Map datetime with year
+
+        Parameters
+        ----------
+        pop
+            A DataFrame with one column, a datetime to be mapped to year
+
+        Returns
+        ------
+        A pd.Series with years corresponding to the pop passed into the function
+        """
+        return pop.squeeze(axis=1).dt.year
+
+    @staticmethod
+    def get_age_bins(builder: Builder):
         raw_age_bins = builder.data.load("population.age_bins")
         age_start = builder.configuration.population.age_start
         exit_age = builder.configuration.population.exit_age
@@ -204,182 +109,7 @@ class ResultsStratifier:
         exit_age_mask = raw_age_bins["age_start"] < exit_age if exit_age else True
 
         age_bins = raw_age_bins.loc[age_start_mask & exit_age_mask, :]
+        age_bins["age_group_name"] = (
+            age_bins["age_group_name"].str.replace(" ", "_").str.lower()
+        )
         return age_bins
-
-    def _register_simulant_initializer(self, builder: Builder) -> None:
-        builder.population.initializes_simulants(
-            self.on_initialize_simulants,
-            requires_columns=list(self.columns_required),
-            requires_values=[pipeline_name for pipeline_name in self.pipelines],
-        )
-
-    def _register_timestep_prepare_listener(self, builder: Builder) -> None:
-        builder.event.register_listener(
-            "time_step__prepare", self.on_time_step_prepare, priority=0
-        )
-
-    ########################
-    # Event-driven methods #
-    ########################
-
-    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
-        if self.stratification_groups is not None:
-            # noinspection PyAttributeOutsideInit
-            self.stratification_groups = pd.concat(
-                [self.stratification_groups, self._set_stratification_groups(pop_data.index)]
-            )
-
-    def on_time_step_prepare(self, event: Event) -> None:
-        # noinspection PyAttributeOutsideInit
-        self.stratification_groups = self._set_stratification_groups(event.index)
-
-    ##################
-    # Public methods #
-    ##################
-
-    # todo add caching of stratifications
-    def group(
-        self, index: pd.Index, include: Iterable[str], exclude: Iterable[str]
-    ) -> Iterable[Tuple[str, pd.Series]]:
-        """Takes a full population index and yields stratified subgroups.
-
-        Parameters
-        ----------
-        index
-            The index of the population to stratify.
-        include
-            List of stratifications to add to the default stratifications
-        exclude
-            List of stratifications to remove from the default stratifications
-
-        Yields
-        ------
-        Tuple[str, pd.Series]
-            A tuple of stratification labels and the population subgroup
-            corresponding to those labels.
-
-        """
-        stratification_groups = self.stratification_groups.loc[index]
-
-        for stratification in self._get_current_stratifications(include, exclude):
-            stratification_key = self._get_stratification_key(stratification)
-
-            group_mask = pd.Series(True, index=index)
-            if not index.empty:
-                for level, category in stratification:
-                    group_mask &= stratification_groups[level.name] == category
-
-            yield stratification_key, group_mask
-
-    ##################
-    # Helper methods #
-    ##################
-
-    def setup_stratification(
-        self,
-        builder: Builder,
-        name: str,
-        sources: List[Source],
-        categories: Set[str],
-        mapper: Callable[[pd.Series], str] = None,
-        current_category_getter: Callable[[], Set[str]] = None,
-    ) -> None:
-        """
-        Defines the characteristics of a stratification level and ensures that
-        each of its sources is available to the ResultsStratifier
-        """
-        stratification_level = StratificationLevel(
-            name, sources, categories, mapper, current_category_getter
-        )
-        self.stratification_levels[name] = stratification_level
-
-        for source in sources:
-            if source.type == SourceType.PIPELINE:
-                self.pipelines[source.name] = builder.value.get_value(source.name)
-            elif source.type == SourceType.COLUMN:
-                self.columns_required.add(source.name)
-            elif source.type == SourceType.CLOCK:
-                self.clock_sources.add(source.name)
-            else:
-                raise ValueError(f"Invalid stratification source type '{source.type}'.")
-
-    def _get_current_stratifications(
-        self, include: Iterable[str], exclude: Iterable[str]
-    ) -> List[Tuple[Tuple[StratificationLevel, str], ...]]:
-        """
-        Gets all stratification combinations. Returns a List of
-        Stratifications. Each Stratification is represented as a Tuple of
-        Levels. Each Level is represented as a Tuple of a StratificationLevel
-        object and string referring to the specific stratification category.
-
-        If no stratification levels are defined, returns a List with a single empty Tuple
-        """
-        include = set(include)
-        exclude = set(exclude)
-        level_names = (self.default_stratification_levels | include) - exclude
-
-        groups = [
-            [(level, category) for category in level.current_categories]
-            for level_name, level in self.stratification_levels.items()
-            if level_name in level_names
-        ]
-        # Get product of all stratification combinations
-        return list(itertools.product(*groups))
-
-    @staticmethod
-    def _get_stratification_key(
-        stratification: Iterable[Tuple[StratificationLevel, str]]
-    ) -> str:
-        return (
-            "_".join([f"{level[0].name}_{level[1]}" for level in stratification])
-            .replace(" ", "_")
-            .lower()
-        )
-
-    def _set_stratification_groups(self, index: pd.Index) -> pd.DataFrame:
-        """Determine each simulant's category for each stratification level"""
-        pop = self.population_view.get(index, query='tracked == True and alive == "alive"')
-        pipeline_values = [
-            pd.Series(pipeline(pop.index), name=name)
-            for name, pipeline in self.pipelines.items()
-        ]
-        clock_values = [
-            pd.Series(self.clock(), index=pop.index, name=name) for name in self.clock_sources
-        ]
-        sources = pd.concat([pop] + pipeline_values + clock_values, axis=1)
-
-        stratification_groups = [
-            sources[[source.name for source in stratification_level.sources]]
-            .apply(stratification_level.mapper, axis=1)
-            .squeeze(axis=1)
-            .rename(stratification_level.name)
-            for stratification_level in self.stratification_levels.values()
-        ]
-        return pd.concat(stratification_groups, axis=1)
-
-    ##########################
-    # Stratification Details #
-    ##########################
-
-    AGE = "age"
-    AGE_SOURCE = Source("age", SourceType.COLUMN)
-
-    def age_stratification_mapper(self, row: pd.Series) -> str:
-        age_group_mask = (
-            self.age_bins["age_start"] <= row[ResultsStratifier.AGE_SOURCE.name]
-        ) & (row[ResultsStratifier.AGE_SOURCE.name] < self.age_bins["age_end"])
-        return str(self.age_bins.loc[age_group_mask, "age_group_name"].squeeze())
-
-    SEX = "sex"
-    SEX_SOURCE = Source("sex", SourceType.COLUMN)
-    SEX_CATEGORIES = {"Female", "Male"}
-
-    YEAR = "year"
-    YEAR_SOURCE = Source("year", SourceType.CLOCK)
-
-    # noinspection PyMethodMayBeStatic
-    def year_stratification_mapper(self, row: pd.Series) -> str:
-        return str(row[0].year)
-
-    def year_current_categories_getter(self) -> Set[str]:
-        return {str(self.clock().year)}

--- a/tests/metrics/test_stratification.py
+++ b/tests/metrics/test_stratification.py
@@ -1,316 +1,175 @@
-import itertools
-
-import numpy as np
 import pandas as pd
-import pytest
-from vivarium import InteractiveContext
-from vivarium.framework.engine import Builder
-from vivarium.framework.population import SimulantData
-from vivarium.testing_utilities import TestPopulation, metadata
 
-from vivarium_public_health.metrics.stratification import (
-    ResultsStratifier as ResultsStratifier_,
-)
-from vivarium_public_health.metrics.stratification import Source, SourceType
+from vivarium_public_health.metrics.stratification import ResultsStratifier
 
 
-class FavoriteColor:
-
-    OPTIONS = ["red", "green", "orange"]
-
-    @property
-    def name(self) -> str:
-        return "favorite_color"
-
-    def setup(self, builder: Builder):
-        self.randomness = builder.randomness.get_stream(self.name)
-        # Our simulants are fickle and change their
-        # favorite colors every time step.
-        builder.value.register_value_producer(
-            self.name,
-            requires_streams=[self.name],
-            source=lambda index: self.randomness.choice(index, choices=self.OPTIONS),
-        )
-
-
-class FavoriteNumber:
-
-    OPTIONS = [7, 42, 14312]
-
-    @property
-    def name(self) -> str:
-        return "favorite_number"
-
-    def setup(self, builder: Builder) -> None:
-        self.randomness = builder.randomness.get_stream(self.name)
-        self.population_view = builder.population.get_view([self.name])
-        builder.population.initializes_simulants(
-            self.on_initialize_simulants,
-            creates_columns=[self.name],
-            requires_streams=[self.name],
-        )
-
-    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
-        # Favorite numbers are forever though.
-        self.population_view.update(
-            self.randomness.choice(
-                pop_data.index,
-                choices=self.OPTIONS,
-            ).rename(self.name)
-        )
+# Age bins prior to get_age_bins
+def fake_data_load_population_age_bins(*args):
+    AGE_BINS_RAW_DICT = {
+        "age_start": {0: 0.0, 1: 0.01917808, 2: 0.07671233, 3: 0.5, 4: 1.0, 5: 2.0},
+        "age_end": {0: 0.01917808, 1: 0.07671233, 2: 0.5, 3: 1.0, 4: 2.0, 5: 5.0},
+        "age_group_name": {
+            0: "Early Neonatal",
+            1: "Late Neonatal",
+            2: "1-5 months",
+            3: "6-11 months",
+            4: "12 to 23 months",
+            5: "2 to 4",
+        },
+        "age_group_id": {0: 2, 1: 3, 2: 388, 3: 389, 4: 238, 5: 34},
+    }
+    return pd.DataFrame(AGE_BINS_RAW_DICT)
 
 
-FAVORITE_THINGS = {
-    f"{color}_{number}"
-    for color, number in itertools.product(FavoriteColor.OPTIONS, FavoriteNumber.OPTIONS)
+# Age bins as processed by get_age_bins
+AGE_BINS_EXPECTED_DICT = {
+    "age_start": {0: 0.0, 1: 0.01917808, 2: 0.07671233, 3: 0.5, 4: 1.0, 5: 2.0},
+    "age_end": {0: 0.01917808, 1: 0.07671233, 2: 0.5, 3: 1.0, 4: 2.0, 5: 5.0},
+    "age_group_name": {
+        0: "early_neonatal",
+        1: "late_neonatal",
+        2: "1-5_months",
+        3: "6-11_months",
+        4: "12_to_23_months",
+        5: "2_to_4",
+    },
+    "age_group_id": {0: 2, 1: 3, 2: 388, 3: 389, 4: 238, 5: 34},
+}
+
+# Population table for mapper testing
+FAKE_POP_AGE_DICT = {
+    "age": {0: 0.01, 1: 0.45, 2: 1.01, 3: 1.99, 4: 2.02},
+}
+
+# List of expected age_bin intervals for mapper testing
+FAKE_POP_EXPECTED_AGE_BINS_LIST = [
+    "early_neonatal",
+    "1-5_months",
+    "12_to_23_months",
+    "12_to_23_months",
+    "2_to_4",
+]
+
+FAKE_POP_EVENT_TIME = {
+    "year": {
+        0: pd.to_datetime("1/1/2045"),
+        1: pd.to_datetime("1/1/2045"),
+        2: pd.to_datetime("1/1/2045"),
+        3: pd.to_datetime("1/1/2045"),
+        4: pd.to_datetime("1/1/2045"),
+    },
 }
 
 
-class ResultsStratifier(ResultsStratifier_):
-    def register_stratifications(self, builder: Builder) -> None:
-        super().register_stratifications(builder)
-
-        self.setup_stratification(
-            builder,
-            name="favorite_things",
-            sources=[
-                Source("favorite_color", SourceType.PIPELINE),
-                Source("favorite_number", SourceType.COLUMN),
-            ],
-            categories=FAVORITE_THINGS,
-            mapper=lambda row: f"{row['favorite_color']}_{row['favorite_number']}",
-        )
-
-        self.setup_stratification(
-            builder,
-            name="favorite_color",
-            sources=[Source("favorite_color", SourceType.PIPELINE)],
-            categories=set(FavoriteColor.OPTIONS),
-        )
-
-        self.setup_stratification(
-            builder,
-            name="month",
-            sources=[Source("month", SourceType.CLOCK)],
-            categories={str(i + 1) for i in range(12)},
-            mapper=lambda row: str(row[0].month),
-            current_category_getter=lambda: {str(self.clock().month)},
-        )
-
-
-ALL_LEVELS = ["age", "sex", "year", "favorite_things", "favorite_color", "month"]
-
-
-def make_stratifier_and_sim(default_levels, config, plugins):
-    config.update(
-        {
-            "observers": {"default": default_levels},
-            "population": {"population_size": 1000},
-        },
-        **metadata(__file__),
-    )
+def test_results_stratifier_setup(mocker):
+    """Test that set default stratifications happens at setup"""
     rs = ResultsStratifier()
-    sim = InteractiveContext(
-        components=[TestPopulation(), rs, FavoriteColor(), FavoriteNumber()],
-        configuration=config,
-        plugin_configuration=plugins,
-    )
-    return rs, sim
+    builder = mocker.Mock()
+    builder.data.load = fake_data_load_population_age_bins
+    builder.configuration.population.age_start = 0.0
+    builder.configuration.population.exit_age = 5.0
+    builder.configuration.time.start.year = 2022
+    builder.configuration.time.end.year = 2027
+
+    builder.results.set_default_stratifications = mocker.Mock()
+    builder.results.set_default_stratifications.assert_not_called()
+
+    rs.setup(builder)
+
+    builder.results.set_default_stratifications.assert_called_once()
 
 
-@pytest.fixture(params=[[], ["age", "sex", "year"], ALL_LEVELS])
-def default_levels(request):
-    return request.param
-
-
-@pytest.fixture(scope="function")
-def stratifier_and_sim(default_levels, base_config, base_plugins):
-    return make_stratifier_and_sim(default_levels, base_config, base_plugins)
-
-
-@pytest.fixture(
-    params=[
-        [[], []],
-        [["sex", "favorite_color"], []],
-        [[], ["sex", "favorite_color"]],
-        [ALL_LEVELS, []],
-        [[], ALL_LEVELS],
-        [["sex"], ["favorite_color"]],
+def test_results_stratifier_register_stratifications(mocker):
+    """Test that ResultsStratifier.register_stratifications registers expected stratifications
+    and only the expected stratifications."""
+    builder = mocker.Mock()
+    builder.data.load = fake_data_load_population_age_bins
+    builder.configuration.population.age_start = 0.0
+    builder.configuration.population.exit_age = 5.0
+    builder.configuration.time.start.year = 2022
+    builder.configuration.time.end.year = 2025
+    years_list = ["2022", "2023", "2024", "2025"]
+    age_group_names_list = [
+        "early_neonatal",
+        "late_neonatal",
+        "1-5_months",
+        "6-11_months",
+        "12_to_23_months",
+        "2_to_4",
     ]
-)
-def include_and_exclude(request):
-    return request.param
+    mocker.patch.object(builder, "results.register_stratification")
+    builder.results.register_stratification = mocker.MagicMock()
 
-
-@pytest.fixture(
-    params=[
-        [["age"], ["age"]],
-        [ALL_LEVELS, ALL_LEVELS],
-    ]
-)
-def bad_include_and_exclude(request):
-    return request.param
-
-
-def test_ResultsStratifier_setup(stratifier_and_sim, default_levels):
-    rs, sim = stratifier_and_sim
-
-    assert rs.metrics_pipeline_name == "metrics"
-    assert rs.tmrle_key == "population.theoretical_minimum_risk_life_expectancy"
-    assert rs.clock() == sim.current_time
-    assert rs.default_stratification_levels == set(default_levels)
-    assert set(rs.pipelines) == {"favorite_color"}
-    assert rs.columns_required == {"tracked", "favorite_number", "age", "sex"}
-    assert rs.clock_sources == {"year", "month"}
-    assert set(rs.stratification_levels) == {
-        "age",
-        "sex",
-        "year",
-        "favorite_things",
-        "favorite_color",
-        "month",
-    }
-    assert rs.stratification_groups is None
-
-
-@pytest.mark.parametrize(
-    "age_start, age_end, expected_age_start, expected_age_end",
-    [(20, 55, 20, 55), (18, 47, 15, 50)],
-    ids=["on_bound", "between_bounds"],
-)
-def test_ResultsStratifier_setup_age_bins(
-    age_start: int,
-    age_end: int,
-    expected_age_start: int,
-    expected_age_end: int,
-    base_config,
-    base_plugins,
-):
-    base_config.update(
-        {"population": {"age_start": age_start, "exit_age": age_end}},
-        **metadata(__file__),
-    )
+    builder.results.register_stratification.assert_not_called()
 
     rs = ResultsStratifier()
-    _ = InteractiveContext(
-        components=[TestPopulation(), rs],
-        configuration=base_config,
-        plugin_configuration=base_plugins,
+    rs.setup(builder)  # setup calls register_stratifications()
+
+    builder.results.register_stratification.assert_any_call(
+        "age_group",
+        age_group_names_list,
+        rs.map_age_groups,
+        is_vectorized=True,
+        requires_columns=["age"],
     )
-
-    # Assertions
-    expected_outputs = pd.DataFrame(
-        [
-            {
-                "age_start": float(age),
-                "age_end": float(age + 5),
-                "age_group_name": f"{age} to {age + 4}",
-            }
-            for i, age in enumerate(range(expected_age_start, expected_age_end, 5))
-        ]
+    builder.results.register_stratification.assert_any_call(
+        "current_year",
+        years_list,
+        rs.map_year,
+        is_vectorized=True,
+        requires_columns=["current_time"],
     )
-    assert (rs.age_bins.values == expected_outputs.values).all()
-
-
-def test_setting_stratification_groups_on_time_step_prepare(stratifier_and_sim):
-    rs, sim = stratifier_and_sim
-
-    # No time steps yet, so not groups have been set
-    assert rs.stratification_groups is None
-
-    stratification_time = sim.current_time
-    sim.step()
-    # noinspection PyTypeChecker
-    sg: pd.DataFrame = rs.stratification_groups
-
-    def proportion(x):
-        return len(x) / len(sg)
-
-    assert set(sg.columns) == {
-        "age",
-        "sex",
-        "year",
-        "favorite_things",
-        "favorite_color",
-        "month",
-    }
-
-    # Age has different sized bins, so statistical tests are harder.
-    assert set(sg.age) <= set(rs.age_bins.age_group_name)
-
-    assert set(sg.sex) == {"Male", "Female"}
-    assert np.allclose(sg.groupby("sex").apply(proportion), 1 / 2, rtol=0.1)
-
-    years = set(sg.year)
-    assert len(years) == 1
-    assert list(years)[0] == str(stratification_time.year)
-
-    assert set(sg.favorite_things) == FAVORITE_THINGS
-    assert np.allclose(
-        sg.groupby("favorite_things").apply(proportion),
-        1 / len(FAVORITE_THINGS),
-        rtol=0.25,
+    builder.results.register_stratification.assert_any_call(
+        "event_year",
+        years_list,
+        rs.map_year,
+        is_vectorized=True,
+        requires_columns=["event_time"],
     )
-
-    assert set(sg.favorite_color) == set(FavoriteColor.OPTIONS)
-    assert np.allclose(
-        sg.groupby("favorite_color").apply(proportion),
-        1 / len(FavoriteColor.OPTIONS),
-        rtol=0.1,
+    builder.results.register_stratification.assert_any_call(
+        "entrance_year",
+        years_list,
+        rs.map_year,
+        is_vectorized=True,
+        requires_columns=["entrance_time"],
     )
-
-    months = set(sg.month)
-    assert len(months) == 1
-    assert list(months)[0] == str(stratification_time.month)
-
-
-def test_group(stratifier_and_sim, default_levels, include_and_exclude):
-    rs, sim = stratifier_and_sim
-    sim.step()
-
-    include, exclude = include_and_exclude
-    expected_levels = (set(default_levels) | set(include)) - set(exclude)
-
-    pop = sim.get_population()
-    groups = list(rs.group(pop.index, include, exclude))
-
-    _check_groups(rs, expected_levels, groups, pop)
+    builder.results.register_stratification.assert_any_call(
+        "exit_year",
+        years_list,
+        rs.map_year,
+        is_vectorized=True,
+        requires_columns=["exit_time"],
+    )
+    assert builder.results.register_stratification.call_count == 5
 
 
-def test_group_empty_index(stratifier_and_sim, default_levels, include_and_exclude):
-    rs, sim = stratifier_and_sim
-    sim.step()
-
-    include, exclude = include_and_exclude
-    expected_levels = (set(default_levels) | set(include)) - set(exclude)
-
-    pop = sim.get_population()
-    pop = pop[pop.age > 200]
-    groups = list(rs.group(pop.index, include, exclude))
-
-    _check_groups(rs, expected_levels, groups, pop)
+def test_results_stratifier_map_age_groups():
+    """Test that ages of the population are mapped to intervals as expected."""
+    pop = pd.DataFrame(FAKE_POP_AGE_DICT)
+    rs = ResultsStratifier()
+    rs.age_bins = pd.DataFrame(AGE_BINS_EXPECTED_DICT)
+    mapped_pop = rs.map_age_groups(pop)
+    assert mapped_pop.to_list() == FAKE_POP_EXPECTED_AGE_BINS_LIST
 
 
-def _check_groups(stratifier, expected_levels, groups, pop):
-    expected_num_groups = 1
-    for level in expected_levels:
-        if level not in ["month", "year"]:
-            expected_num_groups *= len(stratifier.stratification_levels[level].categories)
-
-    assert len(groups) == expected_num_groups
-
-    if not expected_levels:
-        label, group_mask = groups[0]
-        assert label == ""
-        assert pop[group_mask].equals(pop)
-    else:
-        for label, group_mask in groups:
-            for level in expected_levels:
-                assert level in label
-            assert pop[group_mask].index.isin(pop.index).all()
+def test_results_stratifier_map_year():
+    """Test that datetimes are mapped to the correct year."""
+    pop = pd.DataFrame(FAKE_POP_EVENT_TIME)
+    rs = ResultsStratifier()
+    the_year = rs.map_year(pop)
+    assert (the_year == 2045).all()
 
 
-# todo test age_stratification_mapper
-# todo test year_stratification_mapper
-# todo test year_current_categories_getter
-# todo test StratificationLevel init
+def test_results_stratifier_get_age_bins(mocker):
+    """Test that get_age_bins produces expected age_bins DataFrame."""
+    builder = mocker.Mock()
+    builder.data.load = fake_data_load_population_age_bins
+    builder.configuration.population.age_start = 0.0
+    builder.configuration.population.exit_age = 5.0
+    builder.configuration.time.start.year = 2022
+    builder.configuration.time.end.year = 2025
+
+    rs = ResultsStratifier()
+    age_bins = rs.get_age_bins(builder)
+
+    assert age_bins.to_dict() == AGE_BINS_EXPECTED_DICT


### PR DESCRIPTION
## Implement ResultsStratifier, update tests

### Description

- *Category*: feature
- *JIRA issue*: [MIC-3131](https://jira.ihme.washington.edu/browse/MIC-3131)

### Changes and notes
- Implements ResultsStratifier per design: https://ihmeuw.github.io/vivarium_development/docs/build/html/design/2022_05_25_results_writer.html#resultsstratifier
- Adds tests for setup, registration of stratifications, age_bin manipulation, and mapping age groups and years.
- These are effective rewrites of both the ResultsStratifier and its tests, so it's probably easiest to review the whole raw file.

### Testing
All new tests pass.
