### PR TITLE
Fix failing Disease tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.1.2 - 12/21/23**
+
+ - Fix tests failing due to Vivarium 2.3.0 release
+
 **2.1.1 - 10/13/23**
 
  - Perform actions in DiseaseState setup using class methods rather than hardcoding to allow for cleaner subclassing

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -40,10 +40,6 @@ def base_data():
     return _set_prevalence
 
 
-def get_full_pop_index(simulation):
-    return simulation.get_population().index
-
-
 def get_test_prevalence(simulation, key):
     """
     Helper function to calculate the prevalence for the given state(key)

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -39,6 +39,7 @@ def base_data():
 
     return _set_prevalence
 
+
 def get_full_pop_index(simulation):
     return simulation.get_population().index
 

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -192,7 +192,7 @@ def test_prevalence_single_state_with_migration(
     assert np.isclose(
         get_test_prevalence(simulation, "sick"), test_prevalence_level, 0.01
     ), error_message
-    simulation._clock.step_forward(get_full_pop_index(simulation))
+    simulation.step()
     assert np.isclose(
         get_test_prevalence(simulation, "sick"), test_prevalence_level, 0.01
     ), error_message
@@ -203,7 +203,7 @@ def test_prevalence_single_state_with_migration(
     assert np.isclose(
         get_test_prevalence(simulation, "sick"), test_prevalence_level, 0.01
     ), error_message
-    simulation._clock.step_forward(get_full_pop_index(simulation))
+    simulation.step()
     simulation.simulant_creator(
         50000,
         population_configuration={"age_start": 0, "age_end": 5, "sim_state": "time_step"},
@@ -436,7 +436,7 @@ def test_prevalence_birth_prevalence_initial_assignment(base_config, base_plugin
     assert np.isclose(get_test_prevalence(simulation, "with_condition"), 1)
 
     # birth prevalence should be used for assigning initial status to newly-borns on time steps
-    simulation._clock.step_forward(get_full_pop_index(simulation))
+    simulation.step()
     simulation.simulant_creator(
         pop_size,
         population_configuration={"age_start": 0, "age_end": 0, "sim_state": "time_step"},
@@ -444,7 +444,7 @@ def test_prevalence_birth_prevalence_initial_assignment(base_config, base_plugin
     assert np.isclose(get_test_prevalence(simulation, "with_condition"), 0.75, 0.01)
 
     # and prevalence should be used for ages not start = end = 0
-    simulation._clock.step_forward(get_full_pop_index(simulation))
+    simulation.step()
     simulation.simulant_creator(
         pop_size,
         population_configuration={"age_start": 0, "age_end": 5, "sim_state": "time_step"},
@@ -473,7 +473,7 @@ def test_no_birth_prevalence_initial_assignment(base_config, base_plugins, disea
     assert np.isclose(get_test_prevalence(simulation, "with_condition"), 1)
 
     # with no birth prevalence provided, it should default to 0 for ages start = end = 0
-    simulation._clock.step_forward(get_full_pop_index(simulation))
+    simulation.step()
     simulation.simulant_creator(
         1000,
         population_configuration={"age_start": 0, "age_end": 0, "sim_state": "time_step"},
@@ -481,7 +481,7 @@ def test_no_birth_prevalence_initial_assignment(base_config, base_plugins, disea
     assert np.isclose(get_test_prevalence(simulation, "with_condition"), 0.5, 0.01)
 
     # and default to prevalence for ages not start = end = 0
-    simulation._clock.step_forward(get_full_pop_index(simulation))
+    simulation.step()
     simulation.simulant_creator(
         1000,
         population_configuration={"age_start": 0, "age_end": 5, "sim_state": "time_step"},

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -39,6 +39,9 @@ def base_data():
 
     return _set_prevalence
 
+def get_full_pop_index(simulation):
+    return simulation.get_population().index
+
 
 def get_test_prevalence(simulation, key):
     """
@@ -188,7 +191,7 @@ def test_prevalence_single_state_with_migration(
     assert np.isclose(
         get_test_prevalence(simulation, "sick"), test_prevalence_level, 0.01
     ), error_message
-    simulation._clock.step_forward()
+    simulation._clock.step_forward(get_full_pop_index(simulation))
     assert np.isclose(
         get_test_prevalence(simulation, "sick"), test_prevalence_level, 0.01
     ), error_message
@@ -199,7 +202,7 @@ def test_prevalence_single_state_with_migration(
     assert np.isclose(
         get_test_prevalence(simulation, "sick"), test_prevalence_level, 0.01
     ), error_message
-    simulation._clock.step_forward()
+    simulation._clock.step_forward(get_full_pop_index(simulation))
     simulation.simulant_creator(
         50000,
         population_configuration={"age_start": 0, "age_end": 5, "sim_state": "time_step"},
@@ -432,7 +435,7 @@ def test_prevalence_birth_prevalence_initial_assignment(base_config, base_plugin
     assert np.isclose(get_test_prevalence(simulation, "with_condition"), 1)
 
     # birth prevalence should be used for assigning initial status to newly-borns on time steps
-    simulation._clock.step_forward()
+    simulation._clock.step_forward(get_full_pop_index(simulation))
     simulation.simulant_creator(
         pop_size,
         population_configuration={"age_start": 0, "age_end": 0, "sim_state": "time_step"},
@@ -440,7 +443,7 @@ def test_prevalence_birth_prevalence_initial_assignment(base_config, base_plugin
     assert np.isclose(get_test_prevalence(simulation, "with_condition"), 0.75, 0.01)
 
     # and prevalence should be used for ages not start = end = 0
-    simulation._clock.step_forward()
+    simulation._clock.step_forward(get_full_pop_index(simulation))
     simulation.simulant_creator(
         pop_size,
         population_configuration={"age_start": 0, "age_end": 5, "sim_state": "time_step"},
@@ -469,7 +472,7 @@ def test_no_birth_prevalence_initial_assignment(base_config, base_plugins, disea
     assert np.isclose(get_test_prevalence(simulation, "with_condition"), 1)
 
     # with no birth prevalence provided, it should default to 0 for ages start = end = 0
-    simulation._clock.step_forward()
+    simulation._clock.step_forward(get_full_pop_index(simulation))
     simulation.simulant_creator(
         1000,
         population_configuration={"age_start": 0, "age_end": 0, "sim_state": "time_step"},
@@ -477,7 +480,7 @@ def test_no_birth_prevalence_initial_assignment(base_config, base_plugins, disea
     assert np.isclose(get_test_prevalence(simulation, "with_condition"), 0.5, 0.01)
 
     # and default to prevalence for ages not start = end = 0
-    simulation._clock.step_forward()
+    simulation._clock.step_forward(get_full_pop_index(simulation))
     simulation.simulant_creator(
         1000,
         population_configuration={"age_start": 0, "age_end": 5, "sim_state": "time_step"},


### PR DESCRIPTION
## Fix failing Disease tests
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4782

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Vivarium 2.3.0 adds an index to the `step_forward` method in simulation context. You generally don't need to access this when running a simulation, so it is "backwards compatible" in a sense, but VPH manually calls `step_forward()` in a test (presumably to avoid running component timestep events), which broke with the update.

After a check, it looked like sim.step() should work fine--the models don't have transitions, so having the lifecycle events happen should be OK.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass again

