### PR TITLE
Rename crn attribute randomness arg

### DIFF
--- a/src/vivarium_public_health/population/base_population.py
+++ b/src/vivarium_public_health/population/base_population.py
@@ -67,13 +67,13 @@ class BasePopulation:
         self.randomness = {
             "general_purpose": builder.randomness.get_stream("population_generation"),
             "bin_selection": builder.randomness.get_stream(
-                "bin_selection", for_initialization=True
+                "bin_selection", initializes_crn_attributes=True
             ),
             "age_smoothing": builder.randomness.get_stream(
-                "age_smoothing", for_initialization=True
+                "age_smoothing", initializes_crn_attributes=True
             ),
             "age_smoothing_age_bounds": builder.randomness.get_stream(
-                "age_smoothing_age_bounds", for_initialization=True
+                "age_smoothing_age_bounds", initializes_crn_attributes=True
             ),
         }
         self.register_simulants = builder.randomness.register_simulants


### PR DESCRIPTION
## Rename crn attribute randomness arg
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
*Category*: refactor
*JIRA issue*: N/A

Renames the `for_initialization` arg of `builder.randomness.get_stream` to
`initializes_crn_attributes` which clarifies what's going on.

See upstream PR here: https://github.com/ihmeuw/vivarium/pull/274

### Testing
CI

