### PR TITLE
filter observations to tracked simulants

### DIFF
--- a/src/vivarium_public_health/metrics/disease.py
+++ b/src/vivarium_public_health/metrics/disease.py
@@ -79,7 +79,7 @@ class DiseaseObserver:
         for state in disease_model.states:
             builder.results.register_observation(
                 name=f"{state.state_id}_person_time",
-                pop_filter=f'alive == "alive" and {self.disease}=="{state.state_id}" and tracked==True',
+                pop_filter=f'alive == "alive" and {self.disease} == "{state.state_id}" and tracked==True',
                 aggregator=self.aggregate_state_person_time,
                 requires_columns=["alive", self.disease],
                 additional_stratifications=self.config.include,

--- a/src/vivarium_public_health/metrics/disease.py
+++ b/src/vivarium_public_health/metrics/disease.py
@@ -79,7 +79,7 @@ class DiseaseObserver:
         for state in disease_model.states:
             builder.results.register_observation(
                 name=f"{state.state_id}_person_time",
-                pop_filter=f'alive == "alive" and {self.disease} == "{state.state_id}"',
+                pop_filter=f'alive == "alive" and {self.disease}=="{state.state_id}" and tracked==True',
                 aggregator=self.aggregate_state_person_time,
                 requires_columns=["alive", self.disease],
                 additional_stratifications=self.config.include,
@@ -90,7 +90,8 @@ class DiseaseObserver:
         for transition in disease_model.transition_names:
             filter_string = (
                 f'{self.previous_state_column_name} == "{transition.from_state}" '
-                f'and {self.disease} == "{transition.to_state}"'
+                f'and {self.disease} == "{transition.to_state}" '
+                f'and tracked==True'
             )
             builder.results.register_observation(
                 name=f"{transition}_event_count",

--- a/src/vivarium_public_health/metrics/disease.py
+++ b/src/vivarium_public_health/metrics/disease.py
@@ -91,7 +91,7 @@ class DiseaseObserver:
             filter_string = (
                 f'{self.previous_state_column_name} == "{transition.from_state}" '
                 f'and {self.disease} == "{transition.to_state}" '
-                f'and tracked==True'
+                f"and tracked==True"
             )
             builder.results.register_observation(
                 name=f"{transition}_event_count",

--- a/src/vivarium_public_health/metrics/risk.py
+++ b/src/vivarium_public_health/metrics/risk.py
@@ -107,7 +107,7 @@ class CategoricalRiskObserver:
         for category in self.categories:
             builder.results.register_observation(
                 name=f"{self.risk}_{category}_person_time",
-                pop_filter=f'alive == "alive" and `{self.exposure_pipeline_name}` == "{category}"',
+                pop_filter=f'alive == "alive" and `{self.exposure_pipeline_name}`=="{category}" and tracked==True',
                 aggregator=self.aggregate_risk_category_person_time,
                 requires_columns=["alive"],
                 requires_values=[self.exposure_pipeline_name],


### PR DESCRIPTION
## filter observations to tracked simulants

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4259](https://jira.ihme.washington.edu/browse/MIC-4259)

### Changes and notes
Use pop filter in categorical risk and disease observer to observe only tracked simulants.

### Testing
Ran simulation for a few timesteps. 