### PR TITLE
Fix validating rebinning source 

### DIFF
--- a/src/vivarium_public_health/risks/data_transformations.py
+++ b/src/vivarium_public_health/risks/data_transformations.py
@@ -175,7 +175,7 @@ def _rebin_exposure_data(
 def get_relative_risk_data(builder, risk: EntityString, target: TargetString):
     source_type = validate_relative_risk_data_source(builder, risk, target)
     relative_risk_data = load_relative_risk_data(builder, risk, target, source_type)
-    validate_rebin_source(builder, risk, target, relative_risk_data)
+    validate_relative_risk_rebin_source(builder, risk, target, relative_risk_data)
     relative_risk_data = rebin_relative_risk_data(builder, risk, relative_risk_data)
 
     if get_distribution_type(builder, risk) in [
@@ -470,7 +470,7 @@ def validate_relative_risk_data_source(builder, risk: EntityString, target: Targ
     return source_type
 
 
-def validate_rebin_source(
+def validate_relative_risk_rebin_source(
     builder, risk: EntityString, target: TargetString, data: pd.DataFrame
 ):
     if data.index.size == 0:
@@ -478,7 +478,10 @@ def validate_rebin_source(
             f"Subsetting {risk} relative risk data to {target.name} {target.measure} "
             "returned an empty DataFrame. Check your artifact."
         )
+    validate_rebin_source(builder, risk, data)
 
+
+def validate_rebin_source(builder, risk: EntityString, data: pd.DataFrame):
     rebin_exposed_categories = set(builder.configuration[risk.name]["rebinned_exposed"])
 
     if rebin_exposed_categories and builder.configuration[risk.name]["category_thresholds"]:


### PR DESCRIPTION
## Fix rebinning source validation 

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3795](https://jira.ihme.washington.edu/browse/MIC-3795)

### Changes and notes
Previously added argument to validate_rebin_source which was only relevant when data is for relative risk. A call to this function was not updated appropriately when validating exposure data. Keep the original function in the case of exposure validation and create new function which performs relative risk-specific validation and then calls the original function.  

### Testing
Successfully ran simulation setup for US CVD which was failing because of this bug.