### PR TITLE
Throw error when subsetting relative risk data to empty dataframe

### DIFF
--- a/src/vivarium_public_health/risks/data_transformations.py
+++ b/src/vivarium_public_health/risks/data_transformations.py
@@ -470,10 +470,14 @@ def validate_relative_risk_data_source(builder, risk: EntityString, target: Targ
     return source_type
 
 
-def validate_rebin_source(builder, risk: EntityString, target: TargetString, data: pd.DataFrame):
+def validate_rebin_source(
+    builder, risk: EntityString, target: TargetString, data: pd.DataFrame
+):
     if data.index.size == 0:
-        raise ValueError(f"Subsetting {risk} relative risk data to {target.name} {target.measure} "
-                         "returned an empty DataFrame. Check your artifact.")
+        raise ValueError(
+            f"Subsetting {risk} relative risk data to {target.name} {target.measure} "
+            "returned an empty DataFrame. Check your artifact."
+        )
 
     rebin_exposed_categories = set(builder.configuration[risk.name]["rebinned_exposed"])
 

--- a/src/vivarium_public_health/risks/data_transformations.py
+++ b/src/vivarium_public_health/risks/data_transformations.py
@@ -175,6 +175,7 @@ def _rebin_exposure_data(
 def get_relative_risk_data(builder, risk: EntityString, target: TargetString):
     source_type = validate_relative_risk_data_source(builder, risk, target)
     relative_risk_data = load_relative_risk_data(builder, risk, target, source_type)
+    validate_rebin_source(builder, risk, target, relative_risk_data)
     relative_risk_data = rebin_relative_risk_data(builder, risk, relative_risk_data)
 
     if get_distribution_type(builder, risk) in [
@@ -210,11 +211,6 @@ def load_relative_risk_data(
         correct_target = (relative_risk_data["affected_entity"] == target.name) & (
             relative_risk_data["affected_measure"] == target.measure
         )
-
-        if sum(correct_target) == 0:
-            raise ValueError(f"Subsetting relative risk data to target {target.name}.{target.measure}"
-                             " returned an empty DataFrame.")
-        
         relative_risk_data = relative_risk_data[correct_target].drop(
             columns=["affected_entity", "affected_measure"]
         )
@@ -292,7 +288,6 @@ def rebin_relative_risk_data(
     (0.1 *rr1 + 0.2 * rr2 + 0.3* rr3) / (0.1+0.2+0.3)
     """
     rebin_exposed_categories = set(builder.configuration[risk.name]["rebinned_exposed"])
-    validate_rebin_source(builder, risk, relative_risk_data)
 
     if rebin_exposed_categories:
         exposure_data = load_exposure_data(builder, risk)
@@ -475,7 +470,11 @@ def validate_relative_risk_data_source(builder, risk: EntityString, target: Targ
     return source_type
 
 
-def validate_rebin_source(builder, risk: EntityString, data: pd.DataFrame):
+def validate_rebin_source(builder, risk: EntityString, target: TargetString, data: pd.DataFrame):
+    if data.index.size == 0:
+        raise ValueError(f"Subsetting {risk} relative risk data to {target.name} {target.measure} "
+                         "returned an empty DataFrame. Check your artifact.")
+
     rebin_exposed_categories = set(builder.configuration[risk.name]["rebinned_exposed"])
 
     if rebin_exposed_categories and builder.configuration[risk.name]["category_thresholds"]:

--- a/src/vivarium_public_health/risks/data_transformations.py
+++ b/src/vivarium_public_health/risks/data_transformations.py
@@ -210,6 +210,11 @@ def load_relative_risk_data(
         correct_target = (relative_risk_data["affected_entity"] == target.name) & (
             relative_risk_data["affected_measure"] == target.measure
         )
+
+        if sum(correct_target) == 0:
+            raise ValueError(f"Subsetting relative risk data to target {target.name}.{target.measure}"
+                             " returned an empty DataFrame.")
+        
         relative_risk_data = relative_risk_data[correct_target].drop(
             columns=["affected_entity", "affected_measure"]
         )

--- a/src/vivarium_public_health/testing/mock_artifact.py
+++ b/src/vivarium_public_health/testing/mock_artifact.py
@@ -31,7 +31,15 @@ MOCKERS = {
             [1.5, "continuous", "test_cause", "incidence_rate"],
             1990,
             2017,
-            ("age", "sex", "year", "value", "parameter", "affected_entity", "affected_measure"),
+            (
+                "age",
+                "sex",
+                "year",
+                "value",
+                "parameter",
+                "affected_entity",
+                "affected_measure",
+            ),
         ),
         "population_attributable_fraction": build_table(
             [1, "test_cause_1", "incidence_rate"],

--- a/src/vivarium_public_health/testing/mock_artifact.py
+++ b/src/vivarium_public_health/testing/mock_artifact.py
@@ -31,7 +31,7 @@ MOCKERS = {
             [1.5, "continuous", "test_cause", "incidence_rate"],
             1990,
             2017,
-            ("age", "sex", "year", "value", "parameter", "cause", "affected_measure"),
+            ("age", "sex", "year", "value", "parameter", "affected_entity", "affected_measure"),
         ),
         "population_attributable_fraction": build_table(
             [1, "test_cause_1", "incidence_rate"],

--- a/tests/risks/test_data_transformations.py
+++ b/tests/risks/test_data_transformations.py
@@ -1,13 +1,14 @@
 import pandas as pd
 import pytest
-
 from vivarium.interface.interactive import InteractiveContext
+
 from vivarium_public_health.risks.data_transformations import (
     _rebin_exposure_data,
     _rebin_relative_risk_data,
+    get_relative_risk_data,
 )
 from vivarium_public_health.utilities import EntityString, TargetString
-from vivarium_public_health.risks.data_transformations import get_relative_risk_data
+
 
 @pytest.mark.parametrize(
     "rebin_categories, rebinned_values",
@@ -70,25 +71,34 @@ def test__rebin_relative_risk(rebin_categories, rebinned_values):
     assert (rebinned_df[rebinned_df.parameter == "cat1"].value == rebinned_values[0]).all()
     assert (rebinned_df[rebinned_df.parameter == "cat2"].value == rebinned_values[1]).all()
 
+
 def test__subset_relative_risk_to_empty_dataframe(base_config, base_plugins):
-    risk = EntityString('risk_factor.risk_factor')
+    risk = EntityString("risk_factor.risk_factor")
     target = TargetString("cause.test_cause.missing_measure")
 
-    sim = InteractiveContext(model_specification=None, components=None, configuration=base_config, plugin_configuration=base_plugins, setup=False)
-    sim.configuration.update({
-        f"effect_of_{risk.name}_on_{target.name}": {
-            f"{target.measure}": {
+    sim = InteractiveContext(
+        model_specification=None,
+        components=None,
+        configuration=base_config,
+        plugin_configuration=base_plugins,
+        setup=False,
+    )
+    sim.configuration.update(
+        {
+            f"effect_of_{risk.name}_on_{target.name}": {
+                f"{target.measure}": {
                     "relative_risk": None,
                     "mean": None,
                     "se": None,
                     "log_mean": None,
                     "log_se": None,
                     "tau_squared": None,
-            },
+                },
+            }
         }
-    })
+    )
     sim.setup()
 
-    error_msg = f'Subsetting {risk} relative risk data to {target.name} {target.measure} returned an empty DataFrame. Check your artifact'
+    error_msg = f"Subsetting {risk} relative risk data to {target.name} {target.measure} returned an empty DataFrame. Check your artifact"
     with pytest.raises(ValueError, match=error_msg):
         get_relative_risk_data(sim._builder, risk, target)

--- a/tests/risks/test_data_transformations.py
+++ b/tests/risks/test_data_transformations.py
@@ -1,11 +1,13 @@
 import pandas as pd
 import pytest
 
+from vivarium.interface.interactive import InteractiveContext
 from vivarium_public_health.risks.data_transformations import (
     _rebin_exposure_data,
     _rebin_relative_risk_data,
 )
-
+from vivarium_public_health.utilities import EntityString, TargetString
+from vivarium_public_health.risks.data_transformations import get_relative_risk_data
 
 @pytest.mark.parametrize(
     "rebin_categories, rebinned_values",
@@ -67,3 +69,26 @@ def test__rebin_relative_risk(rebin_categories, rebinned_values):
     assert rebinned_df.shape == (8, 4)
     assert (rebinned_df[rebinned_df.parameter == "cat1"].value == rebinned_values[0]).all()
     assert (rebinned_df[rebinned_df.parameter == "cat2"].value == rebinned_values[1]).all()
+
+def test__subset_relative_risk_to_empty_dataframe(base_config, base_plugins):
+    risk = EntityString('risk_factor.risk_factor')
+    target = TargetString("cause.test_cause.missing_measure")
+
+    sim = InteractiveContext(model_specification=None, components=None, configuration=base_config, plugin_configuration=base_plugins, setup=False)
+    sim.configuration.update({
+        f"effect_of_{risk.name}_on_{target.name}": {
+            f"{target.measure}": {
+                    "relative_risk": None,
+                    "mean": None,
+                    "se": None,
+                    "log_mean": None,
+                    "log_se": None,
+                    "tau_squared": None,
+            },
+        }
+    })
+    sim.setup()
+
+    error_msg = f'Subsetting {risk} relative risk data to {target.name} {target.measure} returned an empty DataFrame. Check your artifact'
+    with pytest.raises(ValueError, match=error_msg):
+        get_relative_risk_data(sim._builder, risk, target)


### PR DESCRIPTION
## Throw error when subsetting relative risk data to empty dataframe

### Description
- *Category*: feature/test
- *JIRA issue*: [MIC-3468](https://jira.ihme.washington.edu/browse/MIC-3468)

### Changes and notes
Move validation out of rebinning step to after loading relative risk data. Throw an error if the data in this validation step is empty. Add a test that checks if error is thrown when relative risk data is missing data for the specified target. Change "cause" column in mock artifact to "affected_entity".

### Testing
Check that test passed. Check that other ways of ending up with an empty dataframe will either not occur or throw a different error. Check that changing mock artifact won't affect existing tests. 