### PR TITLE
Bugfix/sbachmei/mic 4886 fix one year assign demographic proportions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.1.4 - 01/10/24**
+
+ - Exclude undesirable arguments from the return of `BaseDiseaseState` `name` and `__repr__` methods
+ 
 **2.1.3 - 01/09/24**
 
  - Update PyPI to 2FA with trusted publisher

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 **2.2.0 - 02/13/24**
 
  - Implement CausesConfigurationParser to parse causes configuration into DiseaseModel components
+ - Bugfix assign sex-location-age demographic proportions by year when only one year in dataset
  
 **2.1.4 - 01/10/24**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.1.5 - 02/13/24**
+
+ - Bugfix assign sex-location-age demographic proportions by year when only one year in dataset
+
 **2.1.4 - 01/10/24**
 
  - Exclude undesirable arguments from the return of `BaseDiseaseState` `name` and `__repr__` methods

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**2.2.0 - 02/13/24**
+**2.2.0 - 02/14/24**
 
  - Implement CausesConfigurationParser to parse causes configuration into DiseaseModel components
  - Bugfix assign sex-location-age demographic proportions by year when only one year in dataset

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -6,7 +6,7 @@ Disease States
 This module contains tools to manage standard disease states.
 
 """
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -81,6 +81,13 @@ class BaseDiseaseState(State):
     ##################
     # Helper methods #
     ##################
+
+    def get_initialization_parameters(self) -> Dict[str, Any]:
+        """Exclude side effect function and cause type from name and __repr__."""
+        initialization_parameters = super().get_initialization_parameters()
+        del initialization_parameters["side_effect_function"]
+        del initialization_parameters["cause_type"]
+        return initialization_parameters
 
     def get_initial_event_times(self, pop_data: SimulantData) -> pd.DataFrame:
         return pd.DataFrame(

--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -7,6 +7,7 @@ This module contains tools for handling raw demographic data and transforming
 it into different distributions for sampling.
 
 """
+
 from collections import namedtuple
 from typing import Tuple, Union
 
@@ -59,22 +60,22 @@ def assign_demographic_proportions(
     population_data["P(sex, location, age| year)"] = (
         population_data.groupby("year_start", as_index=False)
         .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum())
-        .reset_index(level=0)
-        ["value"].fillna(0.0)
+        .reset_index(level=0)["value"]
+        .fillna(0.0)
     )
 
     population_data["P(sex, location | age, year)"] = (
         population_data.groupby(["age", "year_start"], as_index=False)
         .apply(lambda sub_pop: sub_pop["value"] / sub_pop["value"].sum())
-        .reset_index(level=0)
-        ["value"].fillna(0.0)
+        .reset_index(level=0)["value"]
+        .fillna(0.0)
     )
 
     population_data["P(age | year, sex, location)"] = (
         population_data.groupby(["year_start", "sex", "location"], as_index=False)
         .apply(lambda sub_pop: sub_pop["value"] / sub_pop["value"].sum())
-        .reset_index(level=0)
-        ["value"].fillna(0.0)
+        .reset_index(level=0)["value"]
+        .fillna(0.0)
     )
 
     return population_data.sort_values(_SORT_ORDER).reset_index(drop=True)

--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -52,25 +52,29 @@ def assign_demographic_proportions(
     if include_sex != "Both":
         population_data.loc[population_data.sex != include_sex, "value"] = 0.0
 
+    # NOTE: when grouping by year alone, we return a dataframe (i.e. sub_pop[["value"]])
+    # to ensure that if there is only one year_start the result is a pd.Series and not a
+    # one-row wide pd.DataFrame.
+    # (https://stackoverflow.com/questions/69109980/unclear-why-groupby-with-single-group-produces-row-dataframe)
     population_data["P(sex, location, age| year)"] = (
         population_data.groupby("year_start", as_index=False)
-        .apply(lambda sub_pop: sub_pop.value / sub_pop.value.sum())
+        .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum())
         .reset_index(level=0)
-        .value.fillna(0.0)
+        ["value"].fillna(0.0)
     )
 
     population_data["P(sex, location | age, year)"] = (
         population_data.groupby(["age", "year_start"], as_index=False)
-        .apply(lambda sub_pop: sub_pop.value / sub_pop.value.sum())
+        .apply(lambda sub_pop: sub_pop["value"] / sub_pop["value"].sum())
         .reset_index(level=0)
-        .value.fillna(0.0)
+        ["value"].fillna(0.0)
     )
 
     population_data["P(age | year, sex, location)"] = (
         population_data.groupby(["year_start", "sex", "location"], as_index=False)
-        .apply(lambda sub_pop: sub_pop.value / sub_pop.value.sum())
+        .apply(lambda sub_pop: sub_pop["value"] / sub_pop["value"].sum())
         .reset_index(level=0)
-        .value.fillna(0.0)
+        ["value"].fillna(0.0)
     )
 
     return population_data.sort_values(_SORT_ORDER).reset_index(drop=True)

--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -53,10 +53,6 @@ def assign_demographic_proportions(
     if include_sex != "Both":
         population_data.loc[population_data.sex != include_sex, "value"] = 0.0
 
-    # NOTE: when grouping by year alone, we return a dataframe (i.e. sub_pop[["value"]])
-    # to ensure that if there is only one year_start the result is a pd.Series and not a
-    # one-row wide pd.DataFrame.
-    # (https://stackoverflow.com/questions/69109980/unclear-why-groupby-with-single-group-produces-row-dataframe)
     population_data["P(sex, location, age| year)"] = (
         population_data.groupby("year_start", as_index=False)
         .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum())
@@ -66,14 +62,14 @@ def assign_demographic_proportions(
 
     population_data["P(sex, location | age, year)"] = (
         population_data.groupby(["age", "year_start"], as_index=False)
-        .apply(lambda sub_pop: sub_pop["value"] / sub_pop["value"].sum())
+        .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum())
         .reset_index(level=0)["value"]
         .fillna(0.0)
     )
 
     population_data["P(age | year, sex, location)"] = (
         population_data.groupby(["year_start", "sex", "location"], as_index=False)
-        .apply(lambda sub_pop: sub_pop["value"] / sub_pop["value"].sum())
+        .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum())
         .reset_index(level=0)["value"]
         .fillna(0.0)
     )


### PR DESCRIPTION
## Fix age-sex-location proportions by year when only one year
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4886

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> Syl found when archiving the CVD project with artifacts subset to only 
2019 data that one of the data transformations is broken. Specifically, the lambda
function being applied to a single group returns a wide one-row dataframe
instead of the expected pd.Series. 

(https://stackoverflow.com/questions/69109980/unclear-why-groupby-with-single-group-produces-row-dataframe)

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Ran the cvd simulation with both the subset one-year artifacts and the old
multi-year artifacts; both simulations actually started and finished the
first time step.
