### PR TITLE
Make Mortality Observer act on Collect Metrics

### DIFF
--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -114,7 +114,7 @@ class MortalityObserver:
         builder.event.register_listener("post_setup", self.on_post_setup)
 
     def _register_collect_metrics_listener(self, builder: Builder) -> None:
-        builder.event.register_listener("time_step", self.on_collect_metrics)
+        builder.event.register_listener("collect_metrics", self.on_collect_metrics)
 
     def _register_metrics_modifier(self, builder: Builder) -> None:
         builder.value.register_value_modifier(


### PR DESCRIPTION
## Title: Make Mortality Observer act on Collect Metrics
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: [MIC-4258](https://jira.ihme.washington.edu/browse/MIC-4258)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

The mortality observer `on_collect_metrics` listener is actually registered to `timestep`. Normally this works fine, since the standard mortality handler has a `priority` of `0`, but if you change this, deaths stop being recorded by the observer because the event times are mismatched. It seems that it should be registered to 'collect_metrics' instead.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
This was causing my sim to not register deaths on the right event time, and now it works the way I expect, and presume was intended. It doesn't look like there are unit tests for the mortality component, so I didn't write a new one, but could if requested.