### PR TITLE
pass BaseDiseaseState kwargs up to the State constructor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.0.3 - 08/10/23**
+
+ - Pass `BaseDiseaseState` constructor kwargs to its super-class's constructor
+
 **1.0.2 - 08/10/23**
 
  - Minor bugfix to ensure dead simulants do not get observed transitions

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -26,7 +26,7 @@ class BaseDiseaseState(State):
     def __init__(
         self, cause, name_prefix="", side_effect_function=None, cause_type="cause", **kwargs
     ):
-        super().__init__(name_prefix + cause)  # becomes state_id
+        super().__init__(name_prefix + cause, **kwargs)  # becomes state_id
         self.cause_type = cause_type
         self.cause = cause
 


### PR DESCRIPTION
## Pass BaseDiseaseState kwargs up to the State constructor
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-4440](https://jira.ihme.washington.edu/browse/MIC-4440)

### Changes and notes
This probably should have been happening anyway, but now this allows the `allow_self_transitions` kwarg to be passed to the `State` constructor 

### Testing
Tested with US CVD