### PR TITLE
Mic-4591/all-deaths-switch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.2.3 - 3/6/24**
+
+ - Update Mortality Observer to allow running with cause specific or total deaths and ylls.
+
 **2.2.2 - 2/28/24**
 
  - Fix bug in rescale_binned_proportions to update midpoitn for new age bins

--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -7,7 +7,7 @@ This module contains tools for observing cause-specific and
 excess mortality in the simulation, including "other causes".
 
 """
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import pandas as pd
 from vivarium import Component
@@ -22,7 +22,9 @@ class MortalityObserver(Component):
     By default, this counts cause-specific deaths and years of life lost over
     the full course of the simulation. It can be configured to add or remove
     stratification groups to the default groups defined by a
-    :class:ResultsStratifier.
+    :class:ResultsStratifier. The aggregate configuration key can be set to
+    True to aggregate all deaths and ylls into a single observation and remove
+    the stratification by cause of death to improve runtime.
 
     In the model specification, your configuration for this component should
     be specified as, e.g.:
@@ -47,6 +49,7 @@ class MortalityObserver(Component):
             "mortality": {
                 "exclude": [],
                 "include": [],
+                "aggregate": False,
             }
         }
     }
@@ -78,40 +81,84 @@ class MortalityObserver(Component):
         self.causes_of_death = ["other_causes"] + [
             cause.state_id for cause in self._cause_components if cause.has_excess_mortality
         ]
+        if not self.config.aggregate:
+            self._register_cause_specific_observations(builder)
+        else:
+            self._register_aggregate_observations(builder)
 
+    ###################
+    # Private methods #
+    ###################
+
+    def _register_cause_specific_observations(self, builder: Builder) -> None:
         for cause_of_death in self.causes_of_death:
-            builder.results.register_observation(
+            self._register_observation(
+                builder=builder,
                 name=f"death_due_to_{cause_of_death}",
                 pop_filter=f'alive == "dead" and cause_of_death == "{cause_of_death}"',
-                aggregator=self.count_cause_specific_deaths,
+                aggregator=self.count_deaths,
                 requires_columns=["alive", "cause_of_death", "exit_time"],
-                additional_stratifications=self.config.include,
-                excluded_stratifications=self.config.exclude,
-                when="collect_metrics",
             )
-            builder.results.register_observation(
+            self._register_observation(
+                builder=builder,
                 name=f"ylls_due_to_{cause_of_death}",
                 pop_filter=f'alive == "dead" and cause_of_death == "{cause_of_death}"',
-                aggregator=self.calculate_cause_specific_ylls,
+                aggregator=self.calculate_ylls,
                 requires_columns=[
                     "alive",
                     "cause_of_death",
                     "exit_time",
                     "years_of_life_lost",
                 ],
-                additional_stratifications=self.config.include,
-                excluded_stratifications=self.config.exclude,
-                when="collect_metrics",
             )
+
+    def _register_aggregate_observations(self, builder: Builder) -> None:
+        self._register_observation(
+            builder=builder,
+            name="total_deaths",
+            pop_filter='alive == "dead"',
+            aggregator=self.count_deaths,
+            requires_columns=["alive", "exit_time"],
+        )
+        self._register_observation(
+            builder=builder,
+            name="total_ylls",
+            pop_filter='alive == "dead"',
+            aggregator=self.calculate_ylls,
+            requires_columns=[
+                "alive",
+                "cause_of_death",
+                "exit_time",
+                "years_of_life_lost",
+            ],
+        )
+
+    def _register_observation(
+        self,
+        builder: Builder,
+        name: str,
+        pop_filter: str,
+        aggregator: Callable,
+        requires_columns: List[str],
+    ) -> None:
+        builder.results.register_observation(
+            name=name,
+            pop_filter=pop_filter,
+            aggregator=aggregator,
+            requires_columns=requires_columns,
+            additional_stratifications=self.config.include,
+            excluded_stratifications=self.config.exclude,
+            when="collect_metrics",
+        )
 
     ###############
     # Aggregators #
     ###############
 
-    def count_cause_specific_deaths(self, x: pd.DataFrame) -> float:
+    def count_deaths(self, x: pd.DataFrame) -> float:
         died_of_cause = x["exit_time"] > self.clock()
         return sum(died_of_cause)
 
-    def calculate_cause_specific_ylls(self, x: pd.DataFrame) -> float:
+    def calculate_ylls(self, x: pd.DataFrame) -> float:
         died_of_cause = x["exit_time"] > self.clock()
         return x.loc[died_of_cause, "years_of_life_lost"].sum()

--- a/tests/metrics/test_mortality_observer.py
+++ b/tests/metrics/test_mortality_observer.py
@@ -197,10 +197,10 @@ def test_aggregation_configruation(base_config, base_plugins):
     pop = aggregate_sim.get_population()
 
     expected_observations = [
-        "MEASURE_total_deaths_SEX_Female",
-        "MEASURE_total_deaths_SEX_Male",
-        "MEASURE_total_ylls_SEX_Female",
-        "MEASURE_total_ylls_SEX_Male",
+        "MEASURE_death_due_to_all_causes_SEX_Female",
+        "MEASURE_death_due_to_all_causes_SEX_Male",
+        "MEASURE_ylls_due_to_all_causes_SEX_Female",
+        "MEASURE_ylls_due_to_all_causes_SEX_Male",
     ]
 
     assert set(expected_observations) == set(results(pop.index).keys())

--- a/tests/metrics/test_mortality_observer.py
+++ b/tests/metrics/test_mortality_observer.py
@@ -158,7 +158,7 @@ def test_observation_correctness(simulation_after_one_step):
         )
 
 
-def test_aggregation_configruation(base_config, base_plugins):
+def test_aggregation_configuration(base_config, base_plugins):
     observer = MortalityObserver()
     flu = disease_with_excess_mortality(base_config, "flu", 10)
     mumps = disease_with_excess_mortality(base_config, "mumps", 20)


### PR DESCRIPTION
## Title: Mic-4591/all-deaths-switch

### Adds ability for Mortality Observer to aggregate deaths and yllls or record at cause specific level.
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4591

### Changes and notes
-adds configuration key "aggregate" to mortality observer
-allows mortality observer to record total deaths and ylls instead of cause specific to improve runtime

### Testing
Ran simulation with both the aggregate True and False and saw expected behavior.

