### PR TITLE
Rmudambi/mic 4543 setup

### DIFF
--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -65,7 +65,6 @@ class DisabilityObserver(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.config = builder.configuration.stratification.disability
         self.step_size = pd.Timedelta(days=builder.configuration.time.step_size)
         self.disability_weight = self.get_disability_weight_pipeline(builder)

--- a/src/vivarium_public_health/metrics/disease.py
+++ b/src/vivarium_public_health/metrics/disease.py
@@ -81,7 +81,6 @@ class DiseaseObserver(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.step_size = builder.time.step_size()
         self.config = builder.configuration.stratification[self.disease]
 

--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -70,7 +70,6 @@ class MortalityObserver(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.clock = builder.time.clock()
         self.config = builder.configuration.stratification.mortality
         self._cause_components = builder.components.get_components_by_type(

--- a/src/vivarium_public_health/metrics/risk.py
+++ b/src/vivarium_public_health/metrics/risk.py
@@ -86,7 +86,6 @@ class CategoricalRiskObserver(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.step_size = builder.time.step_size()
         self.config = builder.configuration.stratification[self.risk]
         self.categories = builder.data.load(f"risk_factor.{self.risk}.categories")

--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -13,16 +13,22 @@ from vivarium.framework.engine import Builder
 
 
 class ResultsStratifier(Component):
-    name = "results_stratifier"
+
+    #####################
+    # Lifecycle methods #
+    #####################
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.age_bins = self.get_age_bins(builder)
         self.start_year = builder.configuration.time.start.year
         self.end_year = builder.configuration.time.end.year
 
         self.register_stratifications(builder)
+
+    #################
+    # Setup methods #
+    #################
 
     def register_stratifications(self, builder: Builder) -> None:
         builder.results.register_stratification(

--- a/src/vivarium_public_health/mslt/delay.py
+++ b/src/vivarium_public_health/mslt/delay.py
@@ -140,8 +140,6 @@ class DelayedRisk(Component):
         handlers and rate modifiers, and setting up the population view.
         """
         self._bin_names = self.get_bin_names()
-        super().setup(builder)
-
         self.config = builder.configuration
 
         self.start_year = builder.configuration.time.start.year

--- a/src/vivarium_public_health/mslt/disease.py
+++ b/src/vivarium_public_health/mslt/disease.py
@@ -47,7 +47,6 @@ class AcuteDisease(Component):
         self.disease = disease
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         """Load the morbidity and mortality data."""
         mty_data = builder.data.load(f"acute_disease.{self.disease}.mortality")
         mty_rate = builder.lookup.build_table(
@@ -152,7 +151,6 @@ class Disease(Component):
 
     def setup(self, builder: Builder) -> None:
         """Load the disease prevalence and rates data."""
-        super().setup(builder)
         data_prefix = "chronic_disease.{}.".format(self.disease)
         bau_prefix = self.disease + "."
         int_prefix = self.disease + "_intervention."

--- a/src/vivarium_public_health/mslt/intervention.py
+++ b/src/vivarium_public_health/mslt/intervention.py
@@ -39,7 +39,6 @@ class ModifyAllCauseMortality(Component):
         self.intervention = intervention
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.config = builder.configuration
         self.scale = self.config.intervention[self.intervention]["scale"]
         if self.scale < 0:
@@ -83,7 +82,6 @@ class ModifyDiseaseRate(Component):
         self._scale_name = f"{self.disease}_{self.rate}_scale"
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.config = builder.configuration
         # NOTE: this will be replaced by an (age, sex, year) lookup-table.
         self.scale = self.config.intervention[self.intervention][self._scale_name]
@@ -160,7 +158,6 @@ class ModifyAcuteDiseaseIncidence(Component):
         self.intervention = intervention
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.config = builder.configuration
         self.scale = self.config.intervention[self.intervention].incidence_scale
         if self.scale < 0:
@@ -204,7 +201,6 @@ class ModifyAcuteDiseaseMorbidity(Component):
         self.intervention = intervention
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.config = builder.configuration
         self.scale = self.config.intervention[self.intervention].yld_scale
         if self.scale < 0:
@@ -246,7 +242,6 @@ class ModifyAcuteDiseaseMortality(Component):
         self.intervention = intervention
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.config = builder.configuration
         self.scale = self.config.intervention[self.intervention].mortality_scale
         if self.scale < 0:
@@ -286,7 +281,6 @@ class TobaccoFreeGeneration(Component):
         self.exposure = "tobacco"
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.year = builder.configuration["tobacco_free_generation"].year
         self.clock = builder.time.clock()
         rate_name = "{}_intervention.incidence".format(self.exposure)
@@ -328,7 +322,6 @@ class TobaccoEradication(Component):
         self.exposure = "tobacco"
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.year = builder.configuration["tobacco_eradication"].year
         self.clock = builder.time.clock()
         inc_rate_name = "{}_intervention.incidence".format(self.exposure)

--- a/src/vivarium_public_health/mslt/magic_wand_components.py
+++ b/src/vivarium_public_health/mslt/magic_wand_components.py
@@ -19,7 +19,6 @@ class MortalityShift(Component):
     #####################
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         builder.value.register_value_modifier("mortality_rate", self.mortality_adjustment)
 
     ##################################
@@ -36,7 +35,6 @@ class YLDShift(Component):
     #####################
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         builder.value.register_value_modifier("yld_rate", self.disability_adjustment)
 
     ##################################
@@ -56,7 +54,6 @@ class IncidenceShift(Component):
         self.disease = disease
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         builder.value.register_value_modifier(
             f"{self.disease}_intervention.incidence", self.incidence_adjustment
         )
@@ -92,7 +89,6 @@ class ModifyAcuteDiseaseYLD(Component):
         self.disease = disease
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.config = builder.configuration
         self.scale = self.config.intervention[self.disease].yld_scale
         if self.scale < 0:
@@ -132,7 +128,6 @@ class ModifyAcuteDiseaseMortality(Component):
         self.disease = disease
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.config = builder.configuration
         self.scale = self.config.intervention[self.disease].mortality_scale
         if self.scale < 0:

--- a/src/vivarium_public_health/mslt/observer.py
+++ b/src/vivarium_public_health/mslt/observer.py
@@ -96,7 +96,6 @@ class MorbidityMortality(Component):
         self.output_suffix = output_suffix
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         # Record the key columns from the core multi-state life table.
         self.clock = builder.time.clock()
 
@@ -226,7 +225,6 @@ class Disease(Component):
         self.int_C_col = "{}_C_intervention".format(self.disease)
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         bau_incidence_value = "{}.incidence".format(self.disease)
         int_incidence_value = "{}_intervention.incidence".format(self.disease)
         self.bau_incidence = builder.value.get_value(bau_incidence_value)
@@ -314,7 +312,6 @@ class TobaccoPrevalence(Component):
 
     def setup(self, builder: Builder) -> None:
         self._bin_names = self.get_bin_names()
-        super().setup(builder)
 
         self.config = builder.configuration
         self.clock = builder.time.clock()

--- a/src/vivarium_public_health/mslt/population.py
+++ b/src/vivarium_public_health/mslt/population.py
@@ -79,7 +79,6 @@ class BasePopulation(Component):
     #####################
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         """Load the population data."""
         self.pop_data = load_population_data(builder)
 
@@ -143,7 +142,6 @@ class Mortality(Component):
 
     def setup(self, builder: Builder) -> None:
         """Load the all-cause mortality rate."""
-        super().setup(builder)
         mortality_data = builder.data.load("cause.all_causes.mortality")
         self.mortality_rate = builder.value.register_rate_producer(
             "mortality_rate",
@@ -208,7 +206,6 @@ class Disability(Component):
     #####################
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         """Load the years lost due to disability (YLD) rate."""
         yld_data = builder.data.load("cause.all_causes.disability_rate")
         yld_rate = builder.lookup.build_table(

--- a/src/vivarium_public_health/population/add_new_birth_cohorts.py
+++ b/src/vivarium_public_health/population/add_new_birth_cohorts.py
@@ -38,7 +38,6 @@ class FertilityDeterministic(Component):
     #####################
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.fractional_new_births = 0
         self.simulants_per_year = (
             builder.configuration.fertility.number_of_new_simulants_each_year
@@ -115,7 +114,6 @@ class FertilityCrudeBirthRate(Component):
     #####################
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.birth_rate = get_live_births_per_year(builder)
 
         self.clock = builder.time.clock()
@@ -190,7 +188,6 @@ class FertilityAgeSpecificRates(Component):
         builder : vivarium.engine.Builder
             Framework coordination object.
         """
-        super().setup(builder)
         age_specific_fertility_rate = self.load_age_specific_fertility_rate_data(builder)
         fertility_rate = builder.lookup.build_table(
             age_specific_fertility_rate, parameter_columns=["age", "year"]

--- a/src/vivarium_public_health/population/base_population.py
+++ b/src/vivarium_public_health/population/base_population.py
@@ -29,7 +29,7 @@ from vivarium_public_health.population.data_transformations import (
 class BasePopulation(Component):
     """Component for producing and aging simulants based on demographic data."""
 
-    configuration_defaults = {
+    CONFIGURATION_DEFAULTS = {
         "population": {
             "age_start": 0,
             "age_end": 125,
@@ -38,16 +38,9 @@ class BasePopulation(Component):
         }
     }
 
-    def __repr__(self) -> str:
-        return "BasePopulation()"
-
     ##############
     # Properties #
     ##############
-
-    @property
-    def name(self) -> str:
-        return "base_population"
 
     @property
     def columns_created(self) -> List[str]:
@@ -67,8 +60,6 @@ class BasePopulation(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
-
         self.config = builder.configuration.population
         self.key_columns = builder.configuration.randomness.key_columns
         if self.config.include_sex not in ["Male", "Female", "Both"]:
@@ -177,16 +168,9 @@ class BasePopulation(Component):
 class AgeOutSimulants(Component):
     """Component for handling aged-out simulants"""
 
-    def __repr__(self) -> str:
-        return "AgeOutSimulants()"
-
     ##############
     # Properties #
     ##############
-
-    @property
-    def name(self) -> str:
-        return "age_out_simulants"
 
     @property
     def columns_required(self) -> List[str]:
@@ -206,8 +190,6 @@ class AgeOutSimulants(Component):
         self.config = builder.configuration.population
         if self.config.exit_age is not None:
             self._columns_required = ["age", "exit_time", "tracked"]
-
-        super().setup(builder)
 
     def on_time_step_cleanup(self, event: Event) -> None:
         if self.config.exit_age is None:

--- a/src/vivarium_public_health/population/mortality.py
+++ b/src/vivarium_public_health/population/mortality.py
@@ -93,7 +93,6 @@ class Mortality(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.random = self.get_randomness_stream(builder)
         self.clock = builder.time.clock()
 

--- a/src/vivarium_public_health/risks/base_risk.py
+++ b/src/vivarium_public_health/risks/base_risk.py
@@ -132,7 +132,6 @@ class Risk(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.randomness = self.get_randomness_stream(builder)
         self.propensity = self.get_propensity_pipeline(builder)
         self.exposure = self.get_exposure_pipeline(builder)

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -40,7 +40,6 @@ class SimulationDistribution(Component):
         self.risk = EntityString(risk)
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         distribution_data = get_distribution_data(builder, self.risk)
         self.implementation = get_distribution(self.risk, **distribution_data)
         self.implementation.setup(builder)
@@ -81,7 +80,6 @@ class EnsembleSimulation(Component):
         self._propensity = f"ensemble_propensity_{self.risk}"
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.weights = builder.lookup.build_table(
             self._weights, key_columns=["sex"], parameter_columns=["age", "year"]
         )
@@ -149,7 +147,6 @@ class ContinuousDistribution(Component):
         self._parameters = self.get_parameters(mean, sd)
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.parameters = builder.lookup.build_table(
             self._parameters, key_columns=["sex"], parameter_columns=["age", "year"]
         )

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -42,7 +42,7 @@ class SimulationDistribution(Component):
     def setup(self, builder: Builder) -> None:
         distribution_data = get_distribution_data(builder, self.risk)
         self.implementation = get_distribution(self.risk, **distribution_data)
-        self.implementation.setup(builder)
+        self.implementation.setup_component(builder)
 
     ##################
     # Public methods #

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -98,7 +98,6 @@ class RiskEffect(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.exposure_distribution_type = self.get_distribution_type(builder)
         self.exposure = self.get_risk_exposure(builder)
         self.relative_risk = self.get_relative_risk_source(builder)

--- a/src/vivarium_public_health/treatment/magic_wand.py
+++ b/src/vivarium_public_health/treatment/magic_wand.py
@@ -47,7 +47,6 @@ class AbsoluteShift(Component):
         self.target = TargetString(target)
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.config = builder.configuration[f"intervention_on_{self.target.name}"]
         builder.value.register_value_modifier(
             f"{self.target.name}.{self.target.measure}",

--- a/src/vivarium_public_health/treatment/scale_up.py
+++ b/src/vivarium_public_health/treatment/scale_up.py
@@ -96,7 +96,6 @@ class LinearScaleUp(Component):
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
         """Perform this component's setup."""
-        super().setup(builder)
         self.is_intervention_scenario = self.get_is_intervention_scenario(builder)
         self.clock = self.get_clock(builder)
         self.scale_up_start_date, self.scale_up_end_date = self.get_scale_up_dates(builder)

--- a/src/vivarium_public_health/treatment/therapeutic_inertia.py
+++ b/src/vivarium_public_health/treatment/therapeutic_inertia.py
@@ -38,7 +38,6 @@ class TherapeuticInertia(Component):
     #####################
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.therapeutic_inertia_parameters = builder.configuration.therapeutic_inertia
 
         self._therapeutic_inertia = self.initialize_therapeutic_inertia(builder)


### PR DESCRIPTION
## Remove super calls from components inheriting directly from Component
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-4543](https://jira.ihme.washington.edu/browse/MIC-4543)

### Changes and notes
- Remove super calls from components inheriting directly from Component 
- Call `setup_component` rather than `setup` for risk distribution implementation
- Fix misnamed `CONFIGURATION_DEFAULTS` constant in `BasePopulation`
- Remove unneeded `name` and `__repr__` in `BasePopulation` and `AgeOutSimulants`

### Testing
Automated tests pass. Ran US CVD simulation for a few steps