### PR TITLE
refactor disease model components accommodate inheriting from Component

### DIFF
--- a/src/vivarium_public_health/disease/model.py
+++ b/src/vivarium_public_health/disease/model.py
@@ -8,14 +8,17 @@ function is to provide coordination across a set of disease states and
 transitions at simulation initialization and during transitions.
 
 """
-from typing import List
+from typing import Callable, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
 from vivarium.exceptions import VivariumError
+from vivarium.framework.engine import Builder
+from vivarium.framework.event import Event
+from vivarium.framework.population import SimulantData
 from vivarium.framework.state_machine import Machine
 
-from vivarium_public_health.disease.state import SusceptibleState
+from vivarium_public_health.disease.state import BaseDiseaseState, SusceptibleState
 from vivarium_public_health.disease.transition import TransitionString
 
 
@@ -24,8 +27,53 @@ class DiseaseModelError(VivariumError):
 
 
 class DiseaseModel(Machine):
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def columns_created(self) -> List[str]:
+        return [self.state_column]
+
+    @property
+    def columns_required(self) -> Optional[List[str]]:
+        return ["age", "sex"]
+
+    @property
+    def initialization_requirements(self) -> Dict[str, List[str]]:
+        return {
+            "requires_columns": ["age", "sex"],
+            "requires_values": [],
+            "requires_streams": [f"{self.state_column}_initial_states"],
+        }
+
+    @property
+    def state_names(self) -> List[str]:
+        return [s.state_id for s in self.states]
+
+    @property
+    def transition_names(self) -> List[TransitionString]:
+        states = {s.name.split(".")[1]: s for s in self.states}
+        transitions = []
+        for state in states.values():
+            transitions += state.get_transition_names()
+        return transitions
+
+    # @property
+    # def transition_names(self) -> List[TransitionString]:
+    #     return [state.get_transition_names() for state in self.states]
+
+    #####################
+    # Lifecycle methods #
+    #####################
+
     def __init__(
-        self, cause, initial_state=None, get_data_functions=None, cause_type="cause", **kwargs
+        self,
+        cause: str,
+        initial_state: Optional[BaseDiseaseState] = None,
+        get_data_functions: Optional[Dict[str, Callable]] = None,
+        cause_type: str = "cause",
+        **kwargs,
     ):
         super().__init__(cause, **kwargs)
         self.cause = cause
@@ -40,23 +88,7 @@ class DiseaseModel(Machine):
             get_data_functions if get_data_functions is not None else {}
         )
 
-    @property
-    def name(self):
-        return f"disease_model.{self.cause}"
-
-    @property
-    def state_names(self) -> List[str]:
-        return [s.name.split(".")[1] for s in self.states]
-
-    @property
-    def transition_names(self) -> List[TransitionString]:
-        states = {s.name.split(".")[1]: s for s in self.states}
-        transitions = []
-        for state in states.values():
-            transitions += state.get_transition_names()
-        return transitions
-
-    def setup(self, builder):
+    def setup(self, builder: Builder) -> None:
         """Perform this component's setup."""
         super().setup(builder)
 
@@ -74,20 +106,32 @@ class DiseaseModel(Machine):
             self.adjust_cause_specific_mortality_rate,
             requires_columns=["age", "sex"],
         )
-
-        self.population_view = builder.population.get_view(["age", "sex", self.state_column])
-        builder.population.initializes_simulants(
-            self.on_initialize_simulants,
-            creates_columns=[self.state_column],
-            requires_columns=["age", "sex"],
-            requires_streams=[f"{self.state_column}_initial_states"],
-        )
         self.randomness = builder.randomness.get_stream(f"{self.state_column}_initial_states")
 
-        builder.event.register_listener("time_step", self.on_time_step)
-        builder.event.register_listener("time_step__cleanup", self.on_time_step_cleanup)
+    #################
+    # Setup methods #
+    #################
 
-    def on_initialize_simulants(self, pop_data):
+    def load_cause_specific_mortality_rate_data(self, builder):
+        if "cause_specific_mortality_rate" not in self._get_data_functions:
+            only_morbid = builder.data.load(f"cause.{self.cause}.restrictions")["yld_only"]
+            if only_morbid:
+                csmr_data = 0
+            else:
+                csmr_data = builder.data.load(
+                    f"{self.cause_type}.{self.cause}.cause_specific_mortality_rate"
+                )
+        else:
+            csmr_data = self._get_data_functions["cause_specific_mortality_rate"](
+                self.cause, builder
+            )
+        return csmr_data
+
+    ########################
+    # Event-driven methods #
+    ########################
+
+    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         population = self.population_view.subview(["age", "sex"]).get(pop_data.index)
 
         assert self.initial_state in {s.state_id for s in self.states}
@@ -136,29 +180,22 @@ class DiseaseModel(Machine):
             )
         self.population_view.update(condition_column)
 
-    def on_time_step(self, event):
+    def on_time_step(self, event: Event) -> None:
         self.transition(event.index, event.time)
 
-    def on_time_step_cleanup(self, event):
+    def on_time_step_cleanup(self, event: Event) -> None:
         self.cleanup(event.index, event.time)
 
-    def load_cause_specific_mortality_rate_data(self, builder):
-        if "cause_specific_mortality_rate" not in self._get_data_functions:
-            only_morbid = builder.data.load(f"cause.{self.cause}.restrictions")["yld_only"]
-            if only_morbid:
-                csmr_data = 0
-            else:
-                csmr_data = builder.data.load(
-                    f"{self.cause_type}.{self.cause}.cause_specific_mortality_rate"
-                )
-        else:
-            csmr_data = self._get_data_functions["cause_specific_mortality_rate"](
-                self.cause, builder
-            )
-        return csmr_data
+    ##################################
+    # Pipeline sources and modifiers #
+    ##################################
 
     def adjust_cause_specific_mortality_rate(self, index, rate):
         return rate + self.cause_specific_mortality_rate(index)
+
+    ####################
+    # Helper functions #
+    ####################
 
     def _get_default_initial_state(self):
         susceptible_states = [s for s in self.states if isinstance(s, SusceptibleState)]

--- a/src/vivarium_public_health/disease/model.py
+++ b/src/vivarium_public_health/disease/model.py
@@ -53,15 +53,7 @@ class DiseaseModel(Machine):
 
     @property
     def transition_names(self) -> List[TransitionString]:
-        states = {s.name.split(".")[1]: s for s in self.states}
-        transitions = []
-        for state in states.values():
-            transitions += state.get_transition_names()
-        return transitions
-
-    # @property
-    # def transition_names(self) -> List[TransitionString]:
-    #     return [state.get_transition_names() for state in self.states]
+        return [state_name for state in self.states for state_name in state.get_transition_names()]
 
     #####################
     # Lifecycle methods #

--- a/src/vivarium_public_health/disease/model.py
+++ b/src/vivarium_public_health/disease/model.py
@@ -53,7 +53,9 @@ class DiseaseModel(Machine):
 
     @property
     def transition_names(self) -> List[TransitionString]:
-        return [state_name for state in self.states for state_name in state.get_transition_names()]
+        return [
+            state_name for state in self.states for state_name in state.get_transition_names()
+        ]
 
     #####################
     # Lifecycle methods #

--- a/src/vivarium_public_health/disease/models.py
+++ b/src/vivarium_public_health/disease/models.py
@@ -18,38 +18,31 @@ from vivarium_public_health.disease.state import (
 
 
 def SI(cause: str) -> DiseaseModel:
-    healthy = SusceptibleState(cause)
-    infected = DiseaseState(cause)
+    healthy = SusceptibleState(cause, allow_self_transition=True)
+    infected = DiseaseState(cause, allow_self_transition=True)
 
-    healthy.allow_self_transitions()
-    healthy.add_transition(infected, source_data_type="rate")
-    infected.allow_self_transitions()
+    healthy.add_rate_transition(infected)
 
     return DiseaseModel(cause, states=[healthy, infected])
 
 
 def SIR(cause: str) -> DiseaseModel:
-    healthy = SusceptibleState(cause)
-    infected = DiseaseState(cause)
-    recovered = RecoveredState(cause)
+    healthy = SusceptibleState(cause, allow_self_transition=True)
+    infected = DiseaseState(cause, allow_self_transition=True)
+    recovered = RecoveredState(cause, allow_self_transition=True)
 
-    healthy.allow_self_transitions()
-    healthy.add_transition(infected, source_data_type="rate")
-    infected.allow_self_transitions()
-    infected.add_transition(recovered, source_data_type="rate")
-    recovered.allow_self_transitions()
+    healthy.add_rate_transition(infected)
+    infected.add_rate_transition(recovered)
 
     return DiseaseModel(cause, states=[healthy, infected, recovered])
 
 
 def SIS(cause: str) -> DiseaseModel:
-    healthy = SusceptibleState(cause)
-    infected = DiseaseState(cause)
+    healthy = SusceptibleState(cause, allow_self_transition=True)
+    infected = DiseaseState(cause, allow_self_transition=True)
 
-    healthy.allow_self_transitions()
-    healthy.add_transition(infected, source_data_type="rate")
-    infected.allow_self_transitions()
-    infected.add_transition(healthy, source_data_type="rate")
+    healthy.add_rate_transition(infected)
+    infected.add_rate_transition(healthy)
 
     return DiseaseModel(cause, states=[healthy, infected])
 
@@ -57,13 +50,15 @@ def SIS(cause: str) -> DiseaseModel:
 def SIS_fixed_duration(cause: str, duration: str) -> DiseaseModel:
     duration = pd.Timedelta(days=float(duration) // 1, hours=(float(duration) % 1) * 24.0)
 
-    healthy = SusceptibleState(cause)
-    infected = DiseaseState(cause, get_data_functions={"dwell_time": lambda _, __: duration})
+    healthy = SusceptibleState(cause, allow_self_transition=True)
+    infected = DiseaseState(
+        cause,
+        get_data_functions={"dwell_time": lambda _, __: duration},
+        allow_self_transition=True,
+    )
 
-    healthy.allow_self_transitions()
-    healthy.add_transition(infected, source_data_type="rate")
-    infected.add_transition(healthy)
-    infected.allow_self_transitions()
+    healthy.add_rate_transition(infected)
+    infected.add_dwell_time_transition(healthy)
 
     return DiseaseModel(cause, states=[healthy, infected])
 
@@ -71,15 +66,16 @@ def SIS_fixed_duration(cause: str, duration: str) -> DiseaseModel:
 def SIR_fixed_duration(cause: str, duration: str) -> DiseaseModel:
     duration = pd.Timedelta(days=float(duration) // 1, hours=(float(duration) % 1) * 24.0)
 
-    healthy = SusceptibleState(cause)
-    infected = DiseaseState(cause, get_data_functions={"dwell_time": lambda _, __: duration})
-    recovered = RecoveredState(cause)
+    healthy = SusceptibleState(cause, allow_self_transition=True)
+    infected = DiseaseState(
+        cause,
+        get_data_functions={"dwell_time": lambda _, __: duration},
+        allow_self_transition=True,
+    )
+    recovered = RecoveredState(cause, allow_self_transition=True)
 
-    healthy.allow_self_transitions()
-    healthy.add_transition(infected, source_data_type="rate")
-    infected.add_transition(recovered)
-    infected.allow_self_transitions()
-    recovered.allow_self_transitions()
+    healthy.add_rate_transition(infected)
+    infected.add_dwell_time_transition(recovered)
 
     return DiseaseModel(cause, states=[healthy, infected, recovered])
 
@@ -91,11 +87,10 @@ def NeonatalSWC_without_incidence(cause):
         )
     }
 
-    healthy = SusceptibleState(cause)
-    with_condition = DiseaseState(cause, get_data_functions=with_condition_data_functions)
-
-    healthy.allow_self_transitions()
-    with_condition.allow_self_transitions()
+    healthy = SusceptibleState(cause, allow_self_transition=True)
+    with_condition = DiseaseState(
+        cause, get_data_functions=with_condition_data_functions, allow_self_transition=True
+    )
 
     return DiseaseModel(cause, states=[healthy, with_condition])
 
@@ -107,11 +102,11 @@ def NeonatalSWC_with_incidence(cause):
         )
     }
 
-    healthy = SusceptibleState(cause)
-    with_condition = DiseaseState(cause, get_data_functions=with_condition_data_functions)
+    healthy = SusceptibleState(cause, allow_self_transition=True)
+    with_condition = DiseaseState(
+        cause, get_data_functions=with_condition_data_functions, allow_self_transition=True
+    )
 
-    healthy.allow_self_transitions()
-    healthy.add_transition(with_condition, source_data_type="rate")
-    with_condition.allow_self_transitions()
+    healthy.add_rate_transition(with_condition)
 
     return DiseaseModel(cause, states=[healthy, with_condition])

--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -9,15 +9,19 @@ This module contains frequently used, but non-standard disease models.
 import re
 from collections import namedtuple
 from operator import gt, lt
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
+from vivarium import Component
+from vivarium.framework.event import Event
+from vivarium.framework.population import SimulantData
 from vivarium.framework.values import list_combiner, union_post_processor
 
 from vivarium_public_health.disease.transition import TransitionString
 from vivarium_public_health.utilities import EntityString, is_non_zero
 
 
-class RiskAttributableDisease:
+class RiskAttributableDisease(Component):
     """Component to model a disease fully attributed by a risk.
 
     For some (risk, cause) pairs with population attributable fraction
@@ -81,7 +85,7 @@ class RiskAttributableDisease:
         recoverable : True
     """
 
-    configuration_defaults = {
+    CONFIGURATION_DEFAULTS = {
         "risk_attributable_disease": {
             "threshold": None,
             "mortality": True,
@@ -89,18 +93,58 @@ class RiskAttributableDisease:
         }
     }
 
-    def __init__(self, cause, risk):
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self):
+        return f"disease_model.{self.cause.name}"
+
+    @property
+    def configuration_defaults(self) -> Dict[str, Any]:
+        return {self.cause.name: self.CONFIGURATION_DEFAULTS["risk_attributable_disease"]}
+
+    @property
+    def columns_created(self) -> List[str]:
+        return [
+            self.cause.name,
+            self.diseased_event_time_column,
+            self.susceptible_event_time_column,
+        ]
+
+    @property
+    def columns_required(self) -> Optional[List[str]]:
+        return ["alive"]
+
+    @property
+    def initialization_requirements(self) -> Dict[str, List[str]]:
+        return {
+            "requires_columns": [],
+            "requires_values": [f"{self.risk.name}.exposure"],
+            "requires_streams": [],
+        }
+
+    @property
+    def state_names(self):
+        return self._state_names
+
+    @property
+    def transition_names(self):
+        return self._transition_names
+
+    #####################
+    # Lifecycle methods #
+    #####################
+
+    def __init__(self, cause: str, risk: str):
+        super().__init__()
         self.cause = EntityString(cause)
         self.risk = EntityString(risk)
         self.state_column = self.cause.name
         self.state_id = self.cause.name
         self.diseased_event_time_column = f"{self.cause.name}_event_time"
         self.susceptible_event_time_column = f"susceptible_to_{self.cause.name}_event_time"
-        self.configuration_defaults = {
-            self.cause.name: RiskAttributableDisease.configuration_defaults[
-                "risk_attributable_disease"
-            ]
-        }
         self._state_names = [f"{self.cause.name}", f"susceptible_to_{self.cause.name}"]
         self._transition_names = [
             TransitionString(f"susceptible_to_{self.cause.name}_TO_{self.cause.name}")
@@ -110,18 +154,6 @@ class RiskAttributableDisease:
         self.excess_mortality_rate_paf_pipeline_name = (
             f"{self.excess_mortality_rate_pipeline_name}.paf"
         )
-
-    @property
-    def name(self):
-        return f"disease_model.{self.cause.name}"
-
-    @property
-    def state_names(self):
-        return self._state_names
-
-    @property
-    def transition_names(self):
-        return self._transition_names
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder):
@@ -186,28 +218,12 @@ class RiskAttributableDisease:
         self.filter_by_exposure = self.get_exposure_filter(
             distribution, exposure_pipeline, threshold
         )
-        self.population_view = builder.population.get_view(
-            [
-                self.cause.name,
-                self.diseased_event_time_column,
-                self.susceptible_event_time_column,
-                "alive",
-            ]
-        )
 
-        builder.population.initializes_simulants(
-            self.on_initialize_simulants,
-            creates_columns=[
-                self.cause.name,
-                self.diseased_event_time_column,
-                self.susceptible_event_time_column,
-            ],
-            requires_values=[f"{self.risk.name}.exposure"],
-        )
+    ########################
+    # Event-driven methods #
+    ########################
 
-        builder.event.register_listener("time_step", self.on_time_step)
-
-    def on_initialize_simulants(self, pop_data):
+    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         new_pop = pd.DataFrame(
             {
                 self.cause.name: f"susceptible_to_{self.cause.name}",
@@ -224,7 +240,7 @@ class RiskAttributableDisease:
 
         self.population_view.update(new_pop)
 
-    def on_time_step(self, event):
+    def on_time_step(self, event: Event) -> None:
         pop = self.population_view.get(event.index, query='alive == "alive"')
         sick = self.filter_by_exposure(pop.index)
         #  if this is recoverable, anyone who gets lower exposure in the event goes back in to susceptible status.
@@ -241,6 +257,10 @@ class RiskAttributableDisease:
         pop.loc[change_to_diseased, self.cause.name] = self.cause.name
 
         self.population_view.update(pop)
+
+    ##################################
+    # Pipeline sources and modifiers #
+    ##################################
 
     def compute_disability_weight(self, index):
         disability_weight = pd.Series(0, index=index)
@@ -274,6 +294,10 @@ class RiskAttributableDisease:
         rate = self.excess_mortality_rate(index, skip_post_processor=True)
         rates_df[self.cause.name] = rate
         return rates_df
+
+    ##################
+    # Helper methods #
+    ##################
 
     def with_condition(self, index):
         pop = self.population_view.subview(["alive", self.cause.name]).get(index)
@@ -322,6 +346,7 @@ class RiskAttributableDisease:
 
         return filter_function
 
+    # todo: reorder these methods to make it easier to understand what they are each doing
     def adjust_state_and_transitions(self):
         if self.recoverable:
             self._transition_names.append(

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -6,6 +6,7 @@ Disease States
 This module contains tools to manage standard disease states.
 
 """
+from abc import ABC
 from typing import Callable, Dict, List, Optional
 
 import numpy as np
@@ -179,8 +180,7 @@ class BaseDiseaseState(State):
         return transition
 
 
-# TODO is there a better name for the union of susceptible and recovered?
-class UninfectedState(BaseDiseaseState):
+class NonDiseasedState(BaseDiseaseState):
     ##################
     # Public methods #
     ##################
@@ -202,7 +202,7 @@ class UninfectedState(BaseDiseaseState):
         return super().add_rate_transition(output, get_data_functions, **kwargs)
 
 
-class SusceptibleState(UninfectedState):
+class SusceptibleState(NonDiseasedState):
     #####################
     # Lifecycle methods #
     #####################
@@ -213,7 +213,7 @@ class SusceptibleState(UninfectedState):
         super().__init__(state_id, **kwargs)
 
 
-class RecoveredState(UninfectedState):
+class RecoveredState(NonDiseasedState):
     def __init__(self, state_id, **kwargs):
         if not state_id.startswith("recovered_from_"):
             state_id = f"recovered_from_{state_id}"

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -6,10 +6,11 @@ Disease States
 This module contains tools to manage standard disease states.
 
 """
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
+from vivarium.framework.engine import Builder
 from vivarium.framework.population import PopulationView, SimulantData
 from vivarium.framework.state_machine import State, Transient, Transition
 from vivarium.framework.values import list_combiner, union_post_processor
@@ -23,44 +24,57 @@ from vivarium_public_health.utilities import is_non_zero
 
 
 class BaseDiseaseState(State):
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def columns_created(self):
+        return [self.event_time_column, self.event_count_column]
+
+    @property
+    def columns_required(self) -> Optional[List[str]]:
+        return [self.model, "alive"]
+
+    @property
+    def initialization_requirements(self) -> Dict[str, List[str]]:
+        return {
+            "requires_columns": [self.model],
+            "requires_values": [],
+            "requires_streams": [],
+        }
+
+    #####################
+    # Lifecycle methods #
+    #####################
+
     def __init__(
-        self, cause, name_prefix="", side_effect_function=None, cause_type="cause", **kwargs
+        self,
+        cause: str,
+        name_prefix: str = "",
+        side_effect_function: Optional[Callable] = None,
+        cause_type: str = "cause",
+        **kwargs,
     ):
         super().__init__(name_prefix + cause, **kwargs)  # becomes state_id
         self.cause_type = cause_type
         self.cause = cause
 
         self.side_effect_function = side_effect_function
-        if self.side_effect_function is not None:
-            self._sub_components.append(side_effect_function)
 
         self.event_time_column = self.state_id + "_event_time"
         self.event_count_column = self.state_id + "_event_count"
 
-    @property
-    def columns_created(self):
-        return [self.event_time_column, self.event_count_column]
-
-    # noinspection PyAttributeOutsideInit
-    def setup(self, builder):
-        """Performs this component's simulation setup.
-
-        Parameters
-        ----------
-        builder : `engine.Builder`
-            Interface to several simulation tools.
-        """
-        super().setup(builder)
-
-        self.clock = builder.time.clock()
-
-        view_columns = self.columns_created + [self._model, "alive"]
-        self.population_view = builder.population.get_view(view_columns)
+    def register_simulant_initializer(self, builder: "Builder") -> None:
         builder.population.initializes_simulants(
             self.on_initialize_simulants,
             creates_columns=self.columns_created,
-            requires_columns=[self._model],
+            requires_columns=[self.model],
         )
+
+    ########################
+    # Event-driven methods #
+    ########################
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         """Adds this state's columns to the simulation state table."""
@@ -71,12 +85,16 @@ class BaseDiseaseState(State):
         pop_update = self.get_initial_event_times(pop_data)
         self.population_view.update(pop_update)
 
+    ##################
+    # Helper methods #
+    ##################
+
     def get_initial_event_times(self, pop_data: SimulantData) -> pd.DataFrame:
         return pd.DataFrame(
             {self.event_time_column: pd.NaT, self.event_count_column: 0}, index=pop_data.index
         )
 
-    def _transition_side_effect(self, index, event_time):
+    def transition_side_effect(self, index: pd.Index, event_time: pd.Timestamp) -> None:
         """Updates the simulation state and triggers any side effects associated with this state.
 
         Parameters
@@ -102,110 +120,124 @@ class BaseDiseaseState(State):
     def get_transition_names(self) -> List[str]:
         transitions = []
         for trans in self.transition_set.transitions:
-            _, _, init_state, _, end_state = trans.name.split(".")
+            init_state = trans.input_state.name.split(".")[1]
+            end_state = trans.output_state.name.split(".")[1]
             transitions.append(TransitionString(f"{init_state}_TO_{end_state}"))
         return transitions
 
-    def add_transition(
+    def add_rate_transition(
         self,
-        output: State,
-        source_data_type: str = None,
+        output: "BaseDiseaseState",
         get_data_functions: Dict[str, Callable] = None,
         **kwargs,
-    ) -> Transition:
-        """Builds a transition from this state to the given state.
+    ) -> RateTransition:
+        """Builds a RateTransition from this state to the given state.
 
         Parameters
         ----------
         output
             The end state after the transition.
 
-        source_data_type
-            the type of transition: either 'rate' or 'proportion'
+        get_data_functions
+            map from transition type to the function to pull that transition's data
+
+        Returns
+        -------
+        RateTransition
+            The created transition object.
+        """
+        transition = RateTransition(self, output, get_data_functions, **kwargs)
+        self.add_transition(transition)
+        return transition
+
+    def add_proportion_transition(
+        self,
+        output: "BaseDiseaseState",
+        get_data_functions: Dict[str, Callable] = None,
+        **kwargs,
+    ) -> ProportionTransition:
+        """Builds a ProportionTransition from this state to the given state.
+
+        Parameters
+        ----------
+        output
+            The end state after the transition.
 
         get_data_functions
             map from transition type to the function to pull that transition's data
 
         Returns
         -------
-        vivarium.framework.state_machine.Transition
+        RateTransition
             The created transition object.
-
         """
-        transition_map = {"rate": RateTransition, "proportion": ProportionTransition}
+        if "proportion" not in get_data_functions:
+            raise ValueError("You must supply a proportion function.")
 
-        if not source_data_type:
-            return super().add_transition(output, **kwargs)
-        elif source_data_type in transition_map:
-            t = transition_map[source_data_type](self, output, get_data_functions, **kwargs)
-            self.transition_set.append(t)
-            return t
-        else:
-            raise ValueError(f"Unrecognized data type {source_data_type}")
+        transition = ProportionTransition(self, output, get_data_functions, **kwargs)
+        self.add_transition(transition)
+        return transition
 
 
-class SusceptibleState(BaseDiseaseState):
-    def __init__(self, cause, *args, **kwargs):
-        super().__init__(cause, *args, name_prefix="susceptible_to_", **kwargs)
+# TODO is there a better name for the union of susceptible and recovered?
+class UninfectedState(BaseDiseaseState):
+    ##################
+    # Public methods #
+    ##################
 
-    def add_transition(
+    def add_rate_transition(
         self,
-        output: State,
-        source_data_type: str = None,
+        output: BaseDiseaseState,
         get_data_functions: Dict[str, Callable] = None,
         **kwargs,
-    ) -> Transition:
-        if source_data_type == "rate":
-            if get_data_functions is None:
-                get_data_functions = {
-                    "incidence_rate": lambda builder, cause: builder.data.load(
-                        f"{self.cause_type}.{cause}.incidence_rate"
-                    )
-                }
-            elif "incidence_rate" not in get_data_functions:
-                raise ValueError("You must supply an incidence rate function.")
-        elif source_data_type == "proportion":
-            if "proportion" not in get_data_functions:
-                raise ValueError("You must supply a proportion function.")
-
-        return super().add_transition(output, source_data_type, get_data_functions, **kwargs)
+    ) -> RateTransition:
+        if get_data_functions is None:
+            get_data_functions = {
+                "incidence_rate": lambda builder, cause: builder.data.load(
+                    f"{self.cause_type}.{cause}.incidence_rate"
+                )
+            }
+        elif "incidence_rate" not in get_data_functions:
+            raise ValueError("You must supply an incidence rate function.")
+        return super().add_rate_transition(output, get_data_functions, **kwargs)
 
 
-class RecoveredState(BaseDiseaseState):
-    def __init__(self, cause, *args, **kwargs):
-        super().__init__(cause, *args, name_prefix="recovered_from_", **kwargs)
+class SusceptibleState(UninfectedState):
+    #####################
+    # Lifecycle methods #
+    #####################
 
-    def add_transition(
-        self,
-        output: State,
-        source_data_type: str = None,
-        get_data_functions: Dict[str, Callable] = None,
-        **kwargs,
-    ) -> Transition:
-        if source_data_type == "rate":
-            if get_data_functions is None:
-                get_data_functions = {
-                    "incidence_rate": lambda builder, cause: builder.data.load(
-                        f"{self.cause_type}.{cause}.incidence_rate"
-                    )
-                }
-            elif "incidence_rate" not in get_data_functions:
-                raise ValueError("You must supply an incidence rate function.")
-        elif source_data_type == "proportion":
-            if "proportion" not in get_data_functions:
-                raise ValueError("You must supply a proportion function.")
+    def __init__(self, state_id: str, **kwargs):
+        if not state_id.startswith("susceptible_to_"):
+            state_id = f"susceptible_to_{state_id}"
+        super().__init__(state_id, **kwargs)
 
-        return super().add_transition(output, source_data_type, get_data_functions, **kwargs)
+
+class RecoveredState(UninfectedState):
+    def __init__(self, state_id, **kwargs):
+        if not state_id.startswith("recovered_from_"):
+            state_id = f"recovered_from_{state_id}"
+        super().__init__(state_id, **kwargs)
 
 
 class DiseaseState(BaseDiseaseState):
     """State representing a disease in a state machine model."""
 
-    def __init__(self, cause, get_data_functions=None, cleanup_function=None, **kwargs):
+    #####################
+    # Lifecycle methods #
+    #####################
+
+    def __init__(
+        self,
+        state_id: str,
+        get_data_functions: Dict[str, Callable] = None,
+        cleanup_function: Callable = None,
+        **kwargs,
+    ):
         """
         Parameters
         ----------
-        cause : str
+        state_id : str
             The name of this state.
         disability_weight : pandas.DataFrame or float, optional
             The amount of disability associated with this state.
@@ -220,7 +252,7 @@ class DiseaseState(BaseDiseaseState):
         side_effect_function : callable, optional
             A function to be called when this state is entered.
         """
-        super().__init__(cause, **kwargs)
+        super().__init__(state_id, **kwargs)
 
         self.excess_mortality_rate_pipeline_name = f"{self.state_id}.excess_mortality_rate"
         self.excess_mortality_rate_paf_pipeline_name = (
@@ -230,7 +262,7 @@ class DiseaseState(BaseDiseaseState):
         self._get_data_functions = (
             get_data_functions if get_data_functions is not None else {}
         )
-        self.cleanup_function = cleanup_function
+        self._cleanup_function = cleanup_function
 
         if self.cause is None and not set(self._get_data_functions.keys()).issuperset(
             ["disability_weight", "dwell_time", "prevalence"]
@@ -250,6 +282,7 @@ class DiseaseState(BaseDiseaseState):
             Interface to several simulation tools.
         """
         super().setup(builder)
+        self.clock = builder.time.clock()
 
         prevalence_data = self.load_prevalence_data(builder)
         self.prevalence = builder.lookup.build_table(
@@ -278,7 +311,7 @@ class DiseaseState(BaseDiseaseState):
         self.disability_weight = builder.value.register_value_producer(
             f"{self.state_id}.disability_weight",
             source=self.compute_disability_weight,
-            requires_columns=["age", "sex", "alive", self._model],
+            requires_columns=["age", "sex", "alive", self.model],
         )
         builder.value.register_value_modifier(
             "disability_weight", modifier=self.disability_weight
@@ -292,7 +325,7 @@ class DiseaseState(BaseDiseaseState):
         self.excess_mortality_rate = builder.value.register_rate_producer(
             self.excess_mortality_rate_pipeline_name,
             source=self.compute_excess_mortality_rate,
-            requires_columns=["age", "sex", "alive", self._model],
+            requires_columns=["age", "sex", "alive", self.model],
             requires_values=[self.excess_mortality_rate_paf_pipeline_name],
         )
         paf = builder.lookup.build_table(0)
@@ -312,11 +345,51 @@ class DiseaseState(BaseDiseaseState):
             f"{self.state_id}_prevalent_cases"
         )
 
+    ##################
+    # Public methods #
+    ##################
+
+    def add_rate_transition(
+        self,
+        output: BaseDiseaseState,
+        get_data_functions: Dict[str, Callable] = None,
+        **kwargs,
+    ) -> RateTransition:
+        if get_data_functions is None:
+            get_data_functions = {
+                "remission_rate": lambda builder, cause: builder.data.load(
+                    f"{self.cause_type}.{cause}.remission_rate"
+                )
+            }
+        elif (
+            "remission_rate" not in get_data_functions
+            and "transition_rate" not in get_data_functions
+        ):
+            raise ValueError("You must supply a transition rate or remission rate function.")
+        return super().add_rate_transition(output, get_data_functions, **kwargs)
+
+    def add_dwell_time_transition(
+        self,
+        output: "BaseDiseaseState",
+        **kwargs,
+    ) -> Transition:
+        if "dwell_time" not in self._get_data_functions:
+            raise ValueError("You must supply a dwell time function.")
+
+        transition = Transition(self, output, **kwargs)
+        self.add_transition(transition)
+        return transition
+
+    ##################
+    # Helper methods #
+    ##################
+
+    # todo: reorder these methods to make it easier to understand what they are each doing
     def get_initial_event_times(self, pop_data: SimulantData) -> pd.DataFrame:
         pop_update = super().get_initial_event_times(pop_data)
 
-        simulants_with_condition = self.population_view.subview([self._model]).get(
-            pop_data.index, query=f'{self._model}=="{self.state_id}"'
+        simulants_with_condition = self.population_view.subview([self.model]).get(
+            pop_data.index, query=f'{self.model}=="{self.state_id}"'
         )
         if not simulants_with_condition.empty:
             infected_at = self._assign_event_time_for_prevalent_cases(
@@ -372,9 +445,9 @@ class DiseaseState(BaseDiseaseState):
         return rates_df
 
     def with_condition(self, index):
-        pop = self.population_view.subview(["alive", self._model]).get(index)
+        pop = self.population_view.subview(["alive", self.model]).get(index)
         with_condition = pop.loc[
-            (pop[self._model] == self.state_id) & (pop["alive"] == "alive")
+            (pop[self.model] == self.state_id) & (pop["alive"] == "alive")
         ].index
         return with_condition
 
@@ -386,32 +459,6 @@ class DiseaseState(BaseDiseaseState):
         infected_at = dwell_time * randomness_func(infected.index)
         infected_at = current_time - pd.to_timedelta(infected_at, unit="D")
         return infected_at
-
-    def add_transition(
-        self,
-        output: State,
-        source_data_type: str = None,
-        get_data_functions: Dict[str, Callable] = None,
-        **kwargs,
-    ) -> Transition:
-        if source_data_type == "rate":
-            if get_data_functions is None:
-                get_data_functions = {
-                    "remission_rate": lambda builder, cause: builder.data.load(
-                        f"{self.cause_type}.{cause}.remission_rate"
-                    )
-                }
-            elif (
-                "remission_rate" not in get_data_functions
-                and "transition_rate" not in get_data_functions
-            ):
-                raise ValueError(
-                    "You must supply a transition rate or remission rate function."
-                )
-        elif source_data_type == "proportion":
-            if "proportion" not in get_data_functions:
-                raise ValueError("You must supply a proportion function.")
-        return super().add_transition(output, source_data_type, get_data_functions, **kwargs)
 
     def next_state(
         self, index: pd.Index, event_time: pd.Timestamp, population_view: PopulationView
@@ -453,8 +500,8 @@ class DiseaseState(BaseDiseaseState):
             return index
 
     def _cleanup_effect(self, index, event_time):
-        if self.cleanup_function is not None:
-            self.cleanup_function(index, event_time)
+        if self._cleanup_function is not None:
+            self._cleanup_function(index, event_time)
 
     def load_prevalence_data(self, builder):
         if "prevalence" in self._get_data_functions:
@@ -501,15 +548,11 @@ class DiseaseState(BaseDiseaseState):
     def load_excess_mortality_rate_data(self, builder):
         if "excess_mortality_rate" in self._get_data_functions:
             return self._get_data_functions["excess_mortality_rate"](builder, self.cause)
-        elif builder.data.load(f"cause.{self._model}.restrictions")["yld_only"]:
+        elif builder.data.load(f"cause.{self.model}.restrictions")["yld_only"]:
             return 0
         else:
             return builder.data.load(f"{self.cause_type}.{self.cause}.excess_mortality_rate")
 
-    def __repr__(self):
-        return "DiseaseState({})".format(self.state_id)
-
 
 class TransientDiseaseState(BaseDiseaseState, Transient):
-    def __repr__(self):
-        return "TransientDiseaseState(name={})".format(self.state_id)
+    pass

--- a/src/vivarium_public_health/population/base_population.py
+++ b/src/vivarium_public_health/population/base_population.py
@@ -203,14 +203,16 @@ class AgeOutSimulants(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        if builder.configuration.population.exit_age is not None:
-            self.config = builder.configuration.population
+        self.config = builder.configuration.population
+        if self.config.exit_age is not None:
             self._columns_required = ["age", "exit_time", "tracked"]
-            self.on_time_step_cleanup = self._on_time_step_cleanup
 
         super().setup(builder)
 
-    def _on_time_step_cleanup(self, event: Event) -> None:
+    def on_time_step_cleanup(self, event: Event) -> None:
+        if self.config.exit_age is None:
+            return
+
         population = self.population_view.get(event.index)
         max_age = float(self.config.exit_age)
         pop = population[(population["age"] >= max_age) & population["tracked"]].copy()

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from vivarium import InteractiveContext
+from vivarium.framework.state_machine import Transition
 from vivarium.framework.utilities import from_yearly
 from vivarium.testing_utilities import TestPopulation, build_table, metadata
 
@@ -69,8 +70,8 @@ def test_dwell_time(assign_cause_mock, base_config, base_plugins, disease, base_
     event_state = DiseaseState("event", get_data_functions=data_function)
     done_state = BaseDiseaseState("sick")
 
-    healthy_state.add_transition(event_state)
-    event_state.add_transition(done_state)
+    healthy_state.add_transition(Transition(healthy_state, event_state))
+    event_state.add_dwell_time_transition(done_state)
 
     model = DiseaseModel(
         disease, initial_state=healthy_state, states=[healthy_state, event_state, done_state]
@@ -120,8 +121,8 @@ def test_dwell_time_with_mortality(base_config, base_plugins, disease):
     mortality_state = DiseaseState("event", get_data_functions=mort_get_data_funcs)
     done_state = BaseDiseaseState("sick")
 
-    healthy_state.add_transition(mortality_state)
-    mortality_state.add_transition(done_state)
+    healthy_state.add_transition(Transition(healthy_state, mortality_state))
+    mortality_state.add_dwell_time_transition(done_state)
 
     model = DiseaseModel(
         disease,
@@ -282,7 +283,7 @@ def test_mortality_rate(base_config, base_plugins, disease):
 
     mortality_state = DiseaseState("sick", get_data_functions=mort_get_data_funcs)
 
-    healthy.add_transition(mortality_state)
+    healthy.add_transition(Transition(healthy, mortality_state))
 
     model = DiseaseModel(disease, initial_state=healthy, states=[healthy, mortality_state])
 
@@ -493,8 +494,8 @@ def test_no_birth_prevalence_initial_assignment(base_config, base_plugins, disea
 def test_state_transition_names(disease):
     with_condition = DiseaseState("diarrheal_diseases")
     healthy = SusceptibleState("diarrheal_diseases")
-    healthy.add_transition(with_condition)
-    with_condition.add_transition(healthy)
+    healthy.add_rate_transition(with_condition)
+    with_condition.add_rate_transition(healthy)
     model = DiseaseModel(disease, initial_state=healthy, states=[healthy, with_condition])
     assert set(model.state_names) == {
         "diarrheal_diseases",

--- a/tests/metrics/test_disease_observer.py
+++ b/tests/metrics/test_disease_observer.py
@@ -27,12 +27,14 @@ def model(base_config, disease: str) -> DiseaseModel:
         "prevalence": lambda _, __: build_table(
             0.2, year_start - 1, year_end, ["age", "year", "sex", "value"]
         ),
-        "incidence": lambda _, __: build_table(
+    }
+    transition_get_data_funcs = {
+        "incidence_rate": lambda _, __: build_table(
             0.9, year_start - 1, year_end, ["age", "year", "sex", "value"]
         ),
     }
     with_condition = DiseaseState("with_condition", get_data_functions=disease_get_data_funcs)
-    healthy.add_transition(with_condition)
+    healthy.add_rate_transition(with_condition, transition_get_data_funcs)
     return DiseaseModel(disease, initial_state=healthy, states=[healthy, with_condition])
 
 

--- a/tests/metrics/test_mortality_observer.py
+++ b/tests/metrics/test_mortality_observer.py
@@ -15,7 +15,7 @@ from vivarium_public_health.population import Mortality
 def disease_with_excess_mortality(base_config, disease_name, emr_value) -> DiseaseModel:
     year_start = base_config.time.start.year
     year_end = base_config.time.end.year
-    healthy = SusceptibleState(disease_name)
+    healthy = SusceptibleState(disease_name, allow_self_transition=True)
     disease_get_data_funcs = {
         "disability_weight": lambda *_: build_table(0.0, year_start - 1, year_end),
         "prevalence": lambda *_: build_table(
@@ -26,7 +26,7 @@ def disease_with_excess_mortality(base_config, disease_name, emr_value) -> Disea
         ),
     }
     with_condition = DiseaseState(disease_name, get_data_functions=disease_get_data_funcs)
-    healthy.add_transition(
+    healthy.add_rate_transition(
         with_condition,
         get_data_functions={
             "incidence_rate": lambda *_: build_table(


### PR DESCRIPTION
## Refactor disease model components accommodate inheriting from Component
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: [MIC-4473](https://jira.ihme.washington.edu/browse/MIC-4473)

### Changes and notes
- Simplifies `AgeOutSimulants`' time-step cleanup method - this is changed in this PR because the test started failing
- Refactors `DiseaseModel` and the various state and transition classes to accommodate the fact that their super-classes now inherit from `Component`. 
- Adds some typing where it wasn't increasing the scope of the PR too much
- Replaced previous `state.add_transition()` functions with `state.add_rate_transition()`, `state.add_proportion_transition()`, and `state.add_dwell_time_transition` which I think are clearer, and bring us in line with the new signature of `add_transition` in `State`. This also means we no longer have sub-classes having a method with the same name, but incompatible arguments as their super-class.

### Testing
All unit tests pass. 
