### PR TITLE
Introduce Causes Configuration Parser

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.2.0 - 01/11/24**
+
+ - Implement CausesConfigurationParser to parse causes configuration into DiseaseModel components
+
 **2.1.4 - 01/10/24**
 
  - Exclude undesirable arguments from the return of `BaseDiseaseState` `name` and `__repr__` methods

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ if __name__ == "__main__":
         "pytest",
         "pytest-mock",
         "hypothesis",
+        "pyyaml",
     ]
 
     doc_requirements = [

--- a/src/vivarium_public_health/plugins/__init__.py
+++ b/src/vivarium_public_health/plugins/__init__.py
@@ -1,0 +1,1 @@
+from vivarium_public_health.plugins.parser import CausesConfigurationParser

--- a/src/vivarium_public_health/plugins/parser.py
+++ b/src/vivarium_public_health/plugins/parser.py
@@ -1,0 +1,358 @@
+from importlib import import_module
+from typing import Any, Callable, Dict, List, Union
+
+import pandas as pd
+from pkg_resources import resource_filename
+from vivarium import Component, ConfigTree
+from vivarium.framework.components import ComponentConfigurationParser
+from vivarium.framework.engine import Builder
+from vivarium.framework.state_machine import Trigger
+from vivarium_public_health.disease import (
+    BaseDiseaseState,
+    DiseaseModel,
+    DiseaseState,
+    RecoveredState,
+    SusceptibleState,
+    TransientDiseaseState,
+)
+from vivarium_public_health.utilities import TargetString
+
+from vivarium_nih_us_cvd.components.causes.state import (
+    MultiTransitionDiseaseState,
+    MultiTransitionSusceptibleState,
+)
+
+
+class CausesConfigurationParser(ComponentConfigurationParser):
+    """
+    Component configuration parser that acts the same as the standard vivarium
+    `ComponentConfigurationParser` but adds the additional ability to parse a
+    `causes` key and create `DiseaseModel` components.
+    """
+
+    def parse_component_config(self, component_config: ConfigTree) -> List[Component]:
+        """
+        Parses the component configuration and returns a list of components.
+
+        In particular, this method looks for an `external_configuration` key and
+        a `causes` key.
+
+        The `external_configuration` key should have names of packages that
+        contain cause model configuration files. Within that key should be a list
+        of paths to cause model configuration files relative to the package.
+
+        .. code-block:: yaml
+
+            external_configuration:
+                some_package:
+                    - some/path/cause_model_1.yaml
+                    - some/path/cause_model_2.yaml
+
+        The `causes` key should contain configuration information for cause
+        models.
+
+        Note that this method modifies the simulation's component configuration
+        by adding the contents of external configuration files to the
+        `model_override` layer and adding default cause model configuration
+        values for all cause models to the `component_config` layer.
+        It also marks states that have multiple exiting transitions with the
+        `is_multi_transition` key in the `model_override` layer.
+
+        Parameters
+        ----------
+        component_config
+            A ConfigTree defining the components to initialize.
+
+        Returns
+        -------
+        List[Component]
+            A list of initialized components.
+        """
+        components = []
+
+        if not component_config:
+            return components
+
+        if "external_configuration" in component_config:
+            for package, config_files in component_config["external_configuration"].items():
+                for config_file in config_files.get_value(None):
+                    source = f"{package}::{config_file}"
+                    config_file = resource_filename(package, config_file)
+
+                    external_config = ConfigTree(config_file)
+                    component_config.update(
+                        external_config, layer="model_override", source=source
+                    )
+
+        if "causes" in component_config:
+            self.mark_multi_transition_states(component_config)
+            self.add_default_config_layer(component_config)
+            components += self.get_cause_model_components(component_config["causes"])
+
+        # Create a copy of the config tree excluding "external_config" and
+        # "causes" keys.
+        component_config_dict = component_config.to_dict()
+        component_config_dict.pop("external_configuration", None)
+        component_config_dict.pop("causes", None)
+
+        components += self.process_level(component_config_dict, [])
+        return components
+
+    ##################################
+    # Configuration creation methods #
+    ##################################
+
+    @staticmethod
+    def mark_multi_transition_states(component_config: ConfigTree) -> None:
+        """
+        Marks states that have multiple exiting transitions using the
+        `is_multi_transition` key.
+
+        Parameters
+        ----------
+        component_config
+            A ConfigTree defining the components to initialize
+
+        Returns
+        -------
+        None
+        """
+        transition_counts = {
+            cause: {state: 0 for state in config.states}
+            for cause, config in component_config.causes.items()
+        }
+
+        for cause, config in component_config.causes.items():
+            for transition in config.transitions.values():
+                transition_counts[cause][transition.source] += 1
+
+        for cause, states in transition_counts.items():
+            for state, counts in states.items():
+                component_config.causes[cause].states[state].update(
+                    {"is_multi_transition": counts > 1},
+                    layer="model_override",
+                    source="causes_configuration_parser",
+                )
+
+    @staticmethod
+    def add_default_config_layer(component_config: ConfigTree) -> None:
+        """
+        Adds a default layer to the provided configuration that specifies
+        default values for the cause model configuration.
+
+        Parameters
+        ----------
+        component_config
+            A ConfigTree that specifies the components to initialize
+
+        Returns
+        -------
+        None
+        """
+        default_config = {"causes": {}}
+        for cause_name, cause_config in component_config.causes.items():
+            default_states_config = {}
+            default_transitions_config = {}
+            default_config["causes"][cause_name] = {
+                "states": default_states_config,
+                "transitions": default_transitions_config,
+            }
+
+            for state_name, state_config in cause_config.states.items():
+                default_states_config[state_name] = {
+                    "cause_type": "cause",
+                    "is_multi_transition": False,
+                    "transient": False,
+                    "allow_self_transition": True,
+                    "side_effect": None,
+                    "cleanup_function": None,
+                }
+
+            for transition_name, transition_config in cause_config.transitions.items():
+                default_transitions_config[transition_name] = {"triggered": "NOT_TRIGGERED"}
+
+        component_config.update(
+            default_config, layer="component_configs", source="causes_configuration_parser"
+        )
+
+    ################################
+    # Cause model creation methods #
+    ################################
+
+    def get_cause_model_components(self, causes_config: ConfigTree) -> List[Component]:
+        """
+        Parses the cause model configuration and returns a list of
+        `DiseaseModel` components.
+
+        Parameters
+        ----------
+        causes_config
+            A ConfigTree defining the cause model components to initialize
+
+        Returns
+        -------
+        List[Component]
+            A list of initialized `DiseaseModel` components
+        """
+        cause_models = []
+
+        for cause_name, cause_config in causes_config.items():
+            states: Dict[str, BaseDiseaseState] = {
+                state_name: self.get_state(state_name, state_config, cause_name)
+                for state_name, state_config in cause_config.states.items()
+            }
+
+            for transition_config in cause_config.transitions.values():
+                self.add_transition(
+                    states[transition_config.source],
+                    states[transition_config.sink],
+                    transition_config,
+                )
+
+            cause_models.append(DiseaseModel(cause_name, states=list(states.values())))
+
+        return cause_models
+
+    def get_state(
+        self, state_name: str, state_config: ConfigTree, cause_name: str
+    ) -> BaseDiseaseState:
+        """
+        Parses a state configuration and returns an initialized `BaseDiseaseState`
+        object.
+
+        Parameters
+        ----------
+        state_name
+            The name of the state to initialize
+        state_config
+            A ConfigTree defining the state to initialize
+        cause_name
+            The name of the cause to which the state belongs
+
+        Returns
+        -------
+        BaseDiseaseState
+            An initialized `BaseDiseaseState` object
+        """
+        state_id = cause_name if state_name in ["susceptible", "recovered"] else state_name
+        state_kwargs = {
+            "cause_type": state_config.cause_type,
+            "allow_self_transition": state_config.allow_self_transition,
+        }
+        if state_config.side_effect:
+            # todo handle side effects properly
+            state_kwargs["side_effect"] = lambda *x: x
+        if state_config.cleanup_function:
+            # todo handle cleanup functions properly
+            state_kwargs["cleanup_function"] = lambda *x: x
+        if "get_data_functions" in state_config:
+            data_getters_config = state_config.get_data_functions
+            state_kwargs["get_data_functions"] = {
+                name: self.get_data_getter(name, data_getters_config[name])
+                for name in data_getters_config.keys()
+            }
+
+        if state_config.transient:
+            state_type = TransientDiseaseState
+        elif state_config.is_multi_transition and state_name == "susceptible":
+            state_type = MultiTransitionSusceptibleState
+        elif state_config.is_multi_transition:
+            state_type = MultiTransitionDiseaseState
+        elif state_name == "susceptible":
+            state_type = SusceptibleState
+        elif state_name == "recovered":
+            state_type = RecoveredState
+        else:
+            state_type = DiseaseState
+
+        state = state_type(state_id, **state_kwargs)
+        return state
+
+    def add_transition(
+        self,
+        source_state: BaseDiseaseState,
+        sink_state: BaseDiseaseState,
+        transition_config: ConfigTree,
+    ) -> None:
+        """
+        Adds a transition between two states.
+
+        Parameters
+        ----------
+        source_state
+            The state the transition starts from
+        sink_state
+            The state the transition ends at
+        transition_config
+            A `ConfigTree` defining the transition to add
+
+        Returns
+        -------
+        None
+        """
+        triggered = Trigger[transition_config.triggered]
+        if "get_data_functions" in transition_config:
+            data_getters_config = transition_config.get_data_functions
+            data_getters = {
+                name: self.get_data_getter(name, data_getters_config[name])
+                for name in data_getters_config.keys()
+            }
+        else:
+            data_getters = None
+
+        if transition_config.data_type == "rate":
+            source_state.add_rate_transition(
+                sink_state, get_data_functions=data_getters, triggered=triggered
+            )
+        elif transition_config.data_type == "proportion":
+            source_state.add_proportion_transition(
+                sink_state, get_data_functions=data_getters, triggered=triggered
+            )
+        elif transition_config.data_type == "dwell_time":
+            source_state.add_dwell_time_transition(sink_state, triggered=triggered)
+        else:
+            raise ValueError(
+                f"Invalid transition data type '{transition_config.data_type}'"
+                f" provided for transition '{transition_config}'."
+            )
+
+    @staticmethod
+    def get_data_getter(
+        name: str, getter: Union[str, float]
+    ) -> Callable[[Builder, Any], Any]:
+        """
+        Parses a data getter and returns a callable that can be used to retrieve
+        the data.
+
+        Parameters
+        ----------
+        name
+            The name of the data getter
+        getter
+            The data getter to parse
+
+        Returns
+        -------
+        Callable[[Builder, Any], Any]
+            A callable that can be used to retrieve the data
+        """
+        if isinstance(getter, float):
+            return lambda builder, *_: getter
+
+        try:
+            timedelta = pd.Timedelta(getter)
+            return lambda builder, *_: timedelta
+        except ValueError:
+            pass
+
+        if "::" in getter:
+            module, method = getter.split("::")
+            return getattr(import_module(module), method)
+
+        try:
+            target_string = TargetString(getter)
+            return lambda builder, *_: builder.data.load(target_string)
+        except ValueError:
+            pass
+
+        raise ValueError(f"Invalid data getter '{getter}' for '{name}'.")

--- a/src/vivarium_public_health/plugins/parser.py
+++ b/src/vivarium_public_health/plugins/parser.py
@@ -293,41 +293,41 @@ class CausesConfigurationParser(ComponentConfigurationParser):
 
     @staticmethod
     def get_data_getter(
-        name: str, getter: Union[str, float]
+        name: str, source: Union[str, float]
     ) -> Callable[[Builder, Any], Any]:
         """
-        Parses a data getter and returns a callable that can be used to retrieve
+        Parses a data source and returns a callable that can be used to retrieve
         the data.
 
         Parameters
         ----------
         name
             The name of the data getter
-        getter
-            The data getter to parse
+        source
+            The data source to parse
 
         Returns
         -------
         Callable[[Builder, Any], Any]
             A callable that can be used to retrieve the data
         """
-        if isinstance(getter, float):
-            return lambda builder, *_: getter
+        if isinstance(source, float):
+            return lambda builder, *_: source
 
         try:
-            timedelta = pd.Timedelta(getter)
+            timedelta = pd.Timedelta(source)
             return lambda builder, *_: timedelta
         except ValueError:
             pass
 
-        if "::" in getter:
-            module, method = getter.split("::")
+        if "::" in source:
+            module, method = source.split("::")
             return getattr(import_module(module), method)
 
         try:
-            target_string = TargetString(getter)
+            target_string = TargetString(source)
             return lambda builder, *_: builder.data.load(target_string)
         except ValueError:
             pass
 
-        raise ValueError(f"Invalid data getter '{getter}' for '{name}'.")
+        raise ValueError(f"Invalid data source '{source}' for '{name}'.")

--- a/src/vivarium_public_health/plugins/parser.py
+++ b/src/vivarium_public_health/plugins/parser.py
@@ -124,6 +124,7 @@ class CausesConfigurationParser(ComponentConfigurationParser):
             default_transitions_config = {}
             default_config[cause_name] = {
                 "model_type": f"{DiseaseModel.__module__}.{DiseaseModel.__name__}",
+                "initial_state": None,
                 "states": default_states_config,
                 "transitions": default_transitions_config,
             }
@@ -179,8 +180,10 @@ class CausesConfigurationParser(ComponentConfigurationParser):
                     transition_config,
                 )
 
+
             model_type = import_by_path(cause_config.model_type)
-            model = model_type(cause_name, states=list(states.values()))
+            initial_state = states[cause_config.initial_state] if cause_config.initial_state else None
+            model = model_type(cause_name, initial_state=initial_state, states=list(states.values()))
             cause_models.append(model)
 
         return cause_models

--- a/src/vivarium_public_health/plugins/parser.py
+++ b/src/vivarium_public_health/plugins/parser.py
@@ -27,8 +27,6 @@ class CausesConfigurationParser(ComponentConfigurationParser):
     `causes` key and create `DiseaseModel` components.
     """
 
-    CAUSE_ALLOWABLE_KEYS = {"model_type", "states", "transitions"}
-
     def parse_component_config(self, component_config: ConfigTree) -> List[Component]:
         """
         Parses the component configuration and returns a list of components.
@@ -71,9 +69,6 @@ class CausesConfigurationParser(ComponentConfigurationParser):
             If the cause model configuration is invalid
         """
         components = []
-
-        if not component_config:
-            return components
 
         if "external_configuration" in component_config:
             for package, config_files in component_config["external_configuration"].items():

--- a/src/vivarium_public_health/plugins/parser.py
+++ b/src/vivarium_public_health/plugins/parser.py
@@ -181,6 +181,8 @@ class CausesConfigurationParser(ComponentConfigurationParser):
                 )
 
             model_type = import_by_path(cause_config.model_type)
+            # TODO: uncomment this once we have proper validation of the config
+            # initial_state = states.get(cause_config.initial_state, None)
             initial_state = (
                 states[cause_config.initial_state] if cause_config.initial_state else None
             )

--- a/src/vivarium_public_health/plugins/parser.py
+++ b/src/vivarium_public_health/plugins/parser.py
@@ -180,10 +180,13 @@ class CausesConfigurationParser(ComponentConfigurationParser):
                     transition_config,
                 )
 
-
             model_type = import_by_path(cause_config.model_type)
-            initial_state = states[cause_config.initial_state] if cause_config.initial_state else None
-            model = model_type(cause_name, initial_state=initial_state, states=list(states.values()))
+            initial_state = (
+                states[cause_config.initial_state] if cause_config.initial_state else None
+            )
+            model = model_type(
+                cause_name, initial_state=initial_state, states=list(states.values())
+            )
             cause_models.append(model)
 
         return cause_models

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,9 +44,8 @@ def base_config_factory() -> Callable[[], ConfigTree]:
 
 
 @pytest.fixture(scope="function")
-def base_config() -> ConfigTree:
-    config = base_config_factory()
-    yield config
+def base_config(base_config_factory) -> ConfigTree:
+    yield base_config_factory()
 
 
 @pytest.fixture(scope="module")

--- a/tests/plugins/test_parser.py
+++ b/tests/plugins/test_parser.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Dict, List, Set, Tuple, Type, NamedTuple
+from typing import Dict, List, NamedTuple, Set, Tuple, Type
 
 import pytest
 import yaml

--- a/tests/plugins/test_parser.py
+++ b/tests/plugins/test_parser.py
@@ -214,127 +214,123 @@ class MockArtifactManager(MockArtifactManager_):
 
 
 SIR_MODEL_CONFIG = {
-    "causes": {
-        SIR_MODEL: {
-            "states": {
-                "susceptible": {},
-                SIR_INFECTED.name: {},
-                "recovered": {},
-            },
-            "transitions": {
-                "infected_incidence": {
-                    "source": "susceptible",
-                    "sink": SIR_INFECTED.name,
-                    "data_type": "rate",
-                    "data_sources": {
-                        "incidence_rate": SIR_SUSCEPTIBLE_STATE.get_transitions()[
-                            SIR_INFECTED.name
-                        ].value
-                    },
-                },
-                "infected_remission": {
-                    "source": SIR_INFECTED.name,
-                    "sink": "recovered",
-                    "data_type": "rate",
-                    "data_sources": {
-                        "remission_rate": SIR_INFECTED.get_transitions()[
-                            f"recovered_from_{SIR_MODEL}"
-                        ].value
-                    },
+    SIR_MODEL: {
+        "states": {
+            "susceptible": {},
+            SIR_INFECTED.name: {},
+            "recovered": {},
+        },
+        "transitions": {
+            "infected_incidence": {
+                "source": "susceptible",
+                "sink": SIR_INFECTED.name,
+                "data_type": "rate",
+                "data_sources": {
+                    "incidence_rate": SIR_SUSCEPTIBLE_STATE.get_transitions()[
+                        SIR_INFECTED.name
+                    ].value
                 },
             },
-        }
+            "infected_remission": {
+                "source": SIR_INFECTED.name,
+                "sink": "recovered",
+                "data_type": "rate",
+                "data_sources": {
+                    "remission_rate": SIR_INFECTED.get_transitions()[
+                        f"recovered_from_{SIR_MODEL}"
+                    ].value
+                },
+            },
+        },
     }
 }
 
 
 COMPLEX_MODEL_CONFIG = {
-    "causes": {
-        COMPLEX_MODEL: {
-            "states": {
-                "susceptible": {},
-                COMPLEX_INFECTED_STATE_1.name: {
-                    "cause_type": COMPLEX_INFECTED_STATE_1.cause_type,
-                    "allow_self_transition": COMPLEX_INFECTED_STATE_1.allow_self_transition,
-                    "data_sources": {
-                        "prevalence": "tests.plugins.test_parser::complex_model_infected_1_prevalence",
-                        "disability_weight": "cause.some_custom_cause.disability_weight",
-                        "excess_mortality_rate": "cause.some_custom_cause.excess_mortality_rate",
-                    },
-                },
-                TRANSIENT_STATE_NAME: {"transient": True},
-                COMPLEX_STATE_2_NAME: {
-                    "data_sources": {
-                        "birth_prevalence": COMPLEX_INFECTED_STATE_2.birth_prevalence,
-                        "dwell_time": f"{COMPLEX_INFECTED_STATE_2.dwell_time} days",
-                    },
-                },
-                COMPLEX_STATE_3_NAME: {},
-            },
-            "transitions": {
-                "infected_state_1_incidence": {
-                    "source": "susceptible",
-                    "sink": COMPLEX_INFECTED_STATE_1.name,
-                    "data_type": "rate",
-                    "data_sources": {
-                        "incidence_rate": COMPLEX_SUSCEPTIBLE_STATE.get_transitions()[
-                            COMPLEX_INFECTED_STATE_1.name
-                        ].value
-                    },
-                },
-                "infected_state_1_to_transient": {
-                    "source": COMPLEX_INFECTED_STATE_1.name,
-                    "sink": TRANSIENT_STATE_NAME,
-                    "data_type": "proportion",
-                    "data_sources": {
-                        "proportion": COMPLEX_INFECTED_STATE_1.get_transitions()[
-                            TRANSIENT_STATE_NAME
-                        ].value
-                    },
-                },
-                "infected_state_1_to_infected_state_2": {
-                    "source": COMPLEX_INFECTED_STATE_1.name,
-                    "sink": COMPLEX_STATE_2_NAME,
-                    "data_type": "proportion",
-                    "data_sources": {
-                        "proportion": COMPLEX_INFECTED_STATE_1.get_transitions()[
-                            COMPLEX_STATE_2_NAME
-                        ].value
-                    },
-                },
-                "transient_to_infected_state_2": {
-                    "source": TRANSIENT_STATE_NAME,
-                    "sink": COMPLEX_STATE_2_NAME,
-                    "data_type": "proportion",
-                    "data_sources": {
-                        "proportion": TRANSIENT_STATE.get_transitions()[
-                            COMPLEX_STATE_2_NAME
-                        ].value
-                    },
-                },
-                "infected_state_2_to_infected_state_3": {
-                    "source": COMPLEX_STATE_2_NAME,
-                    "sink": COMPLEX_STATE_3_NAME,
-                    "data_type": "dwell_time",
-                },
-                "infected_state_3_to_infected_state_1": {
-                    "source": COMPLEX_STATE_3_NAME,
-                    "sink": COMPLEX_INFECTED_STATE_1.name,
-                    "data_type": "rate",
-                    "data_sources": {
-                        "transition_rate": "tests.plugins.test_parser::complex_model_3_to_1_transition_rate"
-                    },
-                },
-                "infected_state_3_remission": {
-                    "source": COMPLEX_STATE_3_NAME,
-                    "sink": "susceptible",
-                    "data_type": "rate",
-                    "data_sources": {
-                        "transition_rate": "tests.plugins.test_parser::complex_model_remission_rate"
-                    },
+    COMPLEX_MODEL: {
+        "states": {
+            "susceptible": {},
+            COMPLEX_INFECTED_STATE_1.name: {
+                "cause_type": COMPLEX_INFECTED_STATE_1.cause_type,
+                "allow_self_transition": COMPLEX_INFECTED_STATE_1.allow_self_transition,
+                "data_sources": {
+                    "prevalence": "tests.plugins.test_parser::complex_model_infected_1_prevalence",
+                    "disability_weight": "cause.some_custom_cause.disability_weight",
+                    "excess_mortality_rate": "cause.some_custom_cause.excess_mortality_rate",
                 },
             },
-        }
+            TRANSIENT_STATE_NAME: {"transient": True},
+            COMPLEX_STATE_2_NAME: {
+                "data_sources": {
+                    "birth_prevalence": COMPLEX_INFECTED_STATE_2.birth_prevalence,
+                    "dwell_time": f"{COMPLEX_INFECTED_STATE_2.dwell_time} days",
+                },
+            },
+            COMPLEX_STATE_3_NAME: {},
+        },
+        "transitions": {
+            "infected_state_1_incidence": {
+                "source": "susceptible",
+                "sink": COMPLEX_INFECTED_STATE_1.name,
+                "data_type": "rate",
+                "data_sources": {
+                    "incidence_rate": COMPLEX_SUSCEPTIBLE_STATE.get_transitions()[
+                        COMPLEX_INFECTED_STATE_1.name
+                    ].value
+                },
+            },
+            "infected_state_1_to_transient": {
+                "source": COMPLEX_INFECTED_STATE_1.name,
+                "sink": TRANSIENT_STATE_NAME,
+                "data_type": "proportion",
+                "data_sources": {
+                    "proportion": COMPLEX_INFECTED_STATE_1.get_transitions()[
+                        TRANSIENT_STATE_NAME
+                    ].value
+                },
+            },
+            "infected_state_1_to_infected_state_2": {
+                "source": COMPLEX_INFECTED_STATE_1.name,
+                "sink": COMPLEX_STATE_2_NAME,
+                "data_type": "proportion",
+                "data_sources": {
+                    "proportion": COMPLEX_INFECTED_STATE_1.get_transitions()[
+                        COMPLEX_STATE_2_NAME
+                    ].value
+                },
+            },
+            "transient_to_infected_state_2": {
+                "source": TRANSIENT_STATE_NAME,
+                "sink": COMPLEX_STATE_2_NAME,
+                "data_type": "proportion",
+                "data_sources": {
+                    "proportion": TRANSIENT_STATE.get_transitions()[
+                        COMPLEX_STATE_2_NAME
+                    ].value
+                },
+            },
+            "infected_state_2_to_infected_state_3": {
+                "source": COMPLEX_STATE_2_NAME,
+                "sink": COMPLEX_STATE_3_NAME,
+                "data_type": "dwell_time",
+            },
+            "infected_state_3_to_infected_state_1": {
+                "source": COMPLEX_STATE_3_NAME,
+                "sink": COMPLEX_INFECTED_STATE_1.name,
+                "data_type": "rate",
+                "data_sources": {
+                    "transition_rate": "tests.plugins.test_parser::complex_model_3_to_1_transition_rate"
+                },
+            },
+            "infected_state_3_remission": {
+                "source": COMPLEX_STATE_3_NAME,
+                "sink": "susceptible",
+                "data_type": "rate",
+                "data_sources": {
+                    "transition_rate": "tests.plugins.test_parser::complex_model_remission_rate"
+                },
+            },
+        },
     }
 }
 
@@ -381,7 +377,7 @@ def resource_filename_mock(tmp_path, mocker):
 
 
 ALL_COMPONENTS_CONFIG_DICT = {
-    "causes": {**SIR_MODEL_CONFIG["causes"], **COMPLEX_MODEL_CONFIG["causes"]},
+    "causes": {**SIR_MODEL_CONFIG, **COMPLEX_MODEL_CONFIG},
     "vivarium": {"testing_utilities": "TestPopulation()"},
 }
 
@@ -418,7 +414,7 @@ def test_parser_returns_list_of_components():
 
 def test_parsing_config_single_external_causes_config_file(tmp_path, resource_filename_mock):
     causes_config = {
-        "causes": {**SIR_MODEL_CONFIG["causes"], **COMPLEX_MODEL_CONFIG["causes"]}
+        "causes": {**SIR_MODEL_CONFIG, **COMPLEX_MODEL_CONFIG}
     }
     with open(tmp_path / "causes_config.yaml", "w") as file:
         yaml.dump(causes_config, file)
@@ -436,10 +432,10 @@ def test_parsing_config_multiple_external_causes_config_file(
     tmp_path, resource_filename_mock
 ):
     with open(tmp_path / "sir.yaml", "w") as file:
-        yaml.dump(SIR_MODEL_CONFIG, file)
+        yaml.dump({"causes": SIR_MODEL_CONFIG}, file)
 
     with open(tmp_path / "complex.yaml", "w") as file:
-        yaml.dump(COMPLEX_MODEL_CONFIG, file)
+        yaml.dump({"causes": COMPLEX_MODEL_CONFIG}, file)
 
     component_config = create_simulation_config_tree(
         {
@@ -454,12 +450,12 @@ def test_parsing_config_external_and_local_causes_config_file(
     tmp_path, resource_filename_mock
 ):
     with open(tmp_path / "sir.yaml", "w") as file:
-        yaml.dump(SIR_MODEL_CONFIG, file)
+        yaml.dump({"causes": SIR_MODEL_CONFIG}, file)
 
     component_config = create_simulation_config_tree(
         {
             "external_configuration": {"some_repo": ["sir.yaml"]},
-            **COMPLEX_MODEL_CONFIG,
+            "causes": COMPLEX_MODEL_CONFIG,
             "vivarium": {"testing_utilities": "TestPopulation()"},
         }
     )

--- a/tests/plugins/test_parser.py
+++ b/tests/plugins/test_parser.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Dict, List, Set, Tuple, Type
+from typing import Dict, List, Set, Tuple, Type, NamedTuple
 
 import pytest
 import yaml
@@ -63,151 +63,144 @@ class ExpectedStateData:
         return {transition.sink: transition for transition in self.transitions}
 
 
-SIR_SUSCEPTIBLE_STATE = ExpectedStateData(
-    name=SIR_SUSCEPTIBLE_NAME,
-    state_type=SusceptibleState,
-    transitions=[
-        ExpectedTransitionData(
-            SIR_SUSCEPTIBLE_NAME, SIR_INFECTED_STATE_NAME, RateTransition, 0.5
-        )
-    ],
-)
-SIR_INFECTED = ExpectedStateData(
-    name=SIR_INFECTED_STATE_NAME,
-    prevalence=0.11,
-    disability_weight=0.12,
-    emr=0.13,
-    transitions=[
-        ExpectedTransitionData(
-            SIR_INFECTED_STATE_NAME, SIR_RECOVERED_NAME, RateTransition, 0.6
-        )
-    ],
-)
-SIR_RECOVERED_STATE = ExpectedStateData(name=SIR_RECOVERED_NAME, state_type=RecoveredState)
+class ExpectedStates(NamedTuple):
 
-COMPLEX_SUSCEPTIBLE_STATE = ExpectedStateData(
-    name=COMPLEX_SUSCEPTIBLE_NAME,
-    state_type=SusceptibleState,
-    transitions=[
-        ExpectedTransitionData(
-            COMPLEX_SUSCEPTIBLE_NAME, COMPLEX_INFECTED_STATE_1_NAME, RateTransition, 0.2
-        )
-    ],
-)
+    SIR_SUSCEPTIBLE: ExpectedStateData = ExpectedStateData(
+        name=SIR_SUSCEPTIBLE_NAME,
+        state_type=SusceptibleState,
+        transitions=[
+            ExpectedTransitionData(
+                SIR_SUSCEPTIBLE_NAME, SIR_INFECTED_STATE_NAME, RateTransition, 0.5
+            )
+        ],
+    )
+    SIR_INFECTED: ExpectedStateData = ExpectedStateData(
+        name=SIR_INFECTED_STATE_NAME,
+        prevalence=0.11,
+        disability_weight=0.12,
+        emr=0.13,
+        transitions=[
+            ExpectedTransitionData(
+                SIR_INFECTED_STATE_NAME, SIR_RECOVERED_NAME, RateTransition, 0.6
+            )
+        ],
+    )
+    SIR_RECOVERED: ExpectedStateData = ExpectedStateData(name=SIR_RECOVERED_NAME, state_type=RecoveredState)
 
-COMPLEX_INFECTED_STATE_1 = ExpectedStateData(
-    name=COMPLEX_INFECTED_STATE_1_NAME,
-    cause_type="sequela",
-    allow_self_transition=False,
-    prevalence=0.21,
-    disability_weight=0.22,
-    emr=0.23,
-    transitions=[
-        ExpectedTransitionData(
-            COMPLEX_INFECTED_STATE_1_NAME, TRANSIENT_STATE_NAME, ProportionTransition, 0.25
-        ),
-        ExpectedTransitionData(
-            COMPLEX_INFECTED_STATE_1_NAME, COMPLEX_STATE_2_NAME, ProportionTransition, 0.75
-        ),
-    ],
-)
-TRANSIENT_STATE = ExpectedStateData(
-    name=TRANSIENT_STATE_NAME,
-    state_type=TransientDiseaseState,
-    is_transient=True,
-    transitions=[
-        ExpectedTransitionData(
-            TRANSIENT_STATE_NAME, COMPLEX_STATE_2_NAME, ProportionTransition, 1.0
-        ),
-    ],
-)
-COMPLEX_INFECTED_STATE_2 = ExpectedStateData(
-    name=COMPLEX_STATE_2_NAME,
-    prevalence=0.31,
-    birth_prevalence=0.3,
-    dwell_time=3.0,
-    disability_weight=0.32,
-    emr=0.33,
-    transitions=[
-        ExpectedTransitionData(COMPLEX_STATE_2_NAME, COMPLEX_STATE_3_NAME, Transition, 0.0),
-    ],
-)
+    COMPLEX_SUSCEPTIBLE: ExpectedStateData = ExpectedStateData(
+        name=COMPLEX_SUSCEPTIBLE_NAME,
+        state_type=SusceptibleState,
+        transitions=[
+            ExpectedTransitionData(
+                COMPLEX_SUSCEPTIBLE_NAME, COMPLEX_INFECTED_STATE_1_NAME, RateTransition, 0.2
+            )
+        ],
+    )
 
-COMPLEX_INFECTED_STATE_3 = ExpectedStateData(
-    name=COMPLEX_STATE_3_NAME,
-    prevalence=0.41,
-    disability_weight=0.42,
-    emr=0.43,
-    transitions=[
-        ExpectedTransitionData(
-            COMPLEX_STATE_3_NAME, COMPLEX_INFECTED_STATE_1_NAME, RateTransition, 0.95
-        ),
-        ExpectedTransitionData(
-            COMPLEX_STATE_3_NAME, COMPLEX_SUSCEPTIBLE_NAME, RateTransition, 0.85
-        ),
-    ],
-)
+    COMPLEX_INFECTED_1: ExpectedStateData = ExpectedStateData(
+        name=COMPLEX_INFECTED_STATE_1_NAME,
+        cause_type="sequela",
+        allow_self_transition=False,
+        prevalence=0.21,
+        disability_weight=0.22,
+        emr=0.23,
+        transitions=[
+            ExpectedTransitionData(
+                COMPLEX_INFECTED_STATE_1_NAME, TRANSIENT_STATE_NAME, ProportionTransition, 0.25
+            ),
+            ExpectedTransitionData(
+                COMPLEX_INFECTED_STATE_1_NAME, COMPLEX_STATE_2_NAME, ProportionTransition, 0.75
+            ),
+        ],
+    )
+    TRANSIENT: ExpectedStateData = ExpectedStateData(
+        name=TRANSIENT_STATE_NAME,
+        state_type=TransientDiseaseState,
+        is_transient=True,
+        transitions=[
+            ExpectedTransitionData(
+                TRANSIENT_STATE_NAME, COMPLEX_STATE_2_NAME, ProportionTransition, 1.0
+            ),
+        ],
+    )
+    COMPLEX_INFECTED_2: ExpectedStateData = ExpectedStateData(
+        name=COMPLEX_STATE_2_NAME,
+        prevalence=0.31,
+        birth_prevalence=0.3,
+        dwell_time=3.0,
+        disability_weight=0.32,
+        emr=0.33,
+        transitions=[
+            ExpectedTransitionData(COMPLEX_STATE_2_NAME, COMPLEX_STATE_3_NAME, Transition, 0.0),
+        ],
+    )
 
-STATES_TO_TEST = [
-    SIR_SUSCEPTIBLE_STATE,
-    SIR_INFECTED,
-    SIR_RECOVERED_STATE,
-    COMPLEX_SUSCEPTIBLE_STATE,
-    COMPLEX_INFECTED_STATE_1,
-    TRANSIENT_STATE,
-    COMPLEX_INFECTED_STATE_2,
-    COMPLEX_INFECTED_STATE_3,
-]
+    COMPLEX_INFECTED_3: ExpectedStateData = ExpectedStateData(
+        name=COMPLEX_STATE_3_NAME,
+        prevalence=0.41,
+        disability_weight=0.42,
+        emr=0.43,
+        transitions=[
+            ExpectedTransitionData(
+                COMPLEX_STATE_3_NAME, COMPLEX_INFECTED_STATE_1_NAME, RateTransition, 0.95
+            ),
+            ExpectedTransitionData(
+                COMPLEX_STATE_3_NAME, COMPLEX_SUSCEPTIBLE_NAME, RateTransition, 0.85
+            ),
+        ],
+    )
+
+STATES = ExpectedStates()
 
 
 def complex_model_infected_1_prevalence(_, __):
-    return COMPLEX_INFECTED_STATE_1.prevalence
+    return STATES.COMPLEX_INFECTED_1.prevalence
 
 
 def complex_model_3_to_1_transition_rate(_, __, ___):
-    return COMPLEX_INFECTED_STATE_3.get_transitions()[COMPLEX_INFECTED_STATE_1_NAME].value
+    return STATES.COMPLEX_INFECTED_3.get_transitions()[COMPLEX_INFECTED_STATE_1_NAME].value
 
 
 def complex_model_remission_rate(_, __, ___):
-    return COMPLEX_INFECTED_STATE_3.get_transitions()[COMPLEX_SUSCEPTIBLE_NAME].value
+    return STATES.COMPLEX_INFECTED_3.get_transitions()[COMPLEX_SUSCEPTIBLE_NAME].value
 
 
 class MockArtifactManager(MockArtifactManager_):
     def _load_artifact(self, _: str) -> MockArtifact:
         artifact = MockArtifact()
 
-        artifact.mocks[f"cause.{SIR_INFECTED.name}.prevalence"] = SIR_INFECTED.prevalence
+        artifact.mocks[f"cause.{STATES.SIR_INFECTED.name}.prevalence"] = STATES.SIR_INFECTED.prevalence
         artifact.mocks[
-            f"cause.{SIR_INFECTED.name}.disability_weight"
-        ] = SIR_INFECTED.disability_weight
-        artifact.mocks[f"cause.{SIR_INFECTED.name}.excess_mortality_rate"] = SIR_INFECTED.emr
+            f"cause.{STATES.SIR_INFECTED.name}.disability_weight"
+        ] = STATES.SIR_INFECTED.disability_weight
+        artifact.mocks[f"cause.{STATES.SIR_INFECTED.name}.excess_mortality_rate"] = STATES.SIR_INFECTED.emr
 
         artifact.mocks[
             "cause.some_custom_cause.disability_weight"
-        ] = COMPLEX_INFECTED_STATE_1.disability_weight
+        ] = STATES.COMPLEX_INFECTED_1.disability_weight
         artifact.mocks[
             "cause.some_custom_cause.excess_mortality_rate"
-        ] = COMPLEX_INFECTED_STATE_1.emr
+        ] = STATES.COMPLEX_INFECTED_1.emr
 
         artifact.mocks[
-            f"cause.{COMPLEX_INFECTED_STATE_2.name}.prevalence"
-        ] = COMPLEX_INFECTED_STATE_2.prevalence
+            f"cause.{STATES.COMPLEX_INFECTED_2.name}.prevalence"
+        ] = STATES.COMPLEX_INFECTED_2.prevalence
         artifact.mocks[
-            f"cause.{COMPLEX_INFECTED_STATE_2.name}.disability_weight"
-        ] = COMPLEX_INFECTED_STATE_2.disability_weight
+            f"cause.{STATES.COMPLEX_INFECTED_2.name}.disability_weight"
+        ] = STATES.COMPLEX_INFECTED_2.disability_weight
         artifact.mocks[
-            f"cause.{COMPLEX_INFECTED_STATE_2.name}.excess_mortality_rate"
-        ] = COMPLEX_INFECTED_STATE_2.emr
+            f"cause.{STATES.COMPLEX_INFECTED_2.name}.excess_mortality_rate"
+        ] = STATES.COMPLEX_INFECTED_2.emr
 
         artifact.mocks[
-            f"cause.{COMPLEX_INFECTED_STATE_3.name}.prevalence"
-        ] = COMPLEX_INFECTED_STATE_3.prevalence
+            f"cause.{STATES.COMPLEX_INFECTED_3.name}.prevalence"
+        ] = STATES.COMPLEX_INFECTED_3.prevalence
         artifact.mocks[
-            f"cause.{COMPLEX_INFECTED_STATE_3.name}.disability_weight"
-        ] = COMPLEX_INFECTED_STATE_3.disability_weight
+            f"cause.{STATES.COMPLEX_INFECTED_3.name}.disability_weight"
+        ] = STATES.COMPLEX_INFECTED_3.disability_weight
         artifact.mocks[
-            f"cause.{COMPLEX_INFECTED_STATE_3.name}.excess_mortality_rate"
-        ] = COMPLEX_INFECTED_STATE_3.emr
+            f"cause.{STATES.COMPLEX_INFECTED_3.name}.excess_mortality_rate"
+        ] = STATES.COMPLEX_INFECTED_3.emr
 
         return artifact
 
@@ -216,26 +209,26 @@ SIR_MODEL_CONFIG = {
     SIR_MODEL: {
         "states": {
             "susceptible": {},
-            SIR_INFECTED.name: {},
+            STATES.SIR_INFECTED.name: {},
             "recovered": {},
         },
         "transitions": {
             "infected_incidence": {
                 "source": "susceptible",
-                "sink": SIR_INFECTED.name,
+                "sink": STATES.SIR_INFECTED.name,
                 "data_type": "rate",
                 "data_sources": {
-                    "incidence_rate": SIR_SUSCEPTIBLE_STATE.get_transitions()[
-                        SIR_INFECTED.name
+                    "incidence_rate": STATES.SIR_SUSCEPTIBLE.get_transitions()[
+                        STATES.SIR_INFECTED.name
                     ].value
                 },
             },
             "infected_remission": {
-                "source": SIR_INFECTED.name,
+                "source": STATES.SIR_INFECTED.name,
                 "sink": "recovered",
                 "data_type": "rate",
                 "data_sources": {
-                    "remission_rate": SIR_INFECTED.get_transitions()[
+                    "remission_rate": STATES.SIR_INFECTED.get_transitions()[
                         f"recovered_from_{SIR_MODEL}"
                     ].value
                 },
@@ -249,9 +242,9 @@ COMPLEX_MODEL_CONFIG = {
     COMPLEX_MODEL: {
         "states": {
             "susceptible": {},
-            COMPLEX_INFECTED_STATE_1.name: {
-                "cause_type": COMPLEX_INFECTED_STATE_1.cause_type,
-                "allow_self_transition": COMPLEX_INFECTED_STATE_1.allow_self_transition,
+            STATES.COMPLEX_INFECTED_1.name: {
+                "cause_type": STATES.COMPLEX_INFECTED_1.cause_type,
+                "allow_self_transition": STATES.COMPLEX_INFECTED_1.allow_self_transition,
                 "data_sources": {
                     "prevalence": "tests.plugins.test_parser::complex_model_infected_1_prevalence",
                     "disability_weight": "cause.some_custom_cause.disability_weight",
@@ -261,8 +254,8 @@ COMPLEX_MODEL_CONFIG = {
             TRANSIENT_STATE_NAME: {"transient": True},
             COMPLEX_STATE_2_NAME: {
                 "data_sources": {
-                    "birth_prevalence": COMPLEX_INFECTED_STATE_2.birth_prevalence,
-                    "dwell_time": f"{COMPLEX_INFECTED_STATE_2.dwell_time} days",
+                    "birth_prevalence": STATES.COMPLEX_INFECTED_2.birth_prevalence,
+                    "dwell_time": f"{STATES.COMPLEX_INFECTED_2.dwell_time} days",
                 },
             },
             COMPLEX_STATE_3_NAME: {},
@@ -270,30 +263,30 @@ COMPLEX_MODEL_CONFIG = {
         "transitions": {
             "infected_state_1_incidence": {
                 "source": "susceptible",
-                "sink": COMPLEX_INFECTED_STATE_1.name,
+                "sink": STATES.COMPLEX_INFECTED_1.name,
                 "data_type": "rate",
                 "data_sources": {
-                    "incidence_rate": COMPLEX_SUSCEPTIBLE_STATE.get_transitions()[
-                        COMPLEX_INFECTED_STATE_1.name
+                    "incidence_rate": STATES.COMPLEX_SUSCEPTIBLE.get_transitions()[
+                        STATES.COMPLEX_INFECTED_1.name
                     ].value
                 },
             },
             "infected_state_1_to_transient": {
-                "source": COMPLEX_INFECTED_STATE_1.name,
+                "source": STATES.COMPLEX_INFECTED_1.name,
                 "sink": TRANSIENT_STATE_NAME,
                 "data_type": "proportion",
                 "data_sources": {
-                    "proportion": COMPLEX_INFECTED_STATE_1.get_transitions()[
+                    "proportion": STATES.COMPLEX_INFECTED_1.get_transitions()[
                         TRANSIENT_STATE_NAME
                     ].value
                 },
             },
             "infected_state_1_to_infected_state_2": {
-                "source": COMPLEX_INFECTED_STATE_1.name,
+                "source": STATES.COMPLEX_INFECTED_1.name,
                 "sink": COMPLEX_STATE_2_NAME,
                 "data_type": "proportion",
                 "data_sources": {
-                    "proportion": COMPLEX_INFECTED_STATE_1.get_transitions()[
+                    "proportion": STATES.COMPLEX_INFECTED_1.get_transitions()[
                         COMPLEX_STATE_2_NAME
                     ].value
                 },
@@ -303,7 +296,7 @@ COMPLEX_MODEL_CONFIG = {
                 "sink": COMPLEX_STATE_2_NAME,
                 "data_type": "proportion",
                 "data_sources": {
-                    "proportion": TRANSIENT_STATE.get_transitions()[
+                    "proportion": STATES.TRANSIENT.get_transitions()[
                         COMPLEX_STATE_2_NAME
                     ].value
                 },
@@ -315,7 +308,7 @@ COMPLEX_MODEL_CONFIG = {
             },
             "infected_state_3_to_infected_state_1": {
                 "source": COMPLEX_STATE_3_NAME,
-                "sink": COMPLEX_INFECTED_STATE_1.name,
+                "sink": STATES.COMPLEX_INFECTED_1.name,
                 "data_type": "rate",
                 "data_sources": {
                     "transition_rate": "tests.plugins.test_parser::complex_model_3_to_1_transition_rate"
@@ -475,19 +468,19 @@ def test_parsing_no_causes_config_file(tmp_path, resource_filename_mock):
         (
             SIR_MODEL,
             {
-                f"susceptible_state.susceptible_to_{SIR_MODEL}",
-                f"disease_state.{SIR_INFECTED.name}",
-                f"recovered_state.recovered_from_{SIR_MODEL}",
+                f"susceptible_state.{STATES.SIR_SUSCEPTIBLE.name}",
+                f"disease_state.{STATES.SIR_INFECTED.name}",
+                f"recovered_state.{STATES.SIR_RECOVERED.name}",
             },
         ),
         (
             COMPLEX_MODEL,
             {
-                f"susceptible_state.susceptible_to_{COMPLEX_MODEL}",
-                f"disease_state.{COMPLEX_INFECTED_STATE_1.name}",
-                f"disease_state.{COMPLEX_STATE_2_NAME}",
-                f"disease_state.{COMPLEX_STATE_3_NAME}",
-                f"transient_disease_state.{TRANSIENT_STATE_NAME}",
+                f"susceptible_state.{STATES.COMPLEX_SUSCEPTIBLE.name}",
+                f"disease_state.{STATES.COMPLEX_INFECTED_1.name}",
+                f"disease_state.{STATES.COMPLEX_INFECTED_2.name}",
+                f"disease_state.{STATES.COMPLEX_INFECTED_3.name}",
+                f"transient_disease_state.{STATES.TRANSIENT.name}",
             },
         ),
     ],
@@ -509,12 +502,12 @@ def test_no_extra_state_components(sim_components: Dict[str, Component]):
         for component in sim_components.values()
         if isinstance(component, BaseDiseaseState)
     }
-    expected_state_names = {state.name for state in STATES_TO_TEST}
+    expected_state_names = {state.name for state in STATES}
     assert actual_state_names == expected_state_names
 
 
 @pytest.mark.parametrize(
-    "expected_state_data", STATES_TO_TEST, ids=[state.name for state in STATES_TO_TEST]
+    "expected_state_data", STATES, ids=[state.name for state in STATES]
 )
 def test_disease_state(
     sim_components: Dict[str, Component], expected_state_data: ExpectedStateData

--- a/tests/plugins/test_parser.py
+++ b/tests/plugins/test_parser.py
@@ -567,7 +567,18 @@ def test_disease_state(
 
 
 def test_invalid_data_source_throws_error():
-    # todo define config object with invalid data source
-    # todo call parser.parse_component_config with config object
-    # todo assert that it throws an error
-    pass
+    invalid_data_source_config_dict = {
+        "causes": {
+            "model_name": {
+                "states": {
+                    "susceptible": {},
+                    "infected": {"data_sources": {"prevalence": "bad_data_source"}},
+                },
+                "transitions": {},
+            }
+        }
+    }
+
+    config = create_simulation_config_tree(invalid_data_source_config_dict)
+    with pytest.raises(ValueError, match="Invalid data source"):
+        CausesConfigurationParser().parse_component_config(config)

--- a/tests/plugins/test_parser.py
+++ b/tests/plugins/test_parser.py
@@ -1,8 +1,8 @@
 import dataclasses
-from typing import Dict, List, Set, Type, Tuple
-import yaml
+from typing import Dict, List, Set, Tuple, Type
 
 import pytest
+import yaml
 from vivarium import Component, ConfigTree, InteractiveContext
 from vivarium.framework.state_machine import Transient, Transition
 
@@ -21,7 +21,6 @@ from vivarium_public_health.testing.mock_artifact import MockArtifact
 from vivarium_public_health.testing.mock_artifact import (
     MockArtifactManager as MockArtifactManager_,
 )
-
 
 SIR_MODEL = "simple_sir_model"
 SIR_SUSCEPTIBLE_NAME = "susceptible_to_simple_sir_model"
@@ -191,23 +190,23 @@ class MockArtifactManager(MockArtifactManager_):
         ] = COMPLEX_INFECTED_STATE_1.emr
 
         artifact.mocks[
-            f"cause.{COMPLEX_STATE_2_NAME}.prevalence"
+            f"cause.{COMPLEX_INFECTED_STATE_2.name}.prevalence"
         ] = COMPLEX_INFECTED_STATE_2.prevalence
         artifact.mocks[
-            f"cause.{COMPLEX_STATE_2_NAME}.disability_weight"
+            f"cause.{COMPLEX_INFECTED_STATE_2.name}.disability_weight"
         ] = COMPLEX_INFECTED_STATE_2.disability_weight
         artifact.mocks[
-            f"cause.{COMPLEX_STATE_2_NAME}.excess_mortality_rate"
+            f"cause.{COMPLEX_INFECTED_STATE_2.name}.excess_mortality_rate"
         ] = COMPLEX_INFECTED_STATE_2.emr
 
         artifact.mocks[
-            f"cause.{COMPLEX_STATE_3_NAME}.prevalence"
+            f"cause.{COMPLEX_INFECTED_STATE_3.name}.prevalence"
         ] = COMPLEX_INFECTED_STATE_3.prevalence
         artifact.mocks[
-            f"cause.{COMPLEX_STATE_3_NAME}.disability_weight"
+            f"cause.{COMPLEX_INFECTED_STATE_3.name}.disability_weight"
         ] = COMPLEX_INFECTED_STATE_3.disability_weight
         artifact.mocks[
-            f"cause.{COMPLEX_STATE_3_NAME}.excess_mortality_rate"
+            f"cause.{COMPLEX_INFECTED_STATE_3.name}.excess_mortality_rate"
         ] = COMPLEX_INFECTED_STATE_3.emr
 
         return artifact
@@ -413,9 +412,7 @@ def test_parser_returns_list_of_components():
 
 
 def test_parsing_config_single_external_causes_config_file(tmp_path, resource_filename_mock):
-    causes_config = {
-        "causes": {**SIR_MODEL_CONFIG, **COMPLEX_MODEL_CONFIG}
-    }
+    causes_config = {"causes": {**SIR_MODEL_CONFIG, **COMPLEX_MODEL_CONFIG}}
     with open(tmp_path / "causes_config.yaml", "w") as file:
         yaml.dump(causes_config, file)
 

--- a/tests/plugins/test_parser.py
+++ b/tests/plugins/test_parser.py
@@ -1,0 +1,446 @@
+from typing import Dict, List
+
+import pytest
+from vivarium import Component, ConfigTree, InteractiveContext
+from vivarium.framework.state_machine import Transient, Transition
+
+from vivarium_public_health.disease import (
+    BaseDiseaseState,
+    DiseaseModel,
+    DiseaseState,
+    ProportionTransition,
+    RateTransition,
+    RecoveredState,
+    SusceptibleState,
+    TransientDiseaseState,
+)
+from vivarium_public_health.plugins import CausesConfigurationParser
+from vivarium_public_health.testing.mock_artifact import MockArtifact
+from vivarium_public_health.testing.mock_artifact import (
+    MockArtifactManager as MockArtifactManager_,
+)
+
+SIMPLE_SIR_MODEL = "simple_sir_model"
+SUSCEPTIBLE_STATE = "susceptible"
+SIMPLE_MODEL_INFECTED_STATE = "some_infected_state_name"
+RECOVERED_STATE = "recovered"
+
+COMPLEX_MODEL = "complex_model"
+TRANSIENT_STATE = "some_transient_state_name"
+COMPLEX_MODEL_INFECTED_STATE_1 = "some_other_infected_state_name"
+COMPLEX_MODEL_INFECTED_STATE_2 = "yet_another_infected_state_name"
+COMPLEX_MODEL_INFECTED_STATE_3 = "still_another_infected_state_name"
+
+
+PREVALENCE_DATA_FROM_FUNCTION = 0.08
+
+
+def some_prevalence_function(_, __):
+    return PREVALENCE_DATA_FROM_FUNCTION
+
+
+RATE_DATA_FROM_FUNCTION = 0.95
+
+
+def some_rate_function(_, __, ___):
+    return RATE_DATA_FROM_FUNCTION
+
+
+REMISSION_DATA_FROM_FUNCTION = 0.85
+
+
+def some_remission_function(_, __, ___):
+    return REMISSION_DATA_FROM_FUNCTION
+
+
+class MockArtifactManager(MockArtifactManager_):
+    def _load_artifact(self, _: str) -> MockArtifact:
+        artifact = MockArtifact()
+
+        artifact.mocks[f"cause.{SIMPLE_MODEL_INFECTED_STATE}.prevalence"] = 0.11
+        artifact.mocks[f"cause.{SIMPLE_MODEL_INFECTED_STATE}.disability_weight"] = 0.12
+        artifact.mocks[f"cause.{SIMPLE_MODEL_INFECTED_STATE}.excess_mortality_rate"] = 0.13
+
+        artifact.mocks["cause.some_custom_cause.disability_weight"] = 0.22
+        artifact.mocks["cause.some_custom_cause.excess_mortality_rate"] = 0.23
+
+        artifact.mocks[f"cause.{COMPLEX_MODEL_INFECTED_STATE_2}.prevalence"] = 0.31
+        artifact.mocks[f"cause.{COMPLEX_MODEL_INFECTED_STATE_2}.disability_weight"] = 0.32
+        artifact.mocks[f"cause.{COMPLEX_MODEL_INFECTED_STATE_2}.excess_mortality_rate"] = 0.33
+
+        artifact.mocks[f"cause.{COMPLEX_MODEL_INFECTED_STATE_3}.prevalence"] = 0.41
+        artifact.mocks[f"cause.{COMPLEX_MODEL_INFECTED_STATE_3}.disability_weight"] = 0.42
+        artifact.mocks[f"cause.{COMPLEX_MODEL_INFECTED_STATE_3}.excess_mortality_rate"] = 0.43
+
+        return artifact
+
+
+# @pytest.fixture(scope="module")
+def get_component_config() -> ConfigTree:
+    component_config = {
+        "causes": {
+            SIMPLE_SIR_MODEL: {
+                "states": {
+                    SUSCEPTIBLE_STATE: {},
+                    SIMPLE_MODEL_INFECTED_STATE: {},
+                    RECOVERED_STATE: {},
+                },
+                "transitions": {
+                    "infected_incidence": {
+                        "source": SUSCEPTIBLE_STATE,
+                        "sink": SIMPLE_MODEL_INFECTED_STATE,
+                        "data_type": "rate",
+                        "data_sources": {"incidence_rate": 0.5},
+                    },
+                    "infected_remission": {
+                        "source": SIMPLE_MODEL_INFECTED_STATE,
+                        "sink": RECOVERED_STATE,
+                        "data_type": "rate",
+                        "data_sources": {"remission_rate": 0.6},
+                    },
+                },
+            },
+            COMPLEX_MODEL: {
+                "states": {
+                    SUSCEPTIBLE_STATE: {},
+                    COMPLEX_MODEL_INFECTED_STATE_1: {
+                        "cause_type": "sequela",
+                        "allow_self_transition": False,
+                        "data_sources": {
+                            "prevalence": "tests.plugins.test_parser::some_prevalence_function",
+                            "disability_weight": "cause.some_custom_cause.disability_weight",
+                            "excess_mortality_rate": "cause.some_custom_cause.excess_mortality_rate",
+                        },
+                    },
+                    TRANSIENT_STATE: {"transient": True},
+                    COMPLEX_MODEL_INFECTED_STATE_2: {
+                        "data_sources": {
+                            "birth_prevalence": 0.3,
+                            "dwell_time": "3 days",
+                        },
+                    },
+                    COMPLEX_MODEL_INFECTED_STATE_3: {},
+                },
+                "transitions": {
+                    "infected_state_1_incidence": {
+                        "source": SUSCEPTIBLE_STATE,
+                        "sink": COMPLEX_MODEL_INFECTED_STATE_1,
+                        "data_type": "rate",
+                        "data_sources": {"incidence_rate": 0.2},
+                    },
+                    "infected_state_1_to_transient": {
+                        "source": COMPLEX_MODEL_INFECTED_STATE_1,
+                        "sink": TRANSIENT_STATE,
+                        "data_type": "proportion",
+                        "data_sources": {"proportion": 0.25},
+                    },
+                    "infected_state_1_to_infected_state_2": {
+                        "source": COMPLEX_MODEL_INFECTED_STATE_1,
+                        "sink": COMPLEX_MODEL_INFECTED_STATE_2,
+                        "data_type": "proportion",
+                        "data_sources": {"proportion": 0.75},
+                    },
+                    "transient_to_infected_state_2": {
+                        "source": TRANSIENT_STATE,
+                        "sink": COMPLEX_MODEL_INFECTED_STATE_2,
+                        "data_type": "proportion",
+                        "data_sources": {"proportion": 1.0},
+                    },
+                    "infected_state_2_to_infected_state_3": {
+                        "source": COMPLEX_MODEL_INFECTED_STATE_2,
+                        "sink": COMPLEX_MODEL_INFECTED_STATE_3,
+                        "data_type": "dwell_time",
+                    },
+                    "infected_state_3_to_infected_state_1": {
+                        "source": COMPLEX_MODEL_INFECTED_STATE_3,
+                        "sink": COMPLEX_MODEL_INFECTED_STATE_1,
+                        "data_type": "rate",
+                        "data_sources": {
+                            "transition_rate": "tests.plugins.test_parser::some_rate_function"
+                        },
+                    },
+                    "infected_state_3_remission": {
+                        "source": COMPLEX_MODEL_INFECTED_STATE_3,
+                        "sink": SUSCEPTIBLE_STATE,
+                        "data_type": "rate",
+                        "data_sources": {
+                            "transition_rate": "tests.plugins.test_parser::some_remission_function"
+                        },
+                    },
+                },
+            },
+        },
+        "vivarium": {"testing_utilities": "TestPopulation()"},
+    }
+    return ConfigTree(
+        component_config,
+        layers=[
+            "base",
+            "user_configs",
+            "component_configs",
+            "model_override",
+            "override",
+        ],
+    )
+
+
+@pytest.fixture(scope="module")
+def base_config(base_config_factory) -> ConfigTree:
+    yield base_config_factory()
+
+
+@pytest.fixture(scope="module")
+def causes_config_parser_plugins() -> ConfigTree:
+    config_parser_plugin_config = {
+        "required": {
+            "data": {
+                "controller": "tests.plugins.test_parser.MockArtifactManager",
+                "builder_interface": "vivarium.framework.artifact.ArtifactInterface",
+            },
+            "component_configuration_parser": {
+                "controller": "vivarium_public_health.plugins.CausesConfigurationParser",
+            },
+        }
+    }
+    return ConfigTree(config_parser_plugin_config)
+
+
+@pytest.fixture(scope="module")
+def sim_components(base_config: ConfigTree, causes_config_parser_plugins: ConfigTree):
+    simulation = InteractiveContext(
+        components=get_component_config(),
+        configuration=base_config,
+        plugin_configuration=causes_config_parser_plugins,
+    )
+    return simulation.list_components()
+
+
+@pytest.fixture(scope="module")
+def component_list_parsed_from_config() -> List[Component]:
+    config_parser = CausesConfigurationParser()
+    component_config = get_component_config()
+    return config_parser.parse_component_config(component_config)
+
+
+def _get_transitions_from_state(state: BaseDiseaseState) -> Dict[str, Transition]:
+    return {
+        transition.output_state.state_id: transition
+        for transition in state.transition_set.transitions
+    }
+
+
+def test_parser_returns_list_of_components(component_list_parsed_from_config):
+    assert isinstance(component_list_parsed_from_config, list)
+    expected_component_names = {
+        f"disease_model.{SIMPLE_SIR_MODEL}",
+        f"disease_model.{COMPLEX_MODEL}",
+        "test_population",
+    }
+    assert expected_component_names == {
+        component.name for component in component_list_parsed_from_config
+    }
+
+
+def test_simple_sir_disease_model(sim_components):
+    sir_model = sim_components[f"disease_model.{SIMPLE_SIR_MODEL}"]
+    assert isinstance(sir_model, DiseaseModel)
+
+    # the disease model's states have the expected names
+    expected_state_names = {
+        f"susceptible_state.susceptible_to_{SIMPLE_SIR_MODEL}",
+        f"disease_state.{SIMPLE_MODEL_INFECTED_STATE}",
+        f"recovered_state.recovered_from_{SIMPLE_SIR_MODEL}",
+    }
+    actual_state_names = {state.name for state in sir_model.sub_components}
+    assert actual_state_names == expected_state_names
+
+
+def test_sir_model_susceptible_state(sim_components):
+    susceptible_state = sim_components[f"susceptible_state.susceptible_to_{SIMPLE_SIR_MODEL}"]
+    assert isinstance(susceptible_state, SusceptibleState)
+    assert susceptible_state.state_id == f"susceptible_to_{SIMPLE_SIR_MODEL}"
+
+    # test that it has the expected default values
+    assert susceptible_state.cause_type == "cause"
+    assert not isinstance(susceptible_state, Transient)
+    assert susceptible_state.transition_set.allow_null_transition
+
+    # test that it has the expected transition
+    transitions = _get_transitions_from_state(susceptible_state)
+    assert set(transitions.keys()) == {SIMPLE_MODEL_INFECTED_STATE}
+
+    incidence_transition = transitions[SIMPLE_MODEL_INFECTED_STATE]
+    assert isinstance(incidence_transition, RateTransition)
+    assert incidence_transition.base_rate.data == 0.5
+
+
+def test_sir_model_disease_state(sim_components):
+    infected_state = sim_components[f"disease_state.{SIMPLE_MODEL_INFECTED_STATE}"]
+    assert isinstance(infected_state, DiseaseState)
+    assert infected_state.state_id == SIMPLE_MODEL_INFECTED_STATE
+
+    # test that it has the expected default values
+    assert infected_state.cause_type == "cause"
+    assert not isinstance(infected_state, Transient)
+    assert infected_state.transition_set.allow_null_transition
+
+    # test we get the default data sources
+    assert infected_state.prevalence.data == 0.11
+    assert infected_state.birth_prevalence.data == 0.0
+    assert infected_state.dwell_time.source.data == 0.0
+    assert infected_state.base_disability_weight.data == 0.12
+    assert infected_state.base_excess_mortality_rate.data == 0.13
+
+    # test that it has the expected transition
+    transitions = _get_transitions_from_state(infected_state)
+    assert set(transitions.keys()) == {f"recovered_from_{SIMPLE_SIR_MODEL}"}
+    incidence_transition = transitions[f"recovered_from_{SIMPLE_SIR_MODEL}"]
+    assert isinstance(incidence_transition, RateTransition)
+    assert incidence_transition.base_rate.data == 0.6
+
+
+def test_sir_recovered_recovered_state(sim_components):
+    recovered_state = sim_components[f"recovered_state.recovered_from_{SIMPLE_SIR_MODEL}"]
+    assert isinstance(recovered_state, RecoveredState)
+    assert recovered_state.state_id == f"recovered_from_{SIMPLE_SIR_MODEL}"
+
+    # test that it has the expected default values
+    assert recovered_state.cause_type == "cause"
+    assert not isinstance(recovered_state, Transient)
+    assert recovered_state.transition_set.allow_null_transition
+
+    # test that it has the expected transitions
+    assert len(recovered_state.transition_set.transitions) == 0
+
+
+# todo test config file references external config file
+# todo test config file defines causes itself
+# todo test config input as dict
+# todo test config file with both local and external definition of causes
+
+
+def test_complex_model(sim_components):
+    complex_model = sim_components[f"disease_model.{COMPLEX_MODEL}"]
+    assert isinstance(complex_model, DiseaseModel)
+
+    # the disease model's states have the expected names
+    expected_state_names = {
+        f"susceptible_state.susceptible_to_{COMPLEX_MODEL}",
+        f"disease_state.{COMPLEX_MODEL_INFECTED_STATE_1}",
+        f"disease_state.{COMPLEX_MODEL_INFECTED_STATE_2}",
+        f"disease_state.{COMPLEX_MODEL_INFECTED_STATE_3}",
+        f"transient_disease_state.{TRANSIENT_STATE}",
+    }
+    actual_state_names = {state.name for state in complex_model.sub_components}
+    assert actual_state_names == expected_state_names
+
+
+def test_complex_model_first_disease_state(sim_components):
+    infected_state = sim_components[f"disease_state.{COMPLEX_MODEL_INFECTED_STATE_1}"]
+    assert isinstance(infected_state, DiseaseState)
+    assert infected_state.state_id == COMPLEX_MODEL_INFECTED_STATE_1
+
+    # test that it has the expected default and configured values
+    assert infected_state.cause_type == "sequela"
+    assert not isinstance(infected_state, Transient)
+    assert not infected_state.transition_set.allow_null_transition
+
+    # test we get the expected default and configured data sources
+    assert infected_state.prevalence.data == PREVALENCE_DATA_FROM_FUNCTION
+    assert infected_state.birth_prevalence.data == 0.0
+    assert infected_state.dwell_time.source.data == 0.0
+    assert infected_state.base_disability_weight.data == 0.22
+    assert infected_state.base_excess_mortality_rate.data == 0.23
+
+    # test that it has the expected transitions
+    transitions = _get_transitions_from_state(infected_state)
+    assert set(transitions.keys()) == {COMPLEX_MODEL_INFECTED_STATE_2, TRANSIENT_STATE}
+
+    to_transient_transition = transitions[TRANSIENT_STATE]
+    assert isinstance(to_transient_transition, ProportionTransition)
+    assert to_transient_transition.proportion.data == 0.25
+
+    to_infected_2_transition = transitions[COMPLEX_MODEL_INFECTED_STATE_2]
+    assert isinstance(to_infected_2_transition, ProportionTransition)
+    assert to_infected_2_transition.proportion.data == 0.75
+
+
+def test_complex_model_transient_disease_state(sim_components):
+    transient_state = sim_components[f"transient_disease_state.{TRANSIENT_STATE}"]
+    assert isinstance(transient_state, TransientDiseaseState)
+    assert transient_state.state_id == TRANSIENT_STATE
+
+    # test that it has the expected default and configured values
+    assert transient_state.cause_type == "cause"
+    assert isinstance(transient_state, Transient)
+
+    # test that it has the expected transitions
+    transitions = _get_transitions_from_state(transient_state)
+    assert set(transitions.keys()) == {COMPLEX_MODEL_INFECTED_STATE_2}
+
+    transition = transitions[COMPLEX_MODEL_INFECTED_STATE_2]
+    assert isinstance(transition, ProportionTransition)
+    assert transition.proportion.data == 1.0
+
+
+def test_complex_model_second_disease_state(sim_components):
+    infected_state = sim_components[f"disease_state.{COMPLEX_MODEL_INFECTED_STATE_2}"]
+    assert isinstance(infected_state, DiseaseState)
+    assert infected_state.state_id == COMPLEX_MODEL_INFECTED_STATE_2
+
+    # test that it has the expected default and configured values
+    assert infected_state.cause_type == "cause"
+    assert not isinstance(infected_state, Transient)
+    assert infected_state.transition_set.allow_null_transition
+
+    # test we get the expected default and configured data sources
+    assert infected_state.prevalence.data == 0.31
+    assert infected_state.birth_prevalence.data == 0.3
+    assert infected_state.dwell_time.source.data == 3.0
+    assert infected_state.base_disability_weight.data == 0.32
+    assert infected_state.base_excess_mortality_rate.data == 0.33
+
+    # test that it has the expected transitions
+    transitions = _get_transitions_from_state(infected_state)
+    assert set(transitions.keys()) == {COMPLEX_MODEL_INFECTED_STATE_3}
+
+    transition = transitions[COMPLEX_MODEL_INFECTED_STATE_3]
+    assert isinstance(transition, Transition)
+    assert not isinstance(transition, ProportionTransition)
+    assert not isinstance(transition, RateTransition)
+
+
+def test_complex_model_third_disease_state(sim_components):
+    infected_state = sim_components[f"disease_state.{COMPLEX_MODEL_INFECTED_STATE_3}"]
+    assert isinstance(infected_state, DiseaseState)
+    assert infected_state.state_id == COMPLEX_MODEL_INFECTED_STATE_3
+
+    # test that it has the expected default values
+    assert infected_state.cause_type == "cause"
+    assert not isinstance(infected_state, Transient)
+    assert infected_state.transition_set.allow_null_transition
+
+    # test we get the default data sources
+    assert infected_state.prevalence.data == 0.41
+    assert infected_state.birth_prevalence.data == 0.0
+    assert infected_state.dwell_time.source.data == 0.0
+    assert infected_state.base_disability_weight.data == 0.42
+    assert infected_state.base_excess_mortality_rate.data == 0.43
+
+    # test that it has the expected transition
+    transitions = _get_transitions_from_state(infected_state)
+    assert set(transitions.keys()) == {
+        COMPLEX_MODEL_INFECTED_STATE_1,
+        f"susceptible_to_{COMPLEX_MODEL}",
+    }
+
+    to_infected_1_transition = transitions[COMPLEX_MODEL_INFECTED_STATE_1]
+    assert isinstance(to_infected_1_transition, RateTransition)
+    assert to_infected_1_transition.base_rate.data == RATE_DATA_FROM_FUNCTION
+
+    to_susceptible_transition = transitions[f"susceptible_to_{COMPLEX_MODEL}"]
+    assert isinstance(to_susceptible_transition, RateTransition)
+    assert to_susceptible_transition.base_rate.data == REMISSION_DATA_FROM_FUNCTION
+
+
+# todo test invalid data source

--- a/tests/plugins/test_parser.py
+++ b/tests/plugins/test_parser.py
@@ -64,7 +64,6 @@ class ExpectedStateData:
 
 
 class ExpectedStates(NamedTuple):
-
     SIR_SUSCEPTIBLE: ExpectedStateData = ExpectedStateData(
         name=SIR_SUSCEPTIBLE_NAME,
         state_type=SusceptibleState,
@@ -85,7 +84,9 @@ class ExpectedStates(NamedTuple):
             )
         ],
     )
-    SIR_RECOVERED: ExpectedStateData = ExpectedStateData(name=SIR_RECOVERED_NAME, state_type=RecoveredState)
+    SIR_RECOVERED: ExpectedStateData = ExpectedStateData(
+        name=SIR_RECOVERED_NAME, state_type=RecoveredState
+    )
 
     COMPLEX_SUSCEPTIBLE: ExpectedStateData = ExpectedStateData(
         name=COMPLEX_SUSCEPTIBLE_NAME,
@@ -106,10 +107,16 @@ class ExpectedStates(NamedTuple):
         emr=0.23,
         transitions=[
             ExpectedTransitionData(
-                COMPLEX_INFECTED_STATE_1_NAME, TRANSIENT_STATE_NAME, ProportionTransition, 0.25
+                COMPLEX_INFECTED_STATE_1_NAME,
+                TRANSIENT_STATE_NAME,
+                ProportionTransition,
+                0.25,
             ),
             ExpectedTransitionData(
-                COMPLEX_INFECTED_STATE_1_NAME, COMPLEX_STATE_2_NAME, ProportionTransition, 0.75
+                COMPLEX_INFECTED_STATE_1_NAME,
+                COMPLEX_STATE_2_NAME,
+                ProportionTransition,
+                0.75,
             ),
         ],
     )
@@ -131,7 +138,9 @@ class ExpectedStates(NamedTuple):
         disability_weight=0.32,
         emr=0.33,
         transitions=[
-            ExpectedTransitionData(COMPLEX_STATE_2_NAME, COMPLEX_STATE_3_NAME, Transition, 0.0),
+            ExpectedTransitionData(
+                COMPLEX_STATE_2_NAME, COMPLEX_STATE_3_NAME, Transition, 0.0
+            ),
         ],
     )
 
@@ -149,6 +158,7 @@ class ExpectedStates(NamedTuple):
             ),
         ],
     )
+
 
 STATES = ExpectedStates()
 
@@ -169,11 +179,15 @@ class MockArtifactManager(MockArtifactManager_):
     def _load_artifact(self, _: str) -> MockArtifact:
         artifact = MockArtifact()
 
-        artifact.mocks[f"cause.{STATES.SIR_INFECTED.name}.prevalence"] = STATES.SIR_INFECTED.prevalence
+        artifact.mocks[
+            f"cause.{STATES.SIR_INFECTED.name}.prevalence"
+        ] = STATES.SIR_INFECTED.prevalence
         artifact.mocks[
             f"cause.{STATES.SIR_INFECTED.name}.disability_weight"
         ] = STATES.SIR_INFECTED.disability_weight
-        artifact.mocks[f"cause.{STATES.SIR_INFECTED.name}.excess_mortality_rate"] = STATES.SIR_INFECTED.emr
+        artifact.mocks[
+            f"cause.{STATES.SIR_INFECTED.name}.excess_mortality_rate"
+        ] = STATES.SIR_INFECTED.emr
 
         artifact.mocks[
             "cause.some_custom_cause.disability_weight"
@@ -506,9 +520,7 @@ def test_no_extra_state_components(sim_components: Dict[str, Component]):
     assert actual_state_names == expected_state_names
 
 
-@pytest.mark.parametrize(
-    "expected_state_data", STATES, ids=[state.name for state in STATES]
-)
+@pytest.mark.parametrize("expected_state_data", STATES, ids=[state.name for state in STATES])
 def test_disease_state(
     sim_components: Dict[str, Component], expected_state_data: ExpectedStateData
 ):


### PR DESCRIPTION
## Introduce Causes Configuration Parser

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4608

### Changes and notes
- Create CausesConfigurationParser component that can parser a yaml 
  configuration of cause models into Vivarium components
- This was previously implemented in CVD and has been ported over and
  modified slightly (https://github.com/ihmeuw/vivarium_nih_us_cvd/blob/main/src/vivarium_nih_us_cvd/plugins/causes_parser.py)


N.B. for reviewers, if you want to see what is different from what was 
previously done in CVD you can exclude the first commit when reviewing.

### Testing
Developed automated tests of the new parser

