### PR TITLE
Remove python3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash -le {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     defaults:
       run:
         shell: bash -le {0}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.1.0 - 10/05/23**
+
+ - No longer using Python 3.8
+
 **2.0.1 - 09/27/23**
 
  - Address a CopyWithSettingWarning in results stratifier

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,6 @@
 **2.1.0 - 10/05/23**
 
  - Remove explicit support for Python 3.8
-
-**2.0.2 - 10/05/23**
-
  - Minor bugfix to ensure default remission rate calls the right artifact key
 
 **2.0.1 - 09/27/23**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 
  - Remove explicit support for Python 3.8
 
+**2.0.2 - 10/05/23**
+
+ - Minor bugfix to ensure default remission rate calls the right artifact key
+
 **2.0.1 - 09/27/23**
 
  - Address a CopyWithSettingWarning in results stratifier

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 **2.1.0 - 10/05/23**
 
- - No longer using Python 3.8
+ - Remove explicit support for Python 3.8
 
 **2.0.1 - 09/27/23**
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -195,7 +195,7 @@ texinfo_documents = [
 
 # Other docs we can link to
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.8", None),
+    "python": ("https://docs.python.org/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "tables": ("https://www.pytables.org/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),


### PR DESCRIPTION
PyTables more or less deprecated Python 3.8 in their most recent release, and it's causing our builds to fail. We determined that it is probably best to just follow suit and drop 3.8 from our CI.