### PR TITLE
Update vivarium_public_health to use setuptools_scm versioning

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,9 +37,9 @@ copyright = f'2023, {about["__author__"]}'
 author = about["__author__"]
 
 # The short X.Y version.
-version = about["__version__"]
+version = vivarium_public_health.__version__
 # The full version, including alpha/beta/rc tags.
-release = about["__version__"]
+release = vivarium_public_health.__version__
 
 
 # -- General configuration ------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ sys.path.insert(0, str(Path("..").resolve()))
 # -- Project information -----------------------------------------------------
 
 project = about["__title__"]
-copyright = f'2021, {about["__author__"]}'
+copyright = f'2023, {about["__author__"]}'
 author = about["__author__"]
 
 # The short X.Y version.

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,15 @@ if __name__ == "__main__":
         long_description = f.read()
 
     install_requirements = [
-        "vivarium>=1.2.0",
+        "vivarium>=1.2.1",
         "numpy",
         "pandas",
         "scipy",
         "tables",
         "risk_distributions>=2.0.11",
     ]
+
+    setup_requires = ["setuptools_scm"]
 
     test_requirements = [
         "pytest",
@@ -39,7 +41,6 @@ if __name__ == "__main__":
 
     setup(
         name=about["__title__"],
-        version=about["__version__"],
         description=about["__summary__"],
         long_description=long_description,
         license=about["__license__"],
@@ -78,4 +79,10 @@ if __name__ == "__main__":
             "dev": doc_requirements + test_requirements,
         },
         zip_safe=False,
+        use_scm_version={
+            "write_to": "src/vivarium_public_health/_version.py",
+            "write_to_template": '__version__ = "{version}"\n',
+            "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
+        },
+        setup_requires=setup_requires,
     )

--- a/src/vivarium_public_health/__about__.py
+++ b/src/vivarium_public_health/__about__.py
@@ -12,7 +12,7 @@ __title__ = "vivarium_public_health"
 __summary__ = "Components for modelling diseases, risks, and interventions with ``vivarium``"
 __uri__ = "https://github.com/ihmeuw/vivarium_public_health"
 
-__author__ = "The vivarium_public_health developers"
+__author__ = "The vivarium developers"
 __email__ = "vivarium.dev@gmail.com"
 
 __license__ = "BSD-3-Clause"

--- a/src/vivarium_public_health/__about__.py
+++ b/src/vivarium_public_health/__about__.py
@@ -2,7 +2,6 @@ __all__ = [
     "__title__",
     "__summary__",
     "__uri__",
-    "__version__",
     "__author__",
     "__email__",
     "__license__",
@@ -13,10 +12,8 @@ __title__ = "vivarium_public_health"
 __summary__ = "Components for modelling diseases, risks, and interventions with ``vivarium``"
 __uri__ = "https://github.com/ihmeuw/vivarium_public_health"
 
-__version__ = "0.11.0"
-
 __author__ = "The vivarium_public_health developers"
 __email__ = "vivarium.dev@gmail.com"
 
 __license__ = "BSD-3-Clause"
-__copyright__ = f"Copyright 2022 {__author__}"
+__copyright__ = f"Copyright 2023 {__author__}"

--- a/src/vivarium_public_health/__init__.py
+++ b/src/vivarium_public_health/__init__.py
@@ -7,7 +7,7 @@ from vivarium_public_health.__about__ import (
     __title__,
     __uri__,
 )
-from vivarium._version import __version__
+from vivarium_public_health._version import __version__
 __all__ = [
     __author__,
     __copyright__,

--- a/src/vivarium_public_health/__init__.py
+++ b/src/vivarium_public_health/__init__.py
@@ -6,9 +6,8 @@ from vivarium_public_health.__about__ import (
     __summary__,
     __title__,
     __uri__,
-    __version__,
 )
-
+from vivarium._version import __version__
 __all__ = [
     __author__,
     __copyright__,

--- a/src/vivarium_public_health/__init__.py
+++ b/src/vivarium_public_health/__init__.py
@@ -8,6 +8,7 @@ from vivarium_public_health.__about__ import (
     __uri__,
 )
 from vivarium_public_health._version import __version__
+
 __all__ = [
     __author__,
     __copyright__,


### PR DESCRIPTION
## Update vivarium_public_health to use setuptools_scm versioning

### Description
- *Category*: CI/infrastructure
- *JIRA issue*: [MIC-4238](https://jira.ihme.washington.edu/browse/MIC-4238)

- Updates repo to use setuptools_scm versioning. This should be mostly transparent as a change, except dev versions will be more informative.

### Testing
`python setup.py --version` gives the expected version from tag, dropping the expected `_version.py`. Docs built successfully.

