### PR TITLE
Address Pandas 2.1 FutureWarnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.0.4 - 09/15/23**
+
+ - Address Pandas 2.1 FutureWarnings
+
 **1.0.3 - 08/10/23**
 
  - Pass `BaseDiseaseState` constructor kwargs to its super-class's constructor

--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -243,13 +243,13 @@ class RiskAttributableDisease:
         self.population_view.update(pop)
 
     def compute_disability_weight(self, index):
-        disability_weight = pd.Series(0, index=index)
+        disability_weight = pd.Series(0.0, index=index)
         with_condition = self.with_condition(index)
         disability_weight.loc[with_condition] = self.base_disability_weight(with_condition)
         return disability_weight
 
     def compute_excess_mortality_rate(self, index):
-        excess_mortality_rate = pd.Series(0, index=index)
+        excess_mortality_rate = pd.Series(0.0, index=index)
         with_condition = self.with_condition(index)
         base_excess_mort = self.base_excess_mortality_rate(with_condition)
         joint_mediated_paf = self.joint_paf(with_condition)

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -342,13 +342,13 @@ class DiseaseState(BaseDiseaseState):
         `pandas.Series`
             An iterable of disability weights indexed by the provided `index`.
         """
-        disability_weight = pd.Series(0, index=index)
+        disability_weight = pd.Series(0.0, index=index)
         with_condition = self.with_condition(index)
         disability_weight.loc[with_condition] = self.base_disability_weight(with_condition)
         return disability_weight
 
     def compute_excess_mortality_rate(self, index):
-        excess_mortality_rate = pd.Series(0, index=index)
+        excess_mortality_rate = pd.Series(0.0, index=index)
         with_condition = self.with_condition(index)
         base_excess_mort = self.base_excess_mortality_rate(with_condition)
         joint_mediated_paf = self.joint_paf(with_condition)

--- a/src/vivarium_public_health/disease/transition.py
+++ b/src/vivarium_public_health/disease/transition.py
@@ -52,7 +52,7 @@ class RateTransition(Transition):
         self.population_view = builder.population.get_view(["alive"])
 
     def compute_transition_rate(self, index):
-        transition_rate = pd.Series(0, index=index)
+        transition_rate = pd.Series(0.0, index=index)
         living = self.population_view.get(index, query='alive == "alive"').index
         base_rates = self.base_rate(living)
         joint_paf = self.joint_paf(living)


### PR DESCRIPTION
## Title: Address Pandas 2.1 FutureWarnings
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
misc
- *JIRA issue*: [MIC-4545](https://jira.ihme.washington.edu/browse/MIC-4545)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Pandas 2.1.0 features a new deprecations (at least, one that we must address in VPH):
https://pandas.pydata.org/docs/dev/whatsnew/v2.1.0.html#deprecations

It is silent upcasting, for which we just need to define pd.Series(0, ...) or DataFrame with a value of 0.0 instead, so it starts out with float data
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Tested in US CVD, futurewarnings are no longer present from VPH, and change should not affect behavior