### PR TITLE
automatically register listeners if components define them

### DIFF
--- a/src/vivarium_public_health/population/base_population.py
+++ b/src/vivarium_public_health/population/base_population.py
@@ -68,8 +68,6 @@ class BasePopulation(Component):
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
         super().setup(builder)
-        self.register_simulant_initializer(builder)
-        self.register_time_step_listener(builder)
 
         self.config = builder.configuration.population
         self.key_columns = builder.configuration.randomness.key_columns
@@ -208,11 +206,11 @@ class AgeOutSimulants(Component):
         if builder.configuration.population.exit_age is not None:
             self.config = builder.configuration.population
             self._columns_required = ["age", "exit_time", "tracked"]
-            self.register_time_step_cleanup_listener(builder)
+            self.on_time_step_cleanup = self._on_time_step_cleanup
 
         super().setup(builder)
 
-    def on_time_step_cleanup(self, event: Event) -> None:
+    def _on_time_step_cleanup(self, event: Event) -> None:
         population = self.population_view.get(event.index)
         max_age = float(self.config.exit_age)
         pop = population[(population["age"] >= max_age) & population["tracked"]].copy()


### PR DESCRIPTION
## Automatically register listeners and initializers
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: [MIC-4370](https://jira.ihme.washington.edu/browse/MIC-4370)

Automatically registers listeners of a `Component` if they have been defined

### Testing
Ran US CVD with `BasePopulation` which worked. 
I will write proper unit tests once I get back from vacation.