### PR TITLE
remission rate bugfix

### DIFF
--- a/src/vivarium_public_health/disease/transition.py
+++ b/src/vivarium_public_health/disease/transition.py
@@ -79,7 +79,7 @@ class RateTransition(Transition):
             pipeline_name = f"{self.output_state.state_id}.incidence_rate"
         elif "remission_rate" in self._get_data_functions:
             rate_data = self._get_data_functions["remission_rate"](
-                builder, self.output_state.state_id
+                builder, self.input_state.state_id
             )
             pipeline_name = f"{self.input_state.state_id}.remission_rate"
         elif "transition_rate" in self._get_data_functions:

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -517,10 +517,10 @@ def test_artifact_transition_keys(mocker, disease):
     healthy.add_rate_transition(with_condition)
     incident_transition = healthy.transition_set.transitions[0]
     incident_transition.load_transition_rate_data(builder)
-    builder.data.load.assert_called_with("cause.diarrheal_diseases.incidence_rate")
+    builder.data.load.assert_called_with(f"cause.{cause}.incidence_rate")
 
     # check remission rate
     with_condition.add_rate_transition(healthy)
     remissive_transition = with_condition.transition_set.transitions[0]
     remissive_transition.load_transition_rate_data(builder)
-    builder.data.load.assert_called_with("cause.diarrheal_diseases.remission_rate")
+    builder.data.load.assert_called_with(f"cause.{cause}.remission_rate")

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -516,10 +516,10 @@ def test_artifact_transition_keys(mocker, disease):
     healthy.add_rate_transition(with_condition)
     incident_transition = healthy.transition_set.transitions[0]
     incident_transition.load_transition_rate_data(builder)
-    builder.data.load.assert_called_with('cause.diarrheal_diseases.incidence_rate')
+    builder.data.load.assert_called_with("cause.diarrheal_diseases.incidence_rate")
 
     # check remission rate
     with_condition.add_rate_transition(healthy)
     remissive_transition = with_condition.transition_set.transitions[0]
     remissive_transition.load_transition_rate_data(builder)
-    builder.data.load.assert_called_with('cause.diarrheal_diseases.remission_rate')
+    builder.data.load.assert_called_with("cause.diarrheal_diseases.remission_rate")

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -503,3 +503,23 @@ def test_state_transition_names(disease):
         TransitionString("diarrheal_diseases_TO_susceptible_to_diarrheal_diseases"),
         TransitionString("susceptible_to_diarrheal_diseases_TO_diarrheal_diseases"),
     }
+
+
+def test_artifact_transition_keys(mocker, disease):
+    builder = mocker.Mock()
+    builder.data.load = mocker.Mock()
+    cause = "diarrheal_diseases"
+    with_condition = DiseaseState(cause)
+    healthy = SusceptibleState(cause)
+
+    # check incidence rate
+    healthy.add_rate_transition(with_condition)
+    incident_transition = healthy.transition_set.transitions[0]
+    incident_transition.load_transition_rate_data(builder)
+    builder.data.load.assert_called_with('cause.diarrheal_diseases.incidence_rate')
+
+    # check remission rate
+    with_condition.add_rate_transition(healthy)
+    remissive_transition = with_condition.transition_set.transitions[0]
+    remissive_transition.load_transition_rate_data(builder)
+    builder.data.load.assert_called_with('cause.diarrheal_diseases.remission_rate')

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -506,7 +506,7 @@ def test_state_transition_names(disease):
 
 
 def test_artifact_transition_keys(mocker, disease):
-    '''Test that we use expected artifact keys to load transition data.'''
+    """Test that we use expected artifact keys to load transition data."""
     builder = mocker.Mock()
     builder.data.load = mocker.Mock()
     cause = "diarrheal_diseases"

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -506,6 +506,7 @@ def test_state_transition_names(disease):
 
 
 def test_artifact_transition_keys(mocker, disease):
+    '''Test that we use expected artifact keys to load transition data.'''
     builder = mocker.Mock()
     builder.data.load = mocker.Mock()
     cause = "diarrheal_diseases"


### PR DESCRIPTION
## remission rate bugfix

### Description
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4590

### Changes and notes
Use input state instead of output state name when calling remission rate.

### Testing
Ran MNCH child model for a few time steps using correct key in artifact.