### PR TITLE
mortality observer

### DIFF
--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -70,8 +70,12 @@ class MortalityObserver:
         self.clock = builder.time.clock()
         self.step_size = builder.time.step_size()
         self.config = builder.configuration.stratification.mortality
-        self._cause_components = builder.components.get_components_by_type((DiseaseState, RiskAttributableDisease))
-        self.causes_of_death = ["other_causes"] + [cause.state_id for cause in self._cause_components if cause.has_excess_mortality]
+        self._cause_components = builder.components.get_components_by_type(
+            (DiseaseState, RiskAttributableDisease)
+        )
+        self.causes_of_death = ["other_causes"] + [
+            cause.state_id for cause in self._cause_components if cause.has_excess_mortality
+        ]
 
         columns_required = [
             "alive",
@@ -95,7 +99,12 @@ class MortalityObserver:
                 name=f"ylls_due_to_{cause_of_death}",
                 pop_filter=f'alive == "dead" and cause_of_death == "{cause_of_death}"',
                 aggregator=self.calculate_cause_specific_ylls,
-                requires_columns=["alive", "cause_of_death", "exit_time", "years_of_life_lost"],
+                requires_columns=[
+                    "alive",
+                    "cause_of_death",
+                    "exit_time",
+                    "years_of_life_lost",
+                ],
                 additional_stratifications=self.config.include,
                 excluded_stratifications=self.config.exclude,
                 when="collect_metrics",
@@ -107,4 +116,4 @@ class MortalityObserver:
 
     def calculate_cause_specific_ylls(self, x: pd.DataFrame) -> float:
         died_of_cause = x["exit_time"] == self.clock() + self.step_size()
-        return x.loc[died_of_cause, 'years_of_life_lost'].sum()
+        return x.loc[died_of_cause, "years_of_life_lost"].sum()

--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -20,7 +20,7 @@ from vivarium_public_health.metrics.stratification import ResultsStratifier
 
 
 class MortalityObserver:
-    """An observer for cause-specific deaths and ylls.
+    """An observer for cause-specific deaths and ylls (including "other causes").
 
     By default, this counts cause-specific deaths and years of life lost over
     the full course of the simulation. It can be configured to add or remove
@@ -68,7 +68,6 @@ class MortalityObserver:
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
         self.clock = builder.time.clock()
-        self.step_size = builder.time.step_size()
         self.config = builder.configuration.stratification.mortality
         self._cause_components = builder.components.get_components_by_type(
             (DiseaseState, RiskAttributableDisease)
@@ -111,9 +110,9 @@ class MortalityObserver:
             )
 
     def count_cause_specific_deaths(self, x: pd.DataFrame) -> float:
-        died_of_cause = x["exit_time"] == self.clock() + self.step_size()
+        died_of_cause = x["exit_time"] > self.clock()
         return sum(died_of_cause)
 
     def calculate_cause_specific_ylls(self, x: pd.DataFrame) -> float:
-        died_of_cause = x["exit_time"] == self.clock() + self.step_size()
+        died_of_cause = x["exit_time"] > self.clock()
         return x.loc[died_of_cause, "years_of_life_lost"].sum()

--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -4,7 +4,7 @@ Mortality Observer
 ==================
 
 This module contains tools for observing cause-specific and
-excess mortality in the simulation.
+excess mortality in the simulation, including "other causes".
 
 """
 from collections import Counter

--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -3,7 +3,7 @@
 Mortality Observer
 ==================
 
-This module contains tools for observing all-cause, cause-specific, and
+This module contains tools for observing cause-specific and
 excess mortality in the simulation.
 
 """
@@ -20,7 +20,7 @@ from vivarium_public_health.metrics.stratification import ResultsStratifier
 
 
 class MortalityObserver:
-    """An observer for cause-specific deaths, ylls, and total person time.
+    """An observer for cause-specific deaths and ylls.
 
     By default, this counts cause-specific deaths and years of life lost over
     the full course of the simulation. It can be configured to add or remove
@@ -33,7 +33,7 @@ class MortalityObserver:
     .. code-block:: yaml
 
         configuration:
-            observers:
+            stratification:
                 mortality:
                     exclude:
                         - "sex"
@@ -42,17 +42,13 @@ class MortalityObserver:
     """
 
     configuration_defaults = {
-        "observers": {
+        "stratification": {
             "mortality": {
                 "exclude": [],
                 "include": [],
             }
         }
     }
-
-    def __init__(self):
-        self.metrics_pipeline_name = "metrics"
-        self.tmrle_key = "population.theoretical_minimum_risk_life_expectancy"
 
     def __repr__(self):
         return "MortalityObserver()"
@@ -71,99 +67,44 @@ class MortalityObserver:
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
-        self.config = self._get_stratification_configuration(builder)
-        self.stratifier = self._get_stratifier(builder)
-        self._cause_components = self._get_cause_components(builder)
-        self.causes_of_death = ["other_causes"]
-        self.population_view = self._get_population_view(builder)
+        self.clock = builder.time.clock()
+        self.step_size = builder.time.step_size()
+        self.config = builder.configuration.stratification.mortality
+        self._cause_components = builder.components.get_components_by_type((DiseaseState, RiskAttributableDisease))
+        self.causes_of_death = ["other_causes"] + [cause.state_id for cause in self._cause_components if cause.has_excess_mortality]
 
-        self.counts = Counter()
-
-        self._register_post_setup_listener(builder)
-        self._register_collect_metrics_listener(builder)
-        self._register_metrics_modifier(builder)
-
-    # noinspection PyMethodMayBeStatic
-    def _get_stratification_configuration(self, builder: Builder) -> ConfigTree:
-        return builder.configuration.observers.mortality
-
-    # noinspection PyMethodMayBeStatic
-    def _get_stratifier(self, builder: Builder) -> ResultsStratifier:
-        return builder.components.get_component(ResultsStratifier.name)
-
-    # noinspection PyMethodMayBeStatic
-    def _get_cause_components(
-        self, builder: Builder
-    ) -> List[Union[DiseaseState, RiskAttributableDisease]]:
-        return builder.components.get_components_by_type(
-            (DiseaseState, RiskAttributableDisease)
-        )
-
-    # noinspection PyMethodMayBeStatic
-    def _get_population_view(self, builder: Builder) -> PopulationView:
         columns_required = [
-            "tracked",
             "alive",
             "years_of_life_lost",
             "cause_of_death",
             "exit_time",
         ]
-        return builder.population.get_view(columns_required)
+        self.population_view = builder.population.get_view(columns_required)
 
-    def _register_post_setup_listener(self, builder: Builder) -> None:
-        builder.event.register_listener("post_setup", self.on_post_setup)
+        for cause_of_death in self.causes_of_death:
+            builder.results.register_observation(
+                name=f"death_due_to_{cause_of_death}",
+                pop_filter=f'alive == "dead" and cause_of_death == "{cause_of_death}"',
+                aggregator=self.count_cause_specific_deaths,
+                requires_columns=["alive", "cause_of_death", "exit_time"],
+                additional_stratifications=self.config.include,
+                excluded_stratifications=self.config.exclude,
+                when="collect_metrics",
+            )
+            builder.results.register_observation(
+                name=f"ylls_due_to_{cause_of_death}",
+                pop_filter=f'alive == "dead" and cause_of_death == "{cause_of_death}"',
+                aggregator=self.calculate_cause_specific_ylls,
+                requires_columns=["alive", "cause_of_death", "exit_time", "years_of_life_lost"],
+                additional_stratifications=self.config.include,
+                excluded_stratifications=self.config.exclude,
+                when="collect_metrics",
+            )
 
-    def _register_collect_metrics_listener(self, builder: Builder) -> None:
-        builder.event.register_listener("time_step", self.on_collect_metrics)
+    def count_cause_specific_deaths(self, x: pd.DataFrame) -> float:
+        died_of_cause = x["exit_time"] == self.clock() + self.step_size()
+        return sum(died_of_cause)
 
-    def _register_metrics_modifier(self, builder: Builder) -> None:
-        builder.value.register_value_modifier(
-            self.metrics_pipeline_name,
-            modifier=self.metrics,
-            requires_columns=["age", "exit_time", "alive"],
-        )
-
-    ########################
-    # Event-driven methods #
-    ########################
-
-    # noinspection PyUnusedLocal
-    def on_post_setup(self, event: Event) -> None:
-        self.causes_of_death += [
-            cause.state_id for cause in self._cause_components if cause.has_excess_mortality
-        ]
-
-    def on_collect_metrics(self, event: Event) -> None:
-        pop = self.population_view.get(event.index)
-        pop_died = pop[(pop["alive"] == "dead") & (pop["exit_time"] == event.time)]
-
-        groups = self.stratifier.group(
-            pop_died.index, self.config.include, self.config.exclude
-        )
-        for label, group_mask in groups:
-            for cause in self.causes_of_death:
-                cause_mask = pop_died["cause_of_death"] == cause
-                pop_died_of_cause = pop_died[group_mask & cause_mask]
-                new_observations = {
-                    f"death_due_to_{cause}_{label}": pop_died_of_cause.index.size,
-                    f"ylls_due_to_{cause}_{label}": pop_died_of_cause[
-                        "years_of_life_lost"
-                    ].sum(),
-                }
-                self.counts.update(new_observations)
-
-    ##################################
-    # Pipeline sources and modifiers #
-    ##################################
-
-    def metrics(self, index: pd.Index, metrics: Dict) -> Dict:
-        pop = self.population_view.get(index)
-
-        the_living = pop[(pop.alive == "alive") & pop.tracked]
-        the_dead = pop[pop.alive == "dead"]
-        metrics["years_of_life_lost"] = the_dead["years_of_life_lost"].sum()
-        metrics["total_population_living"] = len(the_living)
-        metrics["total_population_dead"] = len(the_dead)
-        metrics.update(self.counts)
-
-        return metrics
+    def calculate_cause_specific_ylls(self, x: pd.DataFrame) -> float:
+        died_of_cause = x["exit_time"] == self.clock() + self.step_size()
+        return x.loc[died_of_cause, 'years_of_life_lost'].sum()

--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -60,6 +60,7 @@ class ResultsStratifier:
             is_vectorized=True,
             requires_columns=["entrance_time"],
         )
+        # TODO [MIC-4803]: Known bug with this registration
         # builder.results.register_stratification(
         #     "exit_year",
         #     [str(year) for year in range(self.start_year, self.end_year + 1)] + ["nan"],

--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -60,13 +60,13 @@ class ResultsStratifier:
             is_vectorized=True,
             requires_columns=["entrance_time"],
         )
-        builder.results.register_stratification(
-            "exit_year",
-            [str(year) for year in range(self.start_year, self.end_year + 1)] + ["nan"],
-            self.map_year,
-            is_vectorized=True,
-            requires_columns=["exit_time"],
-        )
+        # builder.results.register_stratification(
+        #     "exit_year",
+        #     [str(year) for year in range(self.start_year, self.end_year + 1)] + ["nan"],
+        #     self.map_year,
+        #     is_vectorized=True,
+        #     requires_columns=["exit_time"],
+        # )
         builder.results.register_stratification(
             "sex", ["Female", "Male"], requires_columns=["sex"]
         )

--- a/tests/metrics/test_mortality_observer.py
+++ b/tests/metrics/test_mortality_observer.py
@@ -88,6 +88,9 @@ def simulation_after_one_step(base_config, base_plugins):
 
 
 def get_expected_results(simulation, expected_deaths=Counter(), expected_ylls=Counter()):
+    """Get expected results given a simulation. If expected deaths, for example, are not provided, return
+    the counts of deaths in this time step. If expected deaths are provided, return the counts of deaths
+    in the Counter plus the counts for this time step."""
     pop = simulation.get_population()
 
     for cause in ["other_causes", "flu", "mumps"]:

--- a/tests/metrics/test_mortality_observer.py
+++ b/tests/metrics/test_mortality_observer.py
@@ -22,24 +22,24 @@ class ResultsStratifier(ResultsStratifier_):
     }
 
 
-def disease_with_excess_mortality(base_config, disease_name) -> DiseaseModel:
+def disease_with_excess_mortality(base_config, disease_name, emr_value) -> DiseaseModel:
     year_start = base_config.time.start.year
     year_end = base_config.time.end.year
     healthy = SusceptibleState(disease_name)
     disease_get_data_funcs = {
-        "disability_weight": lambda _, __: build_table(0.0, year_start - 1, year_end),
-        "prevalence": lambda _, __: build_table(
+        "disability_weight": lambda *_: build_table(0.0, year_start - 1, year_end),
+        "prevalence": lambda *_: build_table(
             0.5, year_start - 1, year_end, ["age", "year", "sex", "value"]
         ),
-        "excess_mortality_rate": lambda _, __: build_table(
-            20, year_start - 1, year_end, ["age", "year", "sex", "value"]
+        "excess_mortality_rate": lambda *_: build_table(
+            emr_value, year_start - 1, year_end, ["age", "year", "sex", "value"]
         ),
     }
     with_condition = DiseaseState(disease_name, get_data_functions=disease_get_data_funcs)
     healthy.add_transition(
         with_condition,
         get_data_functions={
-            "incidence_rate": lambda _, __: build_table(
+            "incidence_rate": lambda *_: build_table(
                 0.1, year_start - 1, year_end, ["age", "year", "sex", "value"]
             )
         },
@@ -50,8 +50,8 @@ def disease_with_excess_mortality(base_config, disease_name) -> DiseaseModel:
 @pytest.fixture()
 def simulation_after_one_step(base_config, base_plugins):
     observer = MortalityObserver()
-    flu = disease_with_excess_mortality(base_config, "flu")
-    mumps = disease_with_excess_mortality(base_config, "mumps")
+    flu = disease_with_excess_mortality(base_config, "flu", 10)
+    mumps = disease_with_excess_mortality(base_config, "mumps", 20)
 
     simulation = InteractiveContext(
         components=[

--- a/tests/metrics/test_mortality_observer.py
+++ b/tests/metrics/test_mortality_observer.py
@@ -1,8 +1,8 @@
-import numpy as np
-import pytest
-
 from collections import Counter
 
+import numpy as np
+import pytest
+from vivarium import InteractiveContext
 from vivarium.testing_utilities import TestPopulation, build_table
 
 from vivarium_public_health.disease import DiseaseModel, DiseaseState
@@ -12,7 +12,6 @@ from vivarium_public_health.metrics.stratification import (
     ResultsStratifier as ResultsStratifier_,
 )
 from vivarium_public_health.population import Mortality
-from vivarium import InteractiveContext
 
 
 class ResultsStratifier(ResultsStratifier_):
@@ -21,6 +20,7 @@ class ResultsStratifier(ResultsStratifier_):
             "default": ["age_group", "sex"],
         }
     }
+
 
 def disease_with_excess_mortality(base_config, disease_name) -> DiseaseModel:
     year_start = base_config.time.start.year
@@ -36,12 +36,16 @@ def disease_with_excess_mortality(base_config, disease_name) -> DiseaseModel:
         ),
     }
     with_condition = DiseaseState(disease_name, get_data_functions=disease_get_data_funcs)
-    healthy.add_transition(with_condition, get_data_functions={"incidence_rate": lambda _, __: build_table(
-            0.1, year_start - 1, year_end, ["age", "year", "sex", "value"]
-        )
-                                                               }
-                           )
+    healthy.add_transition(
+        with_condition,
+        get_data_functions={
+            "incidence_rate": lambda _, __: build_table(
+                0.1, year_start - 1, year_end, ["age", "year", "sex", "value"]
+            )
+        },
+    )
     return DiseaseModel(disease_name, states=[healthy, with_condition])
+
 
 @pytest.fixture()
 def simulation_after_one_step(base_config, base_plugins):
@@ -74,7 +78,7 @@ def simulation_after_one_step(base_config, base_plugins):
 
     year_start = base_config.time.start.year
     year_end = base_config.time.end.year
-    acmr_data = build_table(.5, year_start - 1, year_end)
+    acmr_data = build_table(0.5, year_start - 1, year_end)
     simulation._data.write("cause.all_causes.cause_specific_mortality_rate", acmr_data)
 
     simulation.setup()
@@ -82,22 +86,26 @@ def simulation_after_one_step(base_config, base_plugins):
 
     return simulation
 
+
 def get_expected_results(simulation, expected_deaths=Counter(), expected_ylls=Counter()):
     pop = simulation.get_population()
 
-    for cause in ['other_causes', 'flu', 'mumps']:
+    for cause in ["other_causes", "flu", "mumps"]:
         for sex in ["Male", "Female"]:
             deaths_observation = f"MEASURE_death_due_to_{cause}_SEX_{sex}"
             ylls_observation = f"MEASURE_ylls_due_to_{cause}_SEX_{sex}"
 
-            died_of_cause = pop['cause_of_death'] == cause
-            is_sex_of_interest = pop['sex'] == sex
-            died_this_step = pop['exit_time'] == simulation._clock.time
+            died_of_cause = pop["cause_of_death"] == cause
+            is_sex_of_interest = pop["sex"] == sex
+            died_this_step = pop["exit_time"] == simulation._clock.time
             is_pop_of_interest = died_of_cause & is_sex_of_interest & died_this_step
             expected_deaths.update({deaths_observation: sum(is_pop_of_interest)})
-            expected_ylls.update({ylls_observation: sum(pop.loc[is_pop_of_interest, 'years_of_life_lost'])})
+            expected_ylls.update(
+                {ylls_observation: sum(pop.loc[is_pop_of_interest, "years_of_life_lost"])}
+            )
 
     return expected_deaths, expected_ylls
+
 
 def test_observation_registration(simulation_after_one_step):
     """Test that all expected observation keys appear as expected in the results."""
@@ -121,10 +129,11 @@ def test_observation_registration(simulation_after_one_step):
 
     assert set(expected_observations) == set(results(pop.index).keys())
 
+
 def test_observation_correctness(simulation_after_one_step):
     """Test that deaths and YLLs appear as expected in the results."""
     expected_deaths, expected_ylls = get_expected_results(simulation_after_one_step)
-    results = simulation_after_one_step.get_value('metrics')
+    results = simulation_after_one_step.get_value("metrics")
     pop = simulation_after_one_step.get_population()
 
     for observation in expected_deaths:
@@ -138,9 +147,11 @@ def test_observation_correctness(simulation_after_one_step):
 
     # same test on second time step
     simulation_after_one_step.step()
-    expected_deaths, expected_ylls = get_expected_results(simulation_after_one_step,
-                                                          expected_deaths=expected_deaths,
-                                                          expected_ylls=expected_ylls)
+    expected_deaths, expected_ylls = get_expected_results(
+        simulation_after_one_step,
+        expected_deaths=expected_deaths,
+        expected_ylls=expected_ylls,
+    )
     pop = simulation_after_one_step.get_population()
     results = simulation_after_one_step.get_value("metrics")
 

--- a/tests/metrics/test_mortality_observer.py
+++ b/tests/metrics/test_mortality_observer.py
@@ -1,0 +1,154 @@
+import numpy as np
+import pytest
+
+from collections import Counter
+
+from vivarium.testing_utilities import TestPopulation, build_table
+
+from vivarium_public_health.disease import DiseaseModel, DiseaseState
+from vivarium_public_health.disease.state import SusceptibleState
+from vivarium_public_health.metrics import MortalityObserver
+from vivarium_public_health.metrics.stratification import (
+    ResultsStratifier as ResultsStratifier_,
+)
+from vivarium_public_health.population import Mortality
+from vivarium import InteractiveContext
+
+
+class ResultsStratifier(ResultsStratifier_):
+    configuration_defaults = {
+        "stratification": {
+            "default": ["age_group", "sex"],
+        }
+    }
+
+def disease_with_excess_mortality(base_config, disease_name) -> DiseaseModel:
+    year_start = base_config.time.start.year
+    year_end = base_config.time.end.year
+    healthy = SusceptibleState(disease_name)
+    disease_get_data_funcs = {
+        "disability_weight": lambda _, __: build_table(0.0, year_start - 1, year_end),
+        "prevalence": lambda _, __: build_table(
+            0.5, year_start - 1, year_end, ["age", "year", "sex", "value"]
+        ),
+        "excess_mortality_rate": lambda _, __: build_table(
+            20, year_start - 1, year_end, ["age", "year", "sex", "value"]
+        ),
+    }
+    with_condition = DiseaseState(disease_name, get_data_functions=disease_get_data_funcs)
+    healthy.add_transition(with_condition, get_data_functions={"incidence_rate": lambda _, __: build_table(
+            0.1, year_start - 1, year_end, ["age", "year", "sex", "value"]
+        )
+                                                               }
+                           )
+    return DiseaseModel(disease_name, states=[healthy, with_condition])
+
+@pytest.fixture()
+def simulation_after_one_step(base_config, base_plugins):
+    observer = MortalityObserver()
+    flu = disease_with_excess_mortality(base_config, "flu")
+    mumps = disease_with_excess_mortality(base_config, "mumps")
+
+    simulation = InteractiveContext(
+        components=[
+            TestPopulation(),
+            Mortality(),
+            flu,
+            mumps,
+            ResultsStratifier(),
+            observer,
+        ],
+        configuration=base_config,
+        plugin_configuration=base_plugins,
+        setup=False,
+    )
+    simulation.configuration.update(
+        {
+            "stratification": {
+                "mortality": {
+                    "exclude": ["age_group"],
+                }
+            }
+        }
+    )
+
+    year_start = base_config.time.start.year
+    year_end = base_config.time.end.year
+    acmr_data = build_table(.5, year_start - 1, year_end)
+    simulation._data.write("cause.all_causes.cause_specific_mortality_rate", acmr_data)
+
+    simulation.setup()
+    simulation.step()
+
+    return simulation
+
+def get_expected_results(simulation, expected_deaths=Counter(), expected_ylls=Counter()):
+    pop = simulation.get_population()
+
+    for cause in ['other_causes', 'flu', 'mumps']:
+        for sex in ["Male", "Female"]:
+            deaths_observation = f"MEASURE_death_due_to_{cause}_SEX_{sex}"
+            ylls_observation = f"MEASURE_ylls_due_to_{cause}_SEX_{sex}"
+
+            died_of_cause = pop['cause_of_death'] == cause
+            is_sex_of_interest = pop['sex'] == sex
+            died_this_step = pop['exit_time'] == simulation._clock.time
+            is_pop_of_interest = died_of_cause & is_sex_of_interest & died_this_step
+            expected_deaths.update({deaths_observation: sum(is_pop_of_interest)})
+            expected_ylls.update({ylls_observation: sum(pop.loc[is_pop_of_interest, 'years_of_life_lost'])})
+
+    return expected_deaths, expected_ylls
+
+def test_observation_registration(simulation_after_one_step):
+    """Test that all expected observation keys appear as expected in the results."""
+    results = simulation_after_one_step.get_value("metrics")
+    pop = simulation_after_one_step.get_population()
+
+    expected_observations = [
+        "MEASURE_death_due_to_other_causes_SEX_Female",
+        "MEASURE_death_due_to_other_causes_SEX_Male",
+        "MEASURE_ylls_due_to_other_causes_SEX_Female",
+        "MEASURE_ylls_due_to_other_causes_SEX_Male",
+        "MEASURE_death_due_to_flu_SEX_Female",
+        "MEASURE_death_due_to_flu_SEX_Male",
+        "MEASURE_ylls_due_to_flu_SEX_Female",
+        "MEASURE_ylls_due_to_flu_SEX_Male",
+        "MEASURE_death_due_to_mumps_SEX_Female",
+        "MEASURE_death_due_to_mumps_SEX_Male",
+        "MEASURE_ylls_due_to_mumps_SEX_Female",
+        "MEASURE_ylls_due_to_mumps_SEX_Male",
+    ]
+
+    assert set(expected_observations) == set(results(pop.index).keys())
+
+def test_observation_correctness(simulation_after_one_step):
+    """Test that deaths and YLLs appear as expected in the results."""
+    expected_deaths, expected_ylls = get_expected_results(simulation_after_one_step)
+    results = simulation_after_one_step.get_value('metrics')
+    pop = simulation_after_one_step.get_population()
+
+    for observation in expected_deaths:
+        assert np.isclose(
+            results(pop.index)[observation], expected_deaths[observation], rtol=0.001
+        )
+    for observation in expected_ylls:
+        assert np.isclose(
+            results(pop.index)[observation], expected_ylls[observation], rtol=0.001
+        )
+
+    # same test on second time step
+    simulation_after_one_step.step()
+    expected_deaths, expected_ylls = get_expected_results(simulation_after_one_step,
+                                                          expected_deaths=expected_deaths,
+                                                          expected_ylls=expected_ylls)
+    pop = simulation_after_one_step.get_population()
+    results = simulation_after_one_step.get_value("metrics")
+
+    for observation in expected_deaths:
+        assert np.isclose(
+            results(pop.index)[observation], expected_deaths[observation], rtol=0.001
+        )
+    for observation in expected_ylls:
+        assert np.isclose(
+            results(pop.index)[observation], expected_ylls[observation], rtol=0.001
+        )

--- a/tests/metrics/test_stratification.py
+++ b/tests/metrics/test_stratification.py
@@ -138,13 +138,13 @@ def test_results_stratifier_register_stratifications(mocker):
         is_vectorized=True,
         requires_columns=["entrance_time"],
     )
-    builder.results.register_stratification.assert_any_call(
-        "exit_year",
-        years_list + ["nan"],
-        rs.map_year,
-        is_vectorized=True,
-        requires_columns=["exit_time"],
-    )
+    # builder.results.register_stratification.assert_any_call(
+    #     "exit_year",
+    #     years_list + ["nan"],
+    #     rs.map_year,
+    #     is_vectorized=True,
+    #     requires_columns=["exit_time"],
+    # )
     builder.results.register_stratification.assert_any_call(
         "sex", ["Female", "Male"], requires_columns=["sex"]
     )

--- a/tests/metrics/test_stratification.py
+++ b/tests/metrics/test_stratification.py
@@ -138,6 +138,7 @@ def test_results_stratifier_register_stratifications(mocker):
         is_vectorized=True,
         requires_columns=["entrance_time"],
     )
+    # TODO [MIC-4803]: Known bug with this registration
     # builder.results.register_stratification.assert_any_call(
     #     "exit_year",
     #     years_list + ["nan"],

--- a/tests/metrics/test_stratification.py
+++ b/tests/metrics/test_stratification.py
@@ -148,7 +148,7 @@ def test_results_stratifier_register_stratifications(mocker):
     builder.results.register_stratification.assert_any_call(
         "sex", ["Female", "Male"], requires_columns=["sex"]
     )
-    assert builder.results.register_stratification.call_count == 6
+    assert builder.results.register_stratification.call_count == 5
 
 
 def test_results_stratifier_map_age_groups():


### PR DESCRIPTION
## mortality observer

### Description
- *Category*: feature, test
- *JIRA issue*: [MIC-3950](https://jira.ihme.washington.edu/browse/MIC-3950)

### Changes and notes
Update mortality observer for new results management system and add tests. Exit year stratification registration and its use in tests had to be commented out to get builds passing. This is a known bug which should already have a ticket but I'll make one if it doesn't exist. 

### Testing
Ran simulation for a few time steps and tests passed. 