### PR TITLE
Feature/mic 3752 observer integration test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
         long_description = f.read()
 
     install_requirements = [
-        "vivarium>=1.0.2",
+        "vivarium>=1.0.3",
         "numpy",
         "pandas",
         "scipy",

--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -53,8 +53,6 @@ class DisabilityObserver:
     }
 
     def __init__(self):
-        # self.ylds_column_name = "years_lived_with_disability"
-        # self.metrics_pipeline_name = "metrics"
         self.disability_weight_pipeline_name = "disability_weight"
 
     def __repr__(self):
@@ -88,7 +86,9 @@ class DisabilityObserver:
         )
 
         for cause_state in cause_states:
-            cause_disability_weight_pipeline_name = f"{cause_state.state_id}.disability_weight"
+            cause_disability_weight_pipeline_name = (
+                f"{cause_state.state_id}.disability_weight"
+            )
             builder.results.register_observation(
                 name=f"ylds_due_to_{cause_state.state_id}",
                 pop_filter='tracked == True and alive == "alive"',
@@ -106,11 +106,8 @@ class DisabilityObserver:
             self.disability_weight_pipeline_name,
             source=lambda index: [pd.Series(0.0, index=index)],
             preferred_combiner=list_combiner,
-            preferred_post_processor=self._disability_post_processor,
+            preferred_post_processor=union_post_processor,
         )
 
     def _disability_weight_aggregator(self, dw: pd.DataFrame) -> float:
         return (dw * to_years(self.step_size)).sum().squeeze()
-
-    def _disability_post_processor(self, value: NumberLike, step_size: pd.Timedelta) -> NumberLike:
-        return rescale_post_processor(union_post_processor(value, self.step_size), self.step_size)

--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -70,7 +70,7 @@ class DisabilityObserver:
     def setup(self, builder: Builder):
         self.config = builder.configuration.stratification.disability
         self.step_size = pd.Timedelta(days=builder.configuration.time.step_size)
-        self.disability_weight = self._get_disability_weight_pipeline(builder)
+        self.disability_weight = self.get_disability_weight_pipeline(builder)
         cause_states = builder.components.get_components_by_type(tuple(self.disease_classes))
 
         builder.results.register_observation(
@@ -101,7 +101,7 @@ class DisabilityObserver:
                 when="time_step__prepare",
             )
 
-    def _get_disability_weight_pipeline(self, builder: Builder) -> Pipeline:
+    def get_disability_weight_pipeline(self, builder: Builder) -> Pipeline:
         return builder.value.register_value_producer(
             self.disability_weight_pipeline_name,
             source=lambda index: [pd.Series(0.0, index=index)],

--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -78,7 +78,7 @@ class DisabilityObserver:
         builder.results.register_observation(
             name="ylds_due_to_all_causes",
             pop_filter='tracked == True and alive == "alive"',
-            aggregator_sources=[str(self.disability_weight)],
+            aggregator_sources=[self.disability_weight_pipeline_name],
             aggregator=self._disability_weight_aggregator,
             requires_columns=["alive"],
             requires_values=["disability_weight"],
@@ -88,14 +88,14 @@ class DisabilityObserver:
         )
 
         for cause_state in cause_states:
-            pipeline = builder.value.get_value(f"{cause_state.state_id}.disability_weight")
+            cause_disability_weight_pipeline_name = f"{cause_state.state_id}.disability_weight"
             builder.results.register_observation(
                 name=f"ylds_due_to_{cause_state.state_id}",
                 pop_filter='tracked == True and alive == "alive"',
-                aggregator_sources=[str(pipeline)],
+                aggregator_sources=[cause_disability_weight_pipeline_name],
                 aggregator=self._disability_weight_aggregator,
                 requires_columns=["alive"],
-                requires_values=[f"{cause_state.state_id}.disability_weight"],
+                requires_values=[cause_disability_weight_pipeline_name],
                 additional_stratifications=self.config.include,
                 excluded_stratifications=self.config.exclude,
                 when="time_step__prepare",

--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -68,9 +68,7 @@ class ResultsStratifier:
             requires_columns=["exit_time"],
         )
         builder.results.register_stratification(
-            "sex",
-            ["Female", "Male"],
-            requires_columns=["sex"]
+            "sex", ["Female", "Male"], requires_columns=["sex"]
         )
 
     def map_age_groups(self, pop: pd.DataFrame) -> pd.Series:

--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -16,7 +16,7 @@ class ResultsStratifier:
 
     configuration_defaults = {
         "stratification": {
-            "default": ["age_group", "sex"],
+            "default": [],
         }
     }
 
@@ -62,10 +62,15 @@ class ResultsStratifier:
         )
         builder.results.register_stratification(
             "exit_year",
-            [str(year) for year in range(self.start_year, self.end_year + 1)],
+            [str(year) for year in range(self.start_year, self.end_year + 1)] + ["nan"],
             self.map_year,
             is_vectorized=True,
             requires_columns=["exit_time"],
+        )
+        builder.results.register_stratification(
+            "sex",
+            ["Female", "Male"],
+            requires_columns=["sex"]
         )
 
     def map_age_groups(self, pop: pd.DataFrame) -> pd.Series:
@@ -100,7 +105,7 @@ class ResultsStratifier:
         pandas.Series
             A pd.Series with years corresponding to the pop passed into the function
         """
-        return pop.squeeze(axis=1).dt.year
+        return pop.squeeze(axis=1).dt.year.apply(str)
 
     @staticmethod
     def get_age_bins(builder: Builder) -> pd.DataFrame:

--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -16,10 +16,11 @@ class ResultsStratifier:
 
     configuration_defaults = {
         "stratification": {
-            "default": [],
+            "default": ["age_group", "sex"],
         }
     }
 
+    # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
         self.age_bins = self.get_age_bins(builder)
         self.start_year = builder.configuration.time.start.year

--- a/tests/metrics/test_observers.py
+++ b/tests/metrics/test_observers.py
@@ -46,6 +46,7 @@ def test_disability_observer_setup(mocker):
     observer = DisabilityObserver()
     builder = mocker.Mock()
     builder.results.register_observation = mocker.Mock()
+    builder.configuration.time.step_size = 28
 
     # Set up fake calls for cause-specific register_observation args
     MockCause = namedtuple("MockCause", "state_id")
@@ -60,7 +61,7 @@ def test_disability_observer_setup(mocker):
     builder.results.register_observation.assert_any_call(
         name="ylds_due_to_all_causes",
         pop_filter='tracked == True and alive == "alive"',
-        aggregator_sources=[str(observer.disability_weight)],
+        aggregator_sources=["disability_weight"],
         aggregator=observer._disability_weight_aggregator,
         requires_columns=["alive"],
         requires_values=["disability_weight"],
@@ -71,7 +72,7 @@ def test_disability_observer_setup(mocker):
     builder.results.register_observation.assert_any_call(
         name="ylds_due_to_flu",
         pop_filter='tracked == True and alive == "alive"',
-        aggregator_sources=[str("flu.disability_weight")],
+        aggregator_sources=["flu.disability_weight"],
         aggregator=observer._disability_weight_aggregator,
         requires_columns=["alive"],
         requires_values=["flu.disability_weight"],
@@ -82,7 +83,7 @@ def test_disability_observer_setup(mocker):
     builder.results.register_observation.assert_any_call(
         name="ylds_due_to_measles",
         pop_filter='tracked == True and alive == "alive"',
-        aggregator_sources=[str("measles.disability_weight")],
+        aggregator_sources=["measles.disability_weight"],
         aggregator=observer._disability_weight_aggregator,
         requires_columns=["alive"],
         requires_values=["measles.disability_weight"],

--- a/tests/metrics/test_observers.py
+++ b/tests/metrics/test_observers.py
@@ -1,9 +1,61 @@
 from collections import namedtuple
 
+import numpy as np
 import pandas as pd
+import pytest
 
-from vivarium_public_health.disease import DiseaseState, RiskAttributableDisease
-from vivarium_public_health.metrics.disability import DisabilityObserver
+from vivarium import InteractiveContext
+from vivarium.framework.utilities import from_yearly
+from vivarium.testing_utilities import TestPopulation, build_table, metadata
+
+from vivarium_public_health.disease import BaseDiseaseState, DiseaseModel, DiseaseState, RiskAttributableDisease, RateTransition
+from vivarium_public_health.metrics.disability import DisabilityObserver as DisabilityObserver_
+from vivarium_public_health.metrics.stratification import ResultsStratifier as ResultsStratifier_
+
+from vivarium_public_health.disease.state import SusceptibleState
+from vivarium_public_health.disease.transition import TransitionString
+from vivarium_public_health.population import Mortality
+
+
+class ResultsStratifier(ResultsStratifier_):
+    configuration_defaults = {
+        "stratification": {
+            "default": ["age_group", "sex"],
+        }
+    }
+
+
+class DisabilityObserver(DisabilityObserver_):
+    """Counts years lived with disability.
+
+    By default, this counts both aggregate and cause-specific years lived
+    with disability over the full course of the simulation.
+
+    In the model specification, your configuration for this component should
+    be specified as, e.g.:
+
+    .. code-block:: yaml
+
+        configuration:
+            observers:
+                disability:
+                    exclude:
+                        - "sex"
+                    include:
+                        - "sample_stratification"
+    """
+
+    configuration_defaults = {
+        "stratification": {
+            "disability": {
+                "exclude": [],
+                "include": ["age_group", "sex"],
+            }
+        }
+    }
+
+    # def setup(self, builder: Builder):
+    #     super().setup()
 
 
 def test_disability_observer_setup(mocker):
@@ -69,3 +121,53 @@ def test__disability_weight_aggregator():
     fake_weights = pd.DataFrame(1.0, index=range(1000), columns=["disability_weight"])
     aggregated_weight = observer._disability_weight_aggregator(fake_weights)
     assert aggregated_weight == 1000.0
+
+
+# @pytest.mark.parametrize("disability_weight_value", [0.0, 0.25, 0.5, 1.0,])
+@pytest.mark.parametrize("disability_weight_value", [0.5])
+def test_disability_accumulation(base_config, base_plugins, disability_weight_value):
+    """Integration test for the observer and the Results Management system."""
+    year_start = base_config.time.start.year
+    year_end = base_config.time.end.year
+
+    time_step = pd.Timedelta(days=base_config.time.step_size)
+
+    # Set up multiple causes of disability
+    healthy_0 = BaseDiseaseState("healthy_0")
+    healthy_1 = BaseDiseaseState("healthy_1")
+    disability_get_data_funcs = {
+        "dwell_time": lambda _, __: pd.Timedelta(days=0),
+        "disability_weight": lambda _, __: build_table(disability_weight_value, year_start - 1, year_end),
+        "prevalence": lambda _, __: build_table(
+            0.25, year_start - 1, year_end, ["age", "year", "sex", "value"]
+        ),
+        "excess_mortality_rate": lambda _, __: 0.0,
+    }
+
+    disability_state_0 = DiseaseState("sick_cause_0", get_data_functions=disability_get_data_funcs)
+    disability_state_1 = DiseaseState("sick_cause_1", get_data_functions=disability_get_data_funcs)
+
+    # healthy.add_transition(disability_state)
+
+    model_0 = DiseaseModel("cause_0", initial_state=healthy_0, states=[healthy_0, disability_state_0])
+    model_1 = DiseaseModel("cause_1", initial_state=healthy_1, states=[healthy_1, disability_state_1])
+
+    simulation = InteractiveContext(
+        components=[TestPopulation(), model_0, model_1, ResultsStratifier(), DisabilityObserver()],
+        configuration=base_config,
+        plugin_configuration=base_plugins,
+        setup=False,
+    )
+
+    # Register rate producer for "disability_weight" sourced by "sick.disability_weight"
+    # simulation._values.register_value_producer("disability_weight", "sick.disability_weight")
+    simulation.setup()
+
+    disability_weight = simulation._values.get_value("disability_weight")
+
+    simulation.step()
+    # Folks instantly transition to sick so now our mortality rate should be much higher
+    # assert np.allclose(
+    #     from_yearly(0.7, time_step), mortality_rate(simulation.get_population().index)["sick"]
+    # )
+    assert True

--- a/tests/metrics/test_observers.py
+++ b/tests/metrics/test_observers.py
@@ -20,6 +20,7 @@ from vivarium_public_health.metrics.stratification import (
 )
 
 
+# Subclass of ResultsStratifier for integration testing
 class ResultsStratifier(ResultsStratifier_):
     configuration_defaults = {
         "stratification": {
@@ -28,6 +29,7 @@ class ResultsStratifier(ResultsStratifier_):
     }
 
 
+# Subclass of DisabilityObserver for integration testing
 class DisabilityObserver(DisabilityObserver_):
     configuration_defaults = {
         "stratification": {
@@ -43,7 +45,7 @@ def test_disability_observer_setup(mocker):
     """Test that DisabilityObserver.setup() registers expected observations
     and returns expected disease classes."""
 
-    observer = DisabilityObserver()
+    observer = DisabilityObserver_()
     builder = mocker.Mock()
     builder.results.register_observation = mocker.Mock()
     builder.configuration.time.step_size = 28
@@ -98,7 +100,7 @@ def test_disability_observer_setup(mocker):
 
 def test__disability_weight_aggregator():
     """Test that the disability weight aggregator produces expected ylds."""
-    observer = DisabilityObserver()
+    observer = DisabilityObserver_()
     observer.step_size = pd.Timedelta(days=365.25)  # easy yld math
     fake_weights = pd.DataFrame(1.0, index=range(1000), columns=["disability_weight"])
     aggregated_weight = observer._disability_weight_aggregator(fake_weights)
@@ -185,9 +187,9 @@ def test_disability_accumulation(
     }
 
     # Get pipelines
-    disability_weight = simulation._values.get_value("disability_weight")
-    disability_weight_0 = simulation._values.get_value("sick_cause_0.disability_weight")
-    disability_weight_1 = simulation._values.get_value("sick_cause_1.disability_weight")
+    disability_weight = simulation.get_value("disability_weight")
+    disability_weight_0 = simulation.get_value("sick_cause_0.disability_weight")
+    disability_weight_1 = simulation.get_value("sick_cause_1.disability_weight")
 
     # Check that disability weights are computed as expected
     for sub_pop_key in ["healthy", "sick_0", "sick_1", "sick_0_1"]:
@@ -203,7 +205,7 @@ def test_disability_accumulation(
             rtol=0.0000001,
         ).all()
 
-    results_out = simulation._values.get_value("metrics")(pop.index)
+    results_out = simulation.get_value("metrics")(pop.index)
 
     # Check that all expected observation labels are there
     for label in yld_stratification_mask.keys():

--- a/tests/metrics/test_stratification.py
+++ b/tests/metrics/test_stratification.py
@@ -140,12 +140,15 @@ def test_results_stratifier_register_stratifications(mocker):
     )
     builder.results.register_stratification.assert_any_call(
         "exit_year",
-        years_list,
+        years_list + ["nan"],
         rs.map_year,
         is_vectorized=True,
         requires_columns=["exit_time"],
     )
-    assert builder.results.register_stratification.call_count == 5
+    builder.results.register_stratification.assert_any_call(
+        "sex", ["Female", "Male"], requires_columns=["sex"]
+    )
+    assert builder.results.register_stratification.call_count == 6
 
 
 def test_results_stratifier_map_age_groups():
@@ -167,7 +170,7 @@ def test_results_stratifier_map_year():
     pop = pd.DataFrame(FAKE_POP_EVENT_TIME)
     rs = ResultsStratifier()
     the_year = rs.map_year(pop)
-    assert (the_year == 2045).all()
+    assert (the_year == "2045").all()
 
 
 def test_results_stratifier_get_age_bins(mocker):


### PR DESCRIPTION
## Add disability observer integration test, fix bugs in observer

### Description
- *Category*: bugfix and test
- *JIRA issue*: [MIC-3752](https://jira.ihme.washington.edu/browse/MIC-3752)

### Changes and notes
- Adds an integration test for the disability observer, with two sources of disability, checking disability weight and ylds metrics for correctness
- Fixes a number of small bugs in the disability observer implementation and `ResultsStratifier` implementation discovered during development of the integration test
- Corrects the disability weight post processor to not scale to years (it shouldn't).

### Testing
All results tests pass with the develop branch of vivarium.
