### PR TITLE
VPH loads excess mortality rate data in wrong order

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.0.1 - 08/07/23**
+
+- Minor bugfix to improve handling of excess mortality rate data
+
 **1.0.0 - 08/02/23**
 
  - Performance and architectural improvements to results manager, including observers

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -499,10 +499,9 @@ class DiseaseState(BaseDiseaseState):
         return disability_weight
 
     def load_excess_mortality_rate_data(self, builder):
-        only_morbid = builder.data.load(f"cause.{self._model}.restrictions")["yld_only"]
         if "excess_mortality_rate" in self._get_data_functions:
             return self._get_data_functions["excess_mortality_rate"](builder, self.cause)
-        elif only_morbid:
+        elif builder.data.load(f"cause.{self._model}.restrictions")["yld_only"]:
             return 0
         else:
             return builder.data.load(f"{self.cause_type}.{self.cause}.excess_mortality_rate")


### PR DESCRIPTION
## VPH loads EMR data in wrong order
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
bugfix
- *JIRA issue*: [MIC-4145](https://jira.ihme.washington.edu/browse/MIC-4145)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
VPH's disease.state.py contains a function for loading excess mortality rate data; it considers whether to use data passed in through a user-defined function, but oddly, before that it tries to load information about morbidity that is only used if excess mortality data isn't passed directly in, which can break if the disease doesn't have 'restrictions' associated.


### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Tested in vivarium_gates_nutrition_optimization; simulation runs and CI passes. EMR can be passed in through data function without receiving error.