### PR TITLE
Mic-3287/age-start-bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.2.2 - 2/28/24**
+
+ - Fix bug in rescale_binned_proportions to update midpoitn for new age bins
+
 **2.2.1 - 2/26/24**
 
  - Update LinearScaleUp configuration defaults

--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -138,7 +138,21 @@ def rescale_binned_proportions(
         pop_data.loc[padding_bin.index, columns_to_scale] += remainder
 
         pop_data.loc[min_bin.index, "age_start"] = age_start
+        pop_data.loc[min_bin.index, "age"] = float(
+            (
+                pop_data.loc[min_bin.index, "age_start"].iloc[0]
+                + pop_data.loc[min_bin.index, "age_end"].iloc[0]
+            )
+            / 2
+        )
         pop_data.loc[padding_bin.index, "age_end"] = age_start
+        pop_data.loc[padding_bin.index, "age"] = float(
+            (
+                pop_data.loc[padding_bin.index, "age_start"].iloc[0]
+                + pop_data.loc[padding_bin.index, "age_end"].iloc[0]
+            )
+            / 2
+        )
 
         max_bin = sub_pop[(sub_pop["age_end"] > age_end) & (age_end >= sub_pop["age_start"])]
         padding_bin = sub_pop[sub_pop["age_start"] == float(max_bin["age_end"].iloc[0])]


### PR DESCRIPTION
## Mic-3287/age-start-bug

### Fixes bug in rescale_binned_proportions which was not properly updating the age midpoint of the newly defined edge age bins.
- *Category*: Bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-3287

### Changes and notes
-updates the age midpoint for age bins we are redefining based on the user config file when we split an age group

### Testing
Age midpoint for updated age bins was properly updated.

