### PR TITLE
Exclude undesirable init arguments from name and __repr__

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.1.3 - 01/08/24**
+
+ - Exclude undesirable arguments from the return of `BaseDiseaseState` `name` and `__repr__` methods
+
 **2.1.2 - 12/21/23**
 
  - Fix tests failing due to Vivarium 2.3.0 release

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -6,7 +6,7 @@ Disease States
 This module contains tools to manage standard disease states.
 
 """
-from typing import Callable, Dict, List, Optional, Any
+from typing import Any, Callable, Dict, List, Optional
 
 import numpy as np
 import pandas as pd

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -6,7 +6,7 @@ Disease States
 This module contains tools to manage standard disease states.
 
 """
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Any
 
 import numpy as np
 import pandas as pd
@@ -81,6 +81,13 @@ class BaseDiseaseState(State):
     ##################
     # Helper methods #
     ##################
+
+    def get_initialization_parameters(self) -> Dict[str, Any]:
+        """Exclude side effect function and cause type from name and __repr__."""
+        initialization_parameters = super().get_initialization_parameters()
+        del initialization_parameters["side_effect_function"]
+        del initialization_parameters["cause_type"]
+        return initialization_parameters
 
     def get_initial_event_times(self, pop_data: SimulantData) -> pd.DataFrame:
         return pd.DataFrame(


### PR DESCRIPTION
## Exclude undesirable init arguments from name and __repr__
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4797

### Changes and notes
Update method used by name and __repr__ to determine the attributes
to include. 

### Testing
Created model with various disease state types and confirmed that the
name looks as expected.