### PR TITLE
Mic-4557/fix dtype issue in test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.0.5 - 09/19/23**
+
+ - Update unit test for dtypes
+
 **1.0.4 - 09/15/23**
 
  - Address Pandas 2.1 FutureWarnings

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -402,12 +402,10 @@ def test__assign_event_time_for_prevalent_cases():
     dwell_time_func = lambda index: pd.Series(10, index=index)
     # 10* 0.4 = 4 ; 4 days before the current time
     expected = pd.Series(pd.Timestamp(2017, 1, 6, 12), index=pop_data.index)
-
-    assert expected.equals(
-        DiseaseState._assign_event_time_for_prevalent_cases(
-            pop_data, current_time, random_func, dwell_time_func
-        )
+    check = DiseaseState._assign_event_time_for_prevalent_cases(
+        pop_data, current_time, random_func, dwell_time_func
     )
+    assert len(expected) == (expected == check).sum()
 
 
 def test_prevalence_birth_prevalence_initial_assignment(base_config, base_plugins, disease):

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -405,7 +405,7 @@ def test__assign_event_time_for_prevalent_cases():
     check = DiseaseState._assign_event_time_for_prevalent_cases(
         pop_data, current_time, random_func, dwell_time_func
     )
-    assert len(expected) == (expected == check).sum()
+    assert (expected == check).all()
 
 
 def test_prevalence_birth_prevalence_initial_assignment(base_config, base_plugins, disease):


### PR DESCRIPTION
## Mic-4557/fix dtype issue in test

### Fix test that was failing due to a comparison of two series that were of dtypes datetime[ns] and datetime[us].
- *Category*: Test
- *JIRA issue*: [MIC-4557](https://jira.ihme.washington.edu/browse/MIC-4557)

### Changes and notes
-Updates test to check if all values are the same between two series and pd.Series.equals()

### Testing
All tests pass

