### PR TITLE
Add alive == 'alive' to DiseaseObserver pop filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.0.2 - 08/10/23**
+
+- Minor bugfix to ensure dead simulants do not get observed transitions
+
 **1.0.1 - 08/07/23**
 
 - Minor bugfix to improve handling of excess mortality rate data

--- a/src/vivarium_public_health/metrics/disease.py
+++ b/src/vivarium_public_health/metrics/disease.py
@@ -91,7 +91,8 @@ class DiseaseObserver:
             filter_string = (
                 f'{self.previous_state_column_name} == "{transition.from_state}" '
                 f'and {self.disease} == "{transition.to_state}" '
-                f"and tracked==True"
+                f"and tracked==True "
+                f'and alive == "alive"'
             )
             builder.results.register_observation(
                 name=f"{transition}_event_count",


### PR DESCRIPTION
## Add alive == 'alive' to DiseaseObserver pop filter
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
bugfix
- *JIRA issue*: [MIC-4372](https://jira.ihme.washington.edu/browse/MIC-4372)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
DiseaseObserver doesn't filter for living simulants in its transition counts. Normally that works fine, as death usually happens first, but in MNCH maternal model this assumption is violated. I added the alive == 'alive' filter.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Verified in MNCH maternal model that this runs and excludes the relevant transitions.
