### PR TITLE
Implement DisabilityObserver and add unit tests 

### DIFF
--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -29,13 +29,10 @@ from vivarium_public_health.utilities import to_years
 
 
 class DisabilityObserver:
-    """ TODO: revisit
-    Counts years lived with disability.
+    """Counts years lived with disability.
 
     By default, this counts both aggregate and cause-specific years lived
-    with disability over the full course of the simulation. It can be
-    configured to add or remove stratification groups to the default groups
-    defined by a :class:ResultsStratifier.
+    with disability over the full course of the simulation.
 
     In the model specification, your configuration for this component should
     be specified as, e.g.:
@@ -50,6 +47,7 @@ class DisabilityObserver:
                     include:
                         - "sample_stratification"
     """
+
     configuration_defaults = {
         "stratification": {
             "disability": {
@@ -71,8 +69,8 @@ class DisabilityObserver:
         builder.results.register_observation(
             name="ylds_due_to_all_causes",
             pop_filter='tracked == True and alive == "alive"',
-            aggregator_sources=[str(self.disability_weight)],  # XXX is this right?
-            aggregator=self._disability_weight_aggregator,  # XXX is this right?
+            aggregator_sources=[str(self.disability_weight)],
+            aggregator=self._disability_weight_aggregator,
             requires_columns=["alive"],
             requires_values=["disability_weight"],
             additional_stratifications=self.config.include,
@@ -81,11 +79,11 @@ class DisabilityObserver:
         )
 
         for cause_state in cause_states:
-            pipeline = builder.value.get_value(f'{cause_state.state_id}.disability_weight')
+            pipeline = builder.value.get_value(f"{cause_state.state_id}.disability_weight")
             builder.results.register_observation(
                 name=f"ylds_due_to_{cause_state.state_id}",
                 pop_filter='tracked == True and alive == "alive"',
-                aggregator_sources=[str(self.disability_weight)],
+                aggregator_sources=[str(pipeline)],
                 aggregator=self._disability_weight_aggregator,
                 requires_columns=["alive"],
                 requires_values=[f"{cause_state.state_id}.disability_weight"],
@@ -96,174 +94,6 @@ class DisabilityObserver:
 
     def _disability_weight_aggregator(self, pipeline):
         def _aggregate(group):
-            return (pipeline(group.index) * to_years(group['step_size'])).sum()
-        return _aggregate
+            return (pipeline(group.index) * to_years(group["step_size"])).sum()
 
-#
-# class DisabilityObserver:
-#     """Counts years lived with disability.
-#
-#     By default, this counts both aggregate and cause-specific years lived
-#     with disability over the full course of the simulation. It can be
-#     configured to add or remove stratification groups to the default groups
-#     defined by a :class:ResultsStratifier.
-#
-#     In the model specification, your configuration for this component should
-#     be specified as, e.g.:
-#
-#     .. code-block:: yaml
-#
-#         configuration:
-#             observers:
-#                 disability:
-#                     exclude:
-#                         - "sex"
-#                     include:
-#                         - "sample_stratification"
-#     """
-#
-#     configuration_defaults = {
-#         "observers": {
-#             "disability": {
-#                 "exclude": [],
-#                 "include": [],
-#             }
-#         }
-#     }
-#
-#     def __init__(self):
-#         self.ylds_column_name = "years_lived_with_disability"
-#         self.metrics_pipeline_name = "metrics"
-#         self.disability_weight_pipeline_name = "disability_weight"
-#
-#     def __repr__(self):
-#         return "DisabilityObserver()"
-#
-#     ##############
-#     # Properties #
-#     ##############
-#
-#     @property
-#     def name(self):
-#         return "disability_observer"
-#
-#     #################
-#     # Setup methods #
-#     #################
-#
-#     # noinspection PyAttributeOutsideInit
-#     def setup(self, builder: Builder) -> None:
-#         self.config = self._get_stratification_configuration(builder)
-#         self.stratifier = self._get_stratifier(builder)
-#         self.disability_weight = self._get_disability_weight_pipeline(builder)
-#         self._cause_components = self._get_cause_components(builder)
-#         self.disability_pipelines = {}
-#         self.population_view = self._get_population_view(builder)
-#
-#         self.counts = Counter()
-#
-#         self._register_post_setup_listener(builder)
-#         self._register_simulant_initializer(builder)
-#         self._register_time_step_prepare_listener(builder)
-#         self._register_metrics_modifier(builder)
-#
-#     # noinspection PyMethodMayBeStatic
-#     def _get_stratification_configuration(self, builder: Builder) -> ConfigTree:
-#         return builder.configuration.observers.disability
-#
-#     # noinspection PyMethodMayBeStatic
-#     def _get_stratifier(self, builder: Builder) -> ResultsStratifier:
-#         return builder.components.get_component(ResultsStratifier.name)
-#
-#     def _get_disability_weight_pipeline(self, builder: Builder) -> Pipeline:
-#         # todo observer should not be creating the disability weight pipeline
-#         return builder.value.register_value_producer(
-#             self.disability_weight_pipeline_name,
-#             source=lambda index: [pd.Series(0.0, index=index)],
-#             preferred_combiner=list_combiner,
-#             preferred_post_processor=_disability_post_processor,
-#         )
-#
-#     # noinspection PyMethodMayBeStatic
-#     def _get_cause_components(
-#         self, builder: Builder
-#     ) -> List[Union[DiseaseState, RiskAttributableDisease]]:
-#         return builder.components.get_components_by_type(
-#             (DiseaseState, RiskAttributableDisease)
-#         )
-#
-#     # noinspection PyMethodMayBeStatic
-#     def _get_population_view(self, builder: Builder) -> PopulationView:
-#         columns_required = [
-#             self.ylds_column_name,
-#         ]
-#         return builder.population.get_view(columns_required)
-#
-#     def _register_post_setup_listener(self, builder: Builder) -> None:
-#         builder.event.register_listener("post_setup", self.on_post_setup)
-#
-#     def _register_simulant_initializer(self, builder: Builder) -> None:
-#         # todo observer should not be modifying state table
-#         builder.population.initializes_simulants(
-#             self.on_initialize_simulants,
-#             creates_columns=[self.ylds_column_name],
-#         )
-#
-#     def _register_time_step_prepare_listener(self, builder: Builder) -> None:
-#         # In order to get an accurate representation of person time we need to look at
-#         # the state table before anything happens.
-#         builder.event.register_listener("time_step__prepare", self.on_time_step_prepare)
-#
-#     def _register_metrics_modifier(self, builder: Builder) -> None:
-#         builder.value.register_value_modifier(
-#             self.metrics_pipeline_name,
-#             modifier=self.metrics,
-#             requires_columns=[self.ylds_column_name],
-#         )
-#
-#     ########################
-#     # Event-driven methods #
-#     ########################
-#
-#     # noinspection PyUnusedLocal
-#     def on_post_setup(self, event: Event) -> None:
-#         for cause in self._cause_components:
-#             if cause.has_disability:
-#                 self.disability_pipelines[cause.state_id] = cause.disability_weight
-#
-#     def on_initialize_simulants(self, pop_data: pd.DataFrame) -> None:
-#         self.population_view.update(
-#             pd.Series(0.0, index=pop_data.index, name=self.ylds_column_name)
-#         )
-#
-#     def on_time_step_prepare(self, event: Event) -> None:
-#         step_size_in_years = to_years(event.step_size)
-#         pop = self.population_view.get(
-#             event.index, query='tracked == True and alive == "alive"'
-#         )
-#         groups = self.stratifier.group(pop.index, self.config.include, self.config.exclude)
-#         for label, group_mask in groups:
-#             group_index = pop[group_mask].index
-#             for cause, disability_weight in self.disability_pipelines.items():
-#                 disability_weight = disability_weight(group_index).sum() * step_size_in_years
-#                 new_observations = {
-#                     f"ylds_due_to_{cause}_{label}": disability_weight,
-#                 }
-#                 self.counts.update(new_observations)
-#
-#         pop.loc[:, self.ylds_column_name] += self.disability_weight(pop.index)
-#         self.population_view.update(pop)
-#
-#     ##################################
-#     # Pipeline sources and modifiers #
-#     ##################################
-#
-#     def metrics(self, index: pd.Index, metrics: Dict) -> Dict:
-#         total_ylds = self.population_view.get(index)[self.ylds_column_name].sum()
-#         metrics["years_lived_with_disability"] = total_ylds
-#         metrics.update(self.counts)
-#         return metrics
-#
-#
-# def _disability_post_processor(value: NumberLike, step_size: pd.Timedelta) -> NumberLike:
-#     return rescale_post_processor(union_post_processor(value, step_size), step_size)
+        return _aggregate

--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -29,7 +29,8 @@ from vivarium_public_health.utilities import to_years
 
 
 class DisabilityObserver:
-    """Counts years lived with disability.
+    """ TODO: revisit
+    Counts years lived with disability.
 
     By default, this counts both aggregate and cause-specific years lived
     with disability over the full course of the simulation. It can be
@@ -49,9 +50,8 @@ class DisabilityObserver:
                     include:
                         - "sample_stratification"
     """
-
     configuration_defaults = {
-        "observers": {
+        "stratification": {
             "disability": {
                 "exclude": [],
                 "include": [],
@@ -59,139 +59,211 @@ class DisabilityObserver:
         }
     }
 
-    def __init__(self):
-        self.ylds_column_name = "years_lived_with_disability"
-        self.metrics_pipeline_name = "metrics"
-        self.disability_weight_pipeline_name = "disability_weight"
-
-    def __repr__(self):
-        return "DisabilityObserver()"
-
-    ##############
-    # Properties #
-    ##############
-
     @property
-    def name(self):
-        return "disability_observer"
+    def disease_classes(self) -> List:
+        return [DiseaseState, RiskAttributableDisease]
 
-    #################
-    # Setup methods #
-    #################
+    def setup(self, builder: Builder):
+        self.config = builder.configuration.stratification.disability
+        self.disability_weight = builder.value.get_value("disability_weight")
+        cause_states = builder.components.get_components_by_type(tuple(self.disease_classes))
 
-    # noinspection PyAttributeOutsideInit
-    def setup(self, builder: Builder) -> None:
-        self.config = self._get_stratification_configuration(builder)
-        self.stratifier = self._get_stratifier(builder)
-        self.disability_weight = self._get_disability_weight_pipeline(builder)
-        self._cause_components = self._get_cause_components(builder)
-        self.disability_pipelines = {}
-        self.population_view = self._get_population_view(builder)
-
-        self.counts = Counter()
-
-        self._register_post_setup_listener(builder)
-        self._register_simulant_initializer(builder)
-        self._register_time_step_prepare_listener(builder)
-        self._register_metrics_modifier(builder)
-
-    # noinspection PyMethodMayBeStatic
-    def _get_stratification_configuration(self, builder: Builder) -> ConfigTree:
-        return builder.configuration.observers.disability
-
-    # noinspection PyMethodMayBeStatic
-    def _get_stratifier(self, builder: Builder) -> ResultsStratifier:
-        return builder.components.get_component(ResultsStratifier.name)
-
-    def _get_disability_weight_pipeline(self, builder: Builder) -> Pipeline:
-        # todo observer should not be creating the disability weight pipeline
-        return builder.value.register_value_producer(
-            self.disability_weight_pipeline_name,
-            source=lambda index: [pd.Series(0.0, index=index)],
-            preferred_combiner=list_combiner,
-            preferred_post_processor=_disability_post_processor,
+        builder.results.register_observation(
+            name="ylds_due_to_all_causes",
+            pop_filter='tracked == True and alive == "alive"',
+            aggregator_sources=[str(self.disability_weight)],  # XXX is this right?
+            aggregator=self._disability_weight_aggregator,  # XXX is this right?
+            requires_columns=["alive"],
+            requires_values=["disability_weight"],
+            additional_stratifications=self.config.include,
+            excluded_stratifications=self.config.exclude,
+            when="time_step__prepare",
         )
 
-    # noinspection PyMethodMayBeStatic
-    def _get_cause_components(
-        self, builder: Builder
-    ) -> List[Union[DiseaseState, RiskAttributableDisease]]:
-        return builder.components.get_components_by_type(
-            (DiseaseState, RiskAttributableDisease)
-        )
+        for cause_state in cause_states:
+            pipeline = builder.value.get_value(f'{cause_state.state_id}.disability_weight')
+            builder.results.register_observation(
+                name=f"ylds_due_to_{cause_state.state_id}",
+                pop_filter='tracked == True and alive == "alive"',
+                aggregator_sources=[str(self.disability_weight)],
+                aggregator=self._disability_weight_aggregator,
+                requires_columns=["alive"],
+                requires_values=[f"{cause_state.state_id}.disability_weight"],
+                additional_stratifications=self.config.include,
+                excluded_stratifications=self.config.exclude,
+                when="time_step__prepare",
+            )
 
-    # noinspection PyMethodMayBeStatic
-    def _get_population_view(self, builder: Builder) -> PopulationView:
-        columns_required = [
-            self.ylds_column_name,
-        ]
-        return builder.population.get_view(columns_required)
+    def _disability_weight_aggregator(self, pipeline):
+        def _aggregate(group):
+            return (pipeline(group.index) * to_years(group['step_size'])).sum()
+        return _aggregate
 
-    def _register_post_setup_listener(self, builder: Builder) -> None:
-        builder.event.register_listener("post_setup", self.on_post_setup)
-
-    def _register_simulant_initializer(self, builder: Builder) -> None:
-        # todo observer should not be modifying state table
-        builder.population.initializes_simulants(
-            self.on_initialize_simulants,
-            creates_columns=[self.ylds_column_name],
-        )
-
-    def _register_time_step_prepare_listener(self, builder: Builder) -> None:
-        # In order to get an accurate representation of person time we need to look at
-        # the state table before anything happens.
-        builder.event.register_listener("time_step__prepare", self.on_time_step_prepare)
-
-    def _register_metrics_modifier(self, builder: Builder) -> None:
-        builder.value.register_value_modifier(
-            self.metrics_pipeline_name,
-            modifier=self.metrics,
-            requires_columns=[self.ylds_column_name],
-        )
-
-    ########################
-    # Event-driven methods #
-    ########################
-
-    # noinspection PyUnusedLocal
-    def on_post_setup(self, event: Event) -> None:
-        for cause in self._cause_components:
-            if cause.has_disability:
-                self.disability_pipelines[cause.state_id] = cause.disability_weight
-
-    def on_initialize_simulants(self, pop_data: pd.DataFrame) -> None:
-        self.population_view.update(
-            pd.Series(0.0, index=pop_data.index, name=self.ylds_column_name)
-        )
-
-    def on_time_step_prepare(self, event: Event) -> None:
-        step_size_in_years = to_years(event.step_size)
-        pop = self.population_view.get(
-            event.index, query='tracked == True and alive == "alive"'
-        )
-        groups = self.stratifier.group(pop.index, self.config.include, self.config.exclude)
-        for label, group_mask in groups:
-            group_index = pop[group_mask].index
-            for cause, disability_weight in self.disability_pipelines.items():
-                disability_weight = disability_weight(group_index).sum() * step_size_in_years
-                new_observations = {
-                    f"ylds_due_to_{cause}_{label}": disability_weight,
-                }
-                self.counts.update(new_observations)
-
-        pop.loc[:, self.ylds_column_name] += self.disability_weight(pop.index)
-        self.population_view.update(pop)
-
-    ##################################
-    # Pipeline sources and modifiers #
-    ##################################
-
-    def metrics(self, index: pd.Index, metrics: Dict) -> Dict:
-        total_ylds = self.population_view.get(index)[self.ylds_column_name].sum()
-        metrics["years_lived_with_disability"] = total_ylds
-        metrics.update(self.counts)
-        return metrics
-
-
-def _disability_post_processor(value: NumberLike, step_size: pd.Timedelta) -> NumberLike:
-    return rescale_post_processor(union_post_processor(value, step_size), step_size)
+#
+# class DisabilityObserver:
+#     """Counts years lived with disability.
+#
+#     By default, this counts both aggregate and cause-specific years lived
+#     with disability over the full course of the simulation. It can be
+#     configured to add or remove stratification groups to the default groups
+#     defined by a :class:ResultsStratifier.
+#
+#     In the model specification, your configuration for this component should
+#     be specified as, e.g.:
+#
+#     .. code-block:: yaml
+#
+#         configuration:
+#             observers:
+#                 disability:
+#                     exclude:
+#                         - "sex"
+#                     include:
+#                         - "sample_stratification"
+#     """
+#
+#     configuration_defaults = {
+#         "observers": {
+#             "disability": {
+#                 "exclude": [],
+#                 "include": [],
+#             }
+#         }
+#     }
+#
+#     def __init__(self):
+#         self.ylds_column_name = "years_lived_with_disability"
+#         self.metrics_pipeline_name = "metrics"
+#         self.disability_weight_pipeline_name = "disability_weight"
+#
+#     def __repr__(self):
+#         return "DisabilityObserver()"
+#
+#     ##############
+#     # Properties #
+#     ##############
+#
+#     @property
+#     def name(self):
+#         return "disability_observer"
+#
+#     #################
+#     # Setup methods #
+#     #################
+#
+#     # noinspection PyAttributeOutsideInit
+#     def setup(self, builder: Builder) -> None:
+#         self.config = self._get_stratification_configuration(builder)
+#         self.stratifier = self._get_stratifier(builder)
+#         self.disability_weight = self._get_disability_weight_pipeline(builder)
+#         self._cause_components = self._get_cause_components(builder)
+#         self.disability_pipelines = {}
+#         self.population_view = self._get_population_view(builder)
+#
+#         self.counts = Counter()
+#
+#         self._register_post_setup_listener(builder)
+#         self._register_simulant_initializer(builder)
+#         self._register_time_step_prepare_listener(builder)
+#         self._register_metrics_modifier(builder)
+#
+#     # noinspection PyMethodMayBeStatic
+#     def _get_stratification_configuration(self, builder: Builder) -> ConfigTree:
+#         return builder.configuration.observers.disability
+#
+#     # noinspection PyMethodMayBeStatic
+#     def _get_stratifier(self, builder: Builder) -> ResultsStratifier:
+#         return builder.components.get_component(ResultsStratifier.name)
+#
+#     def _get_disability_weight_pipeline(self, builder: Builder) -> Pipeline:
+#         # todo observer should not be creating the disability weight pipeline
+#         return builder.value.register_value_producer(
+#             self.disability_weight_pipeline_name,
+#             source=lambda index: [pd.Series(0.0, index=index)],
+#             preferred_combiner=list_combiner,
+#             preferred_post_processor=_disability_post_processor,
+#         )
+#
+#     # noinspection PyMethodMayBeStatic
+#     def _get_cause_components(
+#         self, builder: Builder
+#     ) -> List[Union[DiseaseState, RiskAttributableDisease]]:
+#         return builder.components.get_components_by_type(
+#             (DiseaseState, RiskAttributableDisease)
+#         )
+#
+#     # noinspection PyMethodMayBeStatic
+#     def _get_population_view(self, builder: Builder) -> PopulationView:
+#         columns_required = [
+#             self.ylds_column_name,
+#         ]
+#         return builder.population.get_view(columns_required)
+#
+#     def _register_post_setup_listener(self, builder: Builder) -> None:
+#         builder.event.register_listener("post_setup", self.on_post_setup)
+#
+#     def _register_simulant_initializer(self, builder: Builder) -> None:
+#         # todo observer should not be modifying state table
+#         builder.population.initializes_simulants(
+#             self.on_initialize_simulants,
+#             creates_columns=[self.ylds_column_name],
+#         )
+#
+#     def _register_time_step_prepare_listener(self, builder: Builder) -> None:
+#         # In order to get an accurate representation of person time we need to look at
+#         # the state table before anything happens.
+#         builder.event.register_listener("time_step__prepare", self.on_time_step_prepare)
+#
+#     def _register_metrics_modifier(self, builder: Builder) -> None:
+#         builder.value.register_value_modifier(
+#             self.metrics_pipeline_name,
+#             modifier=self.metrics,
+#             requires_columns=[self.ylds_column_name],
+#         )
+#
+#     ########################
+#     # Event-driven methods #
+#     ########################
+#
+#     # noinspection PyUnusedLocal
+#     def on_post_setup(self, event: Event) -> None:
+#         for cause in self._cause_components:
+#             if cause.has_disability:
+#                 self.disability_pipelines[cause.state_id] = cause.disability_weight
+#
+#     def on_initialize_simulants(self, pop_data: pd.DataFrame) -> None:
+#         self.population_view.update(
+#             pd.Series(0.0, index=pop_data.index, name=self.ylds_column_name)
+#         )
+#
+#     def on_time_step_prepare(self, event: Event) -> None:
+#         step_size_in_years = to_years(event.step_size)
+#         pop = self.population_view.get(
+#             event.index, query='tracked == True and alive == "alive"'
+#         )
+#         groups = self.stratifier.group(pop.index, self.config.include, self.config.exclude)
+#         for label, group_mask in groups:
+#             group_index = pop[group_mask].index
+#             for cause, disability_weight in self.disability_pipelines.items():
+#                 disability_weight = disability_weight(group_index).sum() * step_size_in_years
+#                 new_observations = {
+#                     f"ylds_due_to_{cause}_{label}": disability_weight,
+#                 }
+#                 self.counts.update(new_observations)
+#
+#         pop.loc[:, self.ylds_column_name] += self.disability_weight(pop.index)
+#         self.population_view.update(pop)
+#
+#     ##################################
+#     # Pipeline sources and modifiers #
+#     ##################################
+#
+#     def metrics(self, index: pd.Index, metrics: Dict) -> Dict:
+#         total_ylds = self.population_view.get(index)[self.ylds_column_name].sum()
+#         metrics["years_lived_with_disability"] = total_ylds
+#         metrics.update(self.counts)
+#         return metrics
+#
+#
+# def _disability_post_processor(value: NumberLike, step_size: pd.Timedelta) -> NumberLike:
+#     return rescale_post_processor(union_post_processor(value, step_size), step_size)

--- a/tests/metrics/test_observers.py
+++ b/tests/metrics/test_observers.py
@@ -3,6 +3,9 @@ from vivarium_public_health.metrics.disability import DisabilityObserver
 
 
 def test_disability_observer_setup(mocker):
+    """Test that DisabilityObserver.setup() registers expected observation
+    and returns expected disease classes."""
+
     observer = DisabilityObserver()
     builder = mocker.Mock()
     builder.results.register_observation = mocker.Mock()

--- a/tests/metrics/test_observers.py
+++ b/tests/metrics/test_observers.py
@@ -13,8 +13,8 @@ def test_disability_observer_setup(mocker):
     builder.results.register_observation.assert_called_once_with(
         name="ylds_due_to_all_causes",
         pop_filter='tracked == True and alive == "alive"',
-        aggregator_sources=[str(observer.disability_weight)],  # XXX is this right?
-        aggregator=observer._disability_weight_aggregator,  # XXX is this right?
+        aggregator_sources=[str(observer.disability_weight)],
+        aggregator=observer._disability_weight_aggregator,
         requires_columns=["alive"],
         requires_values=["disability_weight"],
         additional_stratifications=observer.config.include,
@@ -23,6 +23,3 @@ def test_disability_observer_setup(mocker):
     )
     assert DiseaseState in observer.disease_classes
     assert RiskAttributableDisease in observer.disease_classes
-
-
-# Test _disability_weight_aggregator?

--- a/tests/metrics/test_observers.py
+++ b/tests/metrics/test_observers.py
@@ -1,19 +1,30 @@
+from collections import namedtuple
+
+import pandas as pd
+
 from vivarium_public_health.disease import DiseaseState, RiskAttributableDisease
 from vivarium_public_health.metrics.disability import DisabilityObserver
 
 
 def test_disability_observer_setup(mocker):
-    """Test that DisabilityObserver.setup() registers expected observation
+    """Test that DisabilityObserver.setup() registers expected observations
     and returns expected disease classes."""
 
     observer = DisabilityObserver()
     builder = mocker.Mock()
     builder.results.register_observation = mocker.Mock()
-    builder.components.get_components_by_type = lambda n: []
+
+    # Set up fake calls for cause-specific register_observation args
+    MockCause = namedtuple("MockCause", "state_id")
+    builder.components.get_components_by_type = lambda n: [
+        MockCause("flu"),
+        MockCause("measles"),
+    ]
+    builder.value.get_value = lambda n: n
 
     builder.results.register_observation.assert_not_called()
     observer.setup(builder)
-    builder.results.register_observation.assert_called_once_with(
+    builder.results.register_observation.assert_any_call(
         name="ylds_due_to_all_causes",
         pop_filter='tracked == True and alive == "alive"',
         aggregator_sources=[str(observer.disability_weight)],
@@ -24,5 +35,37 @@ def test_disability_observer_setup(mocker):
         excluded_stratifications=observer.config.exclude,
         when="time_step__prepare",
     )
+    builder.results.register_observation.assert_any_call(
+        name="ylds_due_to_flu",
+        pop_filter='tracked == True and alive == "alive"',
+        aggregator_sources=[str("flu.disability_weight")],
+        aggregator=observer._disability_weight_aggregator,
+        requires_columns=["alive"],
+        requires_values=["flu.disability_weight"],
+        additional_stratifications=observer.config.include,
+        excluded_stratifications=observer.config.exclude,
+        when="time_step__prepare",
+    )
+    builder.results.register_observation.assert_any_call(
+        name="ylds_due_to_measles",
+        pop_filter='tracked == True and alive == "alive"',
+        aggregator_sources=[str("measles.disability_weight")],
+        aggregator=observer._disability_weight_aggregator,
+        requires_columns=["alive"],
+        requires_values=["measles.disability_weight"],
+        additional_stratifications=observer.config.include,
+        excluded_stratifications=observer.config.exclude,
+        when="time_step__prepare",
+    )
+    assert builder.results.register_observation.call_count == 3
     assert DiseaseState in observer.disease_classes
     assert RiskAttributableDisease in observer.disease_classes
+
+
+def test__disability_weight_aggregator():
+    """Test that the disability weight aggregator produces expected ylds."""
+    observer = DisabilityObserver()
+    observer.step_size = pd.Timedelta(days=365.25)  # easy yld math
+    fake_weights = pd.DataFrame(1.0, index=range(1000), columns=["disability_weight"])
+    aggregated_weight = observer._disability_weight_aggregator(fake_weights)
+    assert aggregated_weight == 1000.0

--- a/tests/metrics/test_observers.py
+++ b/tests/metrics/test_observers.py
@@ -1,0 +1,28 @@
+from vivarium_public_health.disease import DiseaseState, RiskAttributableDisease
+from vivarium_public_health.metrics.disability import DisabilityObserver
+
+
+def test_disability_observer_setup(mocker):
+    observer = DisabilityObserver()
+    builder = mocker.Mock()
+    builder.results.register_observation = mocker.Mock()
+    builder.components.get_components_by_type = lambda n: []
+
+    builder.results.register_observation.assert_not_called()
+    observer.setup(builder)
+    builder.results.register_observation.assert_called_once_with(
+        name="ylds_due_to_all_causes",
+        pop_filter='tracked == True and alive == "alive"',
+        aggregator_sources=[str(observer.disability_weight)],  # XXX is this right?
+        aggregator=observer._disability_weight_aggregator,  # XXX is this right?
+        requires_columns=["alive"],
+        requires_values=["disability_weight"],
+        additional_stratifications=observer.config.include,
+        excluded_stratifications=observer.config.exclude,
+        when="time_step__prepare",
+    )
+    assert DiseaseState in observer.disease_classes
+    assert RiskAttributableDisease in observer.disease_classes
+
+
+# Test _disability_weight_aggregator?


### PR DESCRIPTION
## Implement DisabilityObserver and add unit tests 

### Description
- *Category*: feature
- *JIRA issue*: [MIC-3682](https://jira.ihme.washington.edu/browse/MIC-3682)

### Changes and notes
- Adds DisabilityObserver implementation per design at https://ihmeuw.github.io/vivarium_development/docs/build/html/design/2022_05_25_results_writer.html#sample-observers
- Adds a unit test for setup, testing for expected observations
- Adds test for aggregator for ylds

### Testing
Tests pass.

