### PR TITLE
Refactor/transition names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import os
 from setuptools import find_packages, setup
 
 if __name__ == "__main__":
-
     base_dir = os.path.dirname(__file__)
     src_dir = os.path.join(base_dir, "src")
 

--- a/src/vivarium_public_health/disease/model.py
+++ b/src/vivarium_public_health/disease/model.py
@@ -53,9 +53,7 @@ class DiseaseModel(Machine):
         states = {s.name.split(".")[1]: s for s in self.states}
         transitions = []
         for state in states.values():
-            for trans in state.transition_set.transitions:
-                _, _, init_state, _, end_state = trans.name.split(".")
-                transitions.append(TransitionString(f"{init_state}_TO_{end_state}"))
+            transitions += state.get_transition_names()
         return transitions
 
     def setup(self, builder):

--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -283,7 +283,6 @@ class RiskAttributableDisease:
         return with_condition
 
     def get_exposure_filter(self, distribution, exposure_pipeline, threshold):
-
         if distribution in ["dichotomous", "ordered_polytomous", "unordered_polytomous"]:
 
             def categorical_filter(index):

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -6,7 +6,7 @@ Disease States
 This module contains tools to manage standard disease states.
 
 """
-from typing import Callable, Dict
+from typing import Callable, Dict, List
 
 import numpy as np
 import pandas as pd
@@ -16,7 +16,7 @@ from vivarium.framework.values import list_combiner, union_post_processor
 
 from vivarium_public_health.disease.transition import (
     ProportionTransition,
-    RateTransition,
+    RateTransition, TransitionString,
 )
 from vivarium_public_health.utilities import is_non_zero
 
@@ -93,6 +93,17 @@ class BaseDiseaseState(State):
 
         if self.side_effect_function is not None:
             self.side_effect_function(index, event_time)
+
+    ##################
+    # Public methods #
+    ##################
+
+    def get_transition_names(self) -> List[str]:
+        transitions = []
+        for trans in self.transition_set.transitions:
+            _, _, init_state, _, end_state = trans.name.split(".")
+            transitions.append(TransitionString(f"{init_state}_TO_{end_state}"))
+        return transitions
 
     def add_transition(
         self,

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -16,7 +16,8 @@ from vivarium.framework.values import list_combiner, union_post_processor
 
 from vivarium_public_health.disease.transition import (
     ProportionTransition,
-    RateTransition, TransitionString,
+    RateTransition,
+    TransitionString,
 )
 from vivarium_public_health.utilities import is_non_zero
 

--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -123,7 +123,6 @@ def rescale_binned_proportions(
         "value",
     ]
     for _, sub_pop in pop_data.groupby(["sex", "location"]):
-
         min_bin = sub_pop[(sub_pop.age_start <= age_start) & (age_start < sub_pop.age_end)]
         padding_bin = sub_pop[sub_pop.age_end == float(min_bin.age_start)]
 
@@ -239,7 +238,6 @@ def smooth_ages(
     """
     simulants = simulants.copy()
     for (sex, location), sub_pop in population_data.groupby(["sex", "location"]):
-
         ages = sorted(sub_pop.age.unique())
         younger = [float(sub_pop.loc[sub_pop.age == ages[0], "age_start"])] + ages[:-1]
         older = ages[1:] + [float(sub_pop.loc[sub_pop.age == ages[-1], "age_end"])]

--- a/src/vivarium_public_health/population/mortality.py
+++ b/src/vivarium_public_health/population/mortality.py
@@ -56,7 +56,6 @@ from vivarium.framework.values import Pipeline, list_combiner, union_post_proces
 
 
 class Mortality:
-
     configuration_defaults = {"unmodeled_causes": []}
 
     def __init__(self):

--- a/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
+++ b/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
@@ -31,7 +31,6 @@ GESTATIONAL_AGE = "gestational_age"
 
 
 class LBWSGDistribution(PolytomousDistribution):
-
     configuration_defaults = {
         "lbwsg_distribution": {
             "age_column": "age",
@@ -211,7 +210,6 @@ class LBWSGDistribution(PolytomousDistribution):
 
 
 class LBWSGRisk(Risk):
-
     AXES = [BIRTH_WEIGHT, GESTATIONAL_AGE]
 
     def __init__(self):
@@ -316,7 +314,6 @@ class LBWSGRisk(Risk):
 
 
 class LBWSGRiskEffect(RiskEffect):
-
     TMREL_BIRTH_WEIGHT_INTERVAL: pd.Interval = pd.Interval(3500.0, 4500.0)
     TMREL_GESTATIONAL_AGE_INTERVAL: pd.Interval = pd.Interval(38.0, 42.0)
 

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -52,7 +52,6 @@ def get_test_prevalence(simulation, key):
 
 
 def test_dwell_time(assign_cause_mock, base_config, base_plugins, disease, base_data):
-
     time_step = 10
     assign_cause_mock.side_effect = lambda population, *args: pd.DataFrame(
         {"condition_state": "healthy"}, index=population.index

--- a/tests/metrics/test_stratification.py
+++ b/tests/metrics/test_stratification.py
@@ -15,7 +15,6 @@ from vivarium_public_health.metrics.stratification import Source, SourceType
 
 
 class FavoriteColor:
-
     OPTIONS = ["red", "green", "orange"]
 
     @property
@@ -34,7 +33,6 @@ class FavoriteColor:
 
 
 class FavoriteNumber:
-
     OPTIONS = [7, 42, 14312]
 
     @property

--- a/tests/population/test_add_new_birth_cohort.py
+++ b/tests/population/test_add_new_birth_cohort.py
@@ -16,7 +16,6 @@ from vivarium_public_health.population import (
 
 @pytest.fixture()
 def config(base_config):
-
     base_config.update(
         {
             "population": {


### PR DESCRIPTION
## Modularize the definition of states' transition names
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: [MIC-4085](https://jira.ihme.washington.edu/browse/MIC-4085)

### Changes and notes
Define `get_transition_names` function on `BaseDiseaseState`
Call this function when getting all transitions in a Disease Model
This is a straight refactor with no logic changes. It's needed to support the change I made in the associated US CVD PR (https://github.com/ihmeuw/vivarium_nih_us_cvd/pull/124) to allow the model to use the standard VPH disease observer

A bunch of whitespcae changes got pulled in by the linter.


### Testing
Ran an interactive sim for a few steps and verified that the metrics pipeline was counting transitions as expected. Currently running a parallel sim.
