### PR TITLE
update bmi distribution xmin and xmax

### DIFF
--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -39,6 +39,13 @@ class SimulationDistribution:
     def setup(self, builder):
         distribution_data = get_distribution_data(builder, self.risk)
         self.implementation = get_distribution(self.risk, **distribution_data)
+        if self.risk == 'risk_factor.high_body_mass_index_in_adults':
+            for dist in self.implementation._parameters:
+                dist_params = self.implementation._parameters[dist]
+                dist_params.loc[dist_params['x_min'] != 0, 'x_min'] = 10
+                dist_params.loc[dist_params['x_max'] != 0, 'x_max'] = 50
+                self.implementation._parameters[dist] = dist_params
+            print('using updated BMI distribution')
         self.implementation.setup(builder)
 
     def ppf(self, q):


### PR DESCRIPTION
## update bmi distribution xmin and xmax

### Description
- *Category*: test
- *JIRA issue*: [MIC-4242](https://jira.ihme.washington.edu/browse/MIC-4242)

### Changes and notes
Update distributions in BMI ensemble to have an xmin and xmax of 10 and 50 respectively. 

NOTE: this will not be merged 

### Testing
Put a breakpoint in the setup of the distribution and checked the distribution parameters before the ensemble was setup. 