### PR TITLE
Risk lookup table config

### DIFF
--- a/src/vivarium_public_health/population/mortality.py
+++ b/src/vivarium_public_health/population/mortality.py
@@ -169,7 +169,6 @@ class Mortality(Component):
         self.unmodeled_csmr = self.get_unmodeled_csmr(builder)
         self.unmodeled_csmr_paf = self.get_unmodeled_csmr_paf(builder)
         self.mortality_rate = self.get_mortality_rate(builder)
-        breakpoint
 
     #################
     # Setup methods #

--- a/src/vivarium_public_health/population/mortality.py
+++ b/src/vivarium_public_health/population/mortality.py
@@ -174,7 +174,7 @@ class Mortality(Component):
     # Setup methods #
     #################
 
-    def create_lookup_tables(self, builder: Builder) -> None:
+    def build_lookup_tables(self, builder: Builder) -> None:
         """
         Create lookup tables for the mortality component.
 
@@ -183,7 +183,7 @@ class Mortality(Component):
         builder
             Interface to access simulation managers.
         """
-        super().create_lookup_tables(builder)
+        super().build_lookup_tables(builder)
         self.lookup_tables[
             "unmodeled_cause_specific_mortality_rate"
         ] = self.get_raw_unmodeled_csmr(builder)

--- a/src/vivarium_public_health/risks/base_risk.py
+++ b/src/vivarium_public_health/risks/base_risk.py
@@ -81,51 +81,39 @@ class Risk(Component):
 
     """
 
-    CONFIGURATION_DEFAULTS = {
-        "risk": {
-            "exposure": "data",
-            "rebinned_exposed": [],
-            "category_thresholds": [],
-            # Lookup tables to add
-            #   -weights
-            #   -parameters
-            #   -base exposre
-            #   -base paf
-        }
-    }
-
     ##############
     # Properties #
     ##############
 
     @property
     def configuration_defaults(self) -> Dict[str, Any]:
-        return {self.risk.name: {
-            # Change exposure (probably a bad idea)- replaces exposure with key and then value: data
-            "exposure": self.build_lookup_table_config(
-                value="data",
-                continuous_columns=["age", "year"],
-                # Parameter should also be here?
-                categorical_columns=["sex"],
-                key_name=f"risk_factor.{self.name}.exposure",
-            ),
-            "rebinned_exposed": [],
-            "category_thresholds": [],
-            "weights": self.build_lookup_table_config(
-                value="data",
-                continuous_columns=["age", "year"],
-                categorical_columns=["sex"],
-                key_name=f"risk_factor.{self.name}.exposure_distribution_weights",
-            ),
-            # Probably don't abbreviate?
-            "paf": self.build_lookup_table_config(
-                value=0,
-                continuous_columns=[],
-                categorical_columns=[],
-                key_name=f"{self.name}.population_attributable_fraction",
-            ),
+        return {
+            self.risk.name: {
+                # Change exposure (probably a bad idea)- replaces exposure with key and then value: data
+                "exposure": self.build_lookup_table_config(
+                    value="data",
+                    continuous_columns=["age", "year"],
+                    # Parameter should also be here?
+                    categorical_columns=["sex"],
+                    key_name=f"risk_factor.{self.name}.exposure",
+                ),
+                "ensemble_distribution_weights": self.build_lookup_table_config(
+                    value="data",
+                    continuous_columns=["age", "year"],
+                    categorical_columns=["sex"],
+                    key_name=f"risk_factor.{self.name}.exposure_distribution_weights",
+                ),
+                "exposure_standard_deviation": self.build_lookup_table_config(
+                    value="data",
+                    continuous_columns=["age", "year"],
+                    categorical_columns=["sex"],
+                    key_name=f"risk_factor.{self.name}.exposure_standard_deviation",
+                ),
+                # rebinned_exosed only used for DichotomousDistribution
+                "rebinned_exposed": [],
+                "category_thresholds": [],
+            }
         }
-    }
 
     @property
     def columns_created(self) -> List[str]:
@@ -138,11 +126,6 @@ class Risk(Component):
             "requires_values": [],
             "requires_streams": [self.randomness_stream_name],
         }
-    
-    @property
-    def standard_lookup_tables(self) -> List[str]:
-        #TODO: update method
-        return []
 
     #####################
     # Lifecycle methods #
@@ -170,7 +153,6 @@ class Risk(Component):
         self.randomness = self.get_randomness_stream(builder)
         self.propensity = self.get_propensity_pipeline(builder)
         self.exposure = self.get_exposure_pipeline(builder)
-        breakpoint()
 
     ##########################
     # Initialization methods #

--- a/src/vivarium_public_health/risks/base_risk.py
+++ b/src/vivarium_public_health/risks/base_risk.py
@@ -86,6 +86,11 @@ class Risk(Component):
             "exposure": "data",
             "rebinned_exposed": [],
             "category_thresholds": [],
+            # Lookup tables to add
+            #   -weights
+            #   -parameters
+            #   -base exposre
+            #   -base paf
         }
     }
 
@@ -95,7 +100,32 @@ class Risk(Component):
 
     @property
     def configuration_defaults(self) -> Dict[str, Any]:
-        return {self.risk.name: self.CONFIGURATION_DEFAULTS["risk"]}
+        return {self.risk.name: {
+            # Change exposure (probably a bad idea)- replaces exposure with key and then value: data
+            "exposure": self.build_lookup_table_config(
+                value="data",
+                continuous_columns=["age", "year"],
+                # Parameter should also be here?
+                categorical_columns=["sex"],
+                key_name=f"risk_factor.{self.name}.exposure",
+            ),
+            "rebinned_exposed": [],
+            "category_thresholds": [],
+            "weights": self.build_lookup_table_config(
+                value="data",
+                continuous_columns=["age", "year"],
+                categorical_columns=["sex"],
+                key_name=f"risk_factor.{self.name}.exposure_distribution_weights",
+            ),
+            # Probably don't abbreviate?
+            "paf": self.build_lookup_table_config(
+                value=0,
+                continuous_columns=[],
+                categorical_columns=[],
+                key_name=f"{self.name}.population_attributable_fraction",
+            ),
+        }
+    }
 
     @property
     def columns_created(self) -> List[str]:
@@ -108,6 +138,11 @@ class Risk(Component):
             "requires_values": [],
             "requires_streams": [self.randomness_stream_name],
         }
+    
+    @property
+    def standard_lookup_tables(self) -> List[str]:
+        #TODO: update method
+        return []
 
     #####################
     # Lifecycle methods #
@@ -135,6 +170,7 @@ class Risk(Component):
         self.randomness = self.get_randomness_stream(builder)
         self.propensity = self.get_propensity_pipeline(builder)
         self.exposure = self.get_exposure_pipeline(builder)
+        breakpoint()
 
     ##########################
     # Initialization methods #

--- a/src/vivarium_public_health/risks/base_risk.py
+++ b/src/vivarium_public_health/risks/base_risk.py
@@ -89,27 +89,19 @@ class Risk(Component):
     def configuration_defaults(self) -> Dict[str, Any]:
         return {
             self.risk.name: {
-                # Change exposure (probably a bad idea)- replaces exposure with key and then value: data
                 "exposure": self.build_lookup_table_config(
                     value="data",
                     continuous_columns=["age", "year"],
-                    # Parameter should also be here?
                     categorical_columns=["sex"],
-                    key_name=f"risk_factor.{self.name}.exposure",
+                    key_name=f"risk_factor.{self.risk.name}.exposure",
                 ),
-                "ensemble_distribution_weights": self.build_lookup_table_config(
-                    value="data",
-                    continuous_columns=["age", "year"],
-                    categorical_columns=["sex"],
-                    key_name=f"risk_factor.{self.name}.exposure_distribution_weights",
-                ),
-                "exposure_standard_deviation": self.build_lookup_table_config(
-                    value="data",
-                    continuous_columns=["age", "year"],
-                    categorical_columns=["sex"],
-                    key_name=f"risk_factor.{self.name}.exposure_standard_deviation",
-                ),
-                # rebinned_exosed only used for DichotomousDistribution
+                "ensemble_distribution_weights": {
+                    "key_name": f"risk_factor.{self.risk.name}.exposure_distribution_weights",
+                },
+                "exposure_standard_deviation": {
+                    "key_name": f"risk_factor.{self.risk.name}.exposure_standard_deviation",
+                },
+                # rebinned_exposed only used for DichotomousDistribution
                 "rebinned_exposed": [],
                 "category_thresholds": [],
             }

--- a/src/vivarium_public_health/risks/data_transformations.py
+++ b/src/vivarium_public_health/risks/data_transformations.py
@@ -99,7 +99,7 @@ def get_exposure_data(builder, risk: EntityString):
 
 def load_exposure_data(builder, risk: EntityString):
     risk_config = builder.configuration[risk.name]
-    exposure_source = risk_config["exposure"]
+    exposure_source = risk_config["exposure"]["value"]
 
     if exposure_source == "data":
         exposure_data = builder.data.load(f"{risk}.exposure")
@@ -361,7 +361,7 @@ def get_exposure_effect(builder, risk: EntityString):
 def get_population_attributable_fraction_data(
     builder, risk: EntityString, target: TargetString
 ):
-    exposure_source = builder.configuration[f"{risk.name}"]["exposure"]
+    exposure_source = builder.configuration[f"{risk.name}"]["exposure"]["value"]
     rr_source_type = validate_relative_risk_data_source(builder, risk, target)
 
     if exposure_source == "data" and rr_source_type == "data" and risk.type == "risk_factor":
@@ -388,7 +388,7 @@ def get_population_attributable_fraction_data(
 
 def validate_distribution_data_source(builder, risk: EntityString):
     """Checks that the exposure distribution specification is valid."""
-    exposure_type = builder.configuration[risk.name]["exposure"]
+    exposure_type = builder.configuration[risk.name]["exposure"]["value"]
     rebin = builder.configuration[risk.name]["rebinned_exposed"]
     category_thresholds = builder.configuration[risk.name]["category_thresholds"]
 
@@ -425,8 +425,8 @@ def validate_lookup_configuration(builder, risk: EntityString) -> None:
     distribution_type = get_distribution_type(builder, risk)
     config = builder.configuration[risk.name]
     weights_columns = set(
-        config["exposure_distribution_weights"]["categorical_columns"]
-        + config["exposure_distribution_weights"]["continuous_columns"]
+        config["ensemble_distribution_weights"]["categorical_columns"]
+        + config["ensemble_distribution_weights"]["continuous_columns"]
     )
     mean_columns = set(
         config["exposure"]["categorical_columns"] + config["exposure"]["continuous_columns"]
@@ -453,7 +453,7 @@ def validate_lookup_configuration(builder, risk: EntityString) -> None:
                 f"has mean columns {mean_columns} and standard deviation columns {sd_columns}."
             )
     else:
-        # Do we need to do anything else here?
+        # Currently no other distributions have keys that must have matchign configurations
         pass
 
 

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -36,7 +36,7 @@ class SimulationDistribution(Component):
 
     #####################
     # Lifecycle methods #
-    #####################test_observation_registration
+    #####################
 
     def __init__(self, risk: str):
         super().__init__()

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -33,7 +33,7 @@ class SimulationDistribution(Component):
 
     #####################
     # Lifecycle methods #
-    #####################
+    #####################test_observation_registration
 
     def __init__(self, risk: str):
         super().__init__()
@@ -43,6 +43,7 @@ class SimulationDistribution(Component):
         distribution_data = get_distribution_data(builder, self.risk)
         self.implementation = get_distribution(self.risk, **distribution_data)
         self.implementation.setup_component(builder)
+        breakpoint()
 
     ##################
     # Public methods #
@@ -192,7 +193,7 @@ class PolytomousDistribution(Component):
         self.exposure = self.get_exposure_parameters(builder)
 
     #################
-    # Setup methods #
+    # Setup methods # 
     #################
 
     def get_categories(self) -> List[str]:

--- a/src/vivarium_public_health/utilities.py
+++ b/src/vivarium_public_health/utilities.py
@@ -7,7 +7,7 @@ This module contains utility classes and functions for use across
 vivarium_public_health components.
 
 """
-from typing import Iterable, List, Union
+from typing import Dict, Iterable, List, Union
 
 import pandas as pd
 from vivarium.framework.lookup import LookupTable, ScalarValue
@@ -112,13 +112,14 @@ def get_lookup_columns(
     return list(necessary_columns)
 
 
-def get_index_columns_from_lookup_configuration(lookup_configuration: dict) -> List[str]:
+def get_index_columns_from_lookup_configuration(
+    lookup_configuration: Dict[str, List[str]]
+) -> List[str]:
     index_columns = []
     for column in lookup_configuration["continuous_columns"]:
         start_column = f"{column}_start"
         end_column = f"{column}_end"
-        index_columns.append(start_column)
-        index_columns.append(end_column)
+        index_columns.extend([start_column, end_column])
     for column in lookup_configuration["categorical_columns"]:
         index_columns.append(column)
     return index_columns

--- a/src/vivarium_public_health/utilities.py
+++ b/src/vivarium_public_health/utilities.py
@@ -110,3 +110,15 @@ def get_lookup_columns(
         necessary_columns.remove("year")
 
     return list(necessary_columns)
+
+
+def get_index_columns_from_lookup_configuration(lookup_configuration: dict) -> List[str]:
+    index_columns = []
+    for column in lookup_configuration["continuous_columns"]:
+        start_column = f"{column}_start"
+        end_column = f"{column}_end"
+        index_columns.append(start_column)
+        index_columns.append(end_column)
+    for column in lookup_configuration["categorical_columns"]:
+        index_columns.append(column)
+    return index_columns

--- a/tests/metrics/test_categorical_risk_observer.py
+++ b/tests/metrics/test_categorical_risk_observer.py
@@ -109,29 +109,3 @@ def test_observation_correctness(base_config, simulation_after_one_step, categor
             assert np.isclose(
                 results(pop.index)[observation], expected_person_time, rtol=0.001
             )
-
-
-def test_risk_lookup_configuration(categorical_risk, base_config, base_plugins):
-    risk, risk_data = categorical_risk
-
-    simulation = InteractiveContext(
-        components=[
-            TestPopulation(),
-            risk,
-        ],
-        configuration=base_config,
-        plugin_configuration=base_plugins,
-        setup=False,
-    )
-
-    for key, value in risk_data.items():
-        simulation._data.write(f"risk_factor.test_risk.{key}", value)
-
-    simulation.setup()
-    # We have to get the distribution component's lookup tables. This is the distribution class
-    # instantiated by the sub_component of the risk class
-    distribution = risk.sub_components[0].implementation
-    lookup_tables = distribution.lookup_tables
-    # This risk is a PolytomousDistribution so there will only be an exposure lookup table
-    assert set(["exposure"]) == set(lookup_tables.keys())
-    assert isinstance(lookup_tables["exposure"], InterpolatedTable)

--- a/tests/population/test_mortality.py
+++ b/tests/population/test_mortality.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 import pytest
 from vivarium import Component, InteractiveContext
-from vivarium.framework.lookup.table import InterpolatedTable
 
 from vivarium_public_health.population import BasePopulation, Mortality
 from vivarium_public_health.testing.mock_artifact import MockArtifact


### PR DESCRIPTION
## Risk-lookup-table-configuration

### Updates base risk and sub-components to utilize configurable lookup tables
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4975

### Changes and notes
-adds default configuration for lookup tables for base risk
-updates risk distribution classes so lookup tables are configurable

### Testing
All tests pass. This was tested with an editable install for the upstream necessity from vivarium.

