### PR TITLE
Improve Mortality component LookupTable configuration

### DIFF
--- a/src/vivarium_public_health/disease/model.py
+++ b/src/vivarium_public_health/disease/model.py
@@ -8,6 +8,7 @@ function is to provide coordination across a set of disease states and
 transitions at simulation initialization and during transitions.
 
 """
+
 from typing import Callable, Dict, List, Optional
 
 import numpy as np

--- a/src/vivarium_public_health/disease/models.py
+++ b/src/vivarium_public_health/disease/models.py
@@ -7,6 +7,7 @@ This module contains a collection of frequently used parameterizations of
 disease models.
 
 """
+
 import pandas as pd
 
 from vivarium_public_health.disease.model import DiseaseModel

--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -301,9 +301,9 @@ class RiskAttributableDisease(Component):
         )
         sick = self.filter_by_exposure(pop_data.index)
         new_pop.loc[sick, self.cause.name] = self.cause.name
-        new_pop.loc[sick, self.diseased_event_time_column] = (
-            self.clock()
-        )  # match VPH disease, only set w/ condition
+        new_pop.loc[
+            sick, self.diseased_event_time_column
+        ] = self.clock()  # match VPH disease, only set w/ condition
 
         self.population_view.update(new_pop)
 
@@ -316,9 +316,9 @@ class RiskAttributableDisease(Component):
                 pop[self.cause.name] != f"susceptible_to_{self.cause.name}"
             )
             pop.loc[change_to_susceptible, self.susceptible_event_time_column] = event.time
-            pop.loc[change_to_susceptible, self.cause.name] = (
-                f"susceptible_to_{self.cause.name}"
-            )
+            pop.loc[
+                change_to_susceptible, self.cause.name
+            ] = f"susceptible_to_{self.cause.name}"
         change_to_diseased = sick & (pop[self.cause.name] != self.cause.name)
         pop.loc[change_to_diseased, self.diseased_event_time_column] = event.time
         pop.loc[change_to_diseased, self.cause.name] = self.cause.name

--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -6,6 +6,7 @@
 This module contains frequently used, but non-standard disease models.
 
 """
+
 import re
 from collections import namedtuple
 from operator import gt, lt
@@ -300,9 +301,9 @@ class RiskAttributableDisease(Component):
         )
         sick = self.filter_by_exposure(pop_data.index)
         new_pop.loc[sick, self.cause.name] = self.cause.name
-        new_pop.loc[
-            sick, self.diseased_event_time_column
-        ] = self.clock()  # match VPH disease, only set w/ condition
+        new_pop.loc[sick, self.diseased_event_time_column] = (
+            self.clock()
+        )  # match VPH disease, only set w/ condition
 
         self.population_view.update(new_pop)
 
@@ -315,9 +316,9 @@ class RiskAttributableDisease(Component):
                 pop[self.cause.name] != f"susceptible_to_{self.cause.name}"
             )
             pop.loc[change_to_susceptible, self.susceptible_event_time_column] = event.time
-            pop.loc[
-                change_to_susceptible, self.cause.name
-            ] = f"susceptible_to_{self.cause.name}"
+            pop.loc[change_to_susceptible, self.cause.name] = (
+                f"susceptible_to_{self.cause.name}"
+            )
         change_to_diseased = sick & (pop[self.cause.name] != self.cause.name)
         pop.loc[change_to_diseased, self.diseased_event_time_column] = event.time
         pop.loc[change_to_diseased, self.cause.name] = self.cause.name

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -6,6 +6,7 @@ Disease States
 This module contains tools to manage standard disease states.
 
 """
+
 from typing import Any, Callable, Dict, List, Optional
 
 import numpy as np

--- a/src/vivarium_public_health/disease/transition.py
+++ b/src/vivarium_public_health/disease/transition.py
@@ -6,6 +6,7 @@ Disease Transitions
 This module contains tools to model transitions between disease states.
 
 """
+
 from typing import TYPE_CHECKING, Callable, Dict
 
 import pandas as pd

--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -7,6 +7,7 @@ This module contains tools for observing years lived with disability (YLDs)
 in the simulation.
 
 """
+
 from typing import List
 
 import pandas as pd

--- a/src/vivarium_public_health/metrics/disease.py
+++ b/src/vivarium_public_health/metrics/disease.py
@@ -7,6 +7,7 @@ This module contains tools for observing disease incidence and prevalence
 in the simulation.
 
 """
+
 from typing import Any, Dict, List, Optional
 
 import pandas as pd

--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -7,6 +7,7 @@ This module contains tools for observing cause-specific and
 excess mortality in the simulation, including "other causes".
 
 """
+
 from typing import Callable, List, Optional
 
 import pandas as pd

--- a/src/vivarium_public_health/metrics/risk.py
+++ b/src/vivarium_public_health/metrics/risk.py
@@ -6,6 +6,7 @@ Risk Observers
 This module contains tools for observing risk exposure during the simulation.
 
 """
+
 from typing import Any, Dict, List, Optional
 
 import pandas as pd

--- a/src/vivarium_public_health/mslt/delay.py
+++ b/src/vivarium_public_health/mslt/delay.py
@@ -7,6 +7,7 @@ This module contains tools to represent delayed effects in a multi-state
 lifetable simulation.
 
 """
+
 from typing import Any, Dict, List, Optional
 
 import numpy as np

--- a/src/vivarium_public_health/mslt/disease.py
+++ b/src/vivarium_public_health/mslt/disease.py
@@ -7,6 +7,7 @@ This module contains tools for modeling diseases in multi-state lifetable
 simulations.
 
 """
+
 from typing import Any, Dict, List, Optional
 
 import numpy as np

--- a/src/vivarium_public_health/mslt/intervention.py
+++ b/src/vivarium_public_health/mslt/intervention.py
@@ -7,6 +7,7 @@ This module contains tools for modeling interventions in multi-state lifetable
 simulations.
 
 """
+
 from typing import Any, Dict
 
 from vivarium import Component

--- a/src/vivarium_public_health/mslt/magic_wand_components.py
+++ b/src/vivarium_public_health/mslt/magic_wand_components.py
@@ -7,6 +7,7 @@ This module contains tools for making crude adjustments to rates in
 multi-state lifetable simulations.
 
 """
+
 from typing import Any, Dict
 
 from vivarium import Component

--- a/src/vivarium_public_health/mslt/observer.py
+++ b/src/vivarium_public_health/mslt/observer.py
@@ -7,6 +7,7 @@ This module contains tools for recording various outputs of interest in
 multi-state lifetable simulations.
 
 """
+
 from typing import List, Optional
 
 import pandas as pd

--- a/src/vivarium_public_health/mslt/population.py
+++ b/src/vivarium_public_health/mslt/population.py
@@ -7,6 +7,7 @@ This module contains tools for modeling the core demography in
 multi-state lifetable simulations.
 
 """
+
 from typing import List, Optional
 
 import numpy as np

--- a/src/vivarium_public_health/plugins/parser.py
+++ b/src/vivarium_public_health/plugins/parser.py
@@ -8,6 +8,7 @@ Component Configuration Parsers in this module are specialized implementations o
 that can parse configurations of components specific to the Vivarium Public
 Health package.
 """
+
 from importlib import import_module
 from typing import Any, Callable, Dict, List, Optional, Union
 

--- a/src/vivarium_public_health/population/add_new_birth_cohorts.py
+++ b/src/vivarium_public_health/population/add_new_birth_cohorts.py
@@ -6,6 +6,7 @@ Fertility Models
 This module contains several different models of fertility.
 
 """
+
 from typing import Dict, List, Optional
 
 import numpy as np

--- a/src/vivarium_public_health/population/base_population.py
+++ b/src/vivarium_public_health/population/base_population.py
@@ -7,6 +7,7 @@ This module contains tools for sampling and assigning core demographic
 characteristics to simulants.
 
 """
+
 from typing import Callable, Dict, Iterable, List
 
 import numpy as np

--- a/src/vivarium_public_health/population/mortality.py
+++ b/src/vivarium_public_health/population/mortality.py
@@ -187,7 +187,7 @@ class Mortality(Component):
     def load_unmodeled_csmr(self, builder: Builder) -> Union[float, pd.DataFrame]:
         # todo validate that all data have the same columns
         raw_csmr = 0.0
-        for idx, cause in enumerate(builder.configuration.mortality.unmodeled_causes):
+        for idx, cause in enumerate(builder.configuration[self.name].unmodeled_causes):
             csmr = f"cause.{cause}.cause_specific_mortality_rate"
             if 0 == idx:
                 raw_csmr = builder.data.load(csmr)

--- a/src/vivarium_public_health/risks/base_risk.py
+++ b/src/vivarium_public_health/risks/base_risk.py
@@ -87,20 +87,17 @@ class Risk(Component):
     ##############
 
     @property
+    def name(self) -> str:
+        return self.risk
+
+    @property
     def configuration_defaults(self) -> Dict[str, Any]:
         return {
-            self.risk.name: {
-                "exposure": self.build_lookup_table_config(
-                    value="data",
-                    continuous_columns=["age", "year"],
-                    categorical_columns=["sex"],
-                    key_name=f"risk_factor.{self.risk.name}.exposure",
-                ),
-                "ensemble_distribution_weights": {
-                    "key_name": f"risk_factor.{self.risk.name}.exposure_distribution_weights",
-                },
-                "exposure_standard_deviation": {
-                    "key_name": f"risk_factor.{self.risk.name}.exposure_standard_deviation",
+            self.name: {
+                "data_sources": {
+                    "exposure": f"{self.risk}.exposure",
+                    "ensemble_distribution_weights": f"{self.risk}.exposure_distribution_weights",
+                    "exposure_standard_deviation": f"{self.risk}.exposure_standard_deviation",
                 },
                 # rebinned_exposed only used for DichotomousDistribution
                 "rebinned_exposed": [],
@@ -143,6 +140,7 @@ class Risk(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
+        self.configuration = builder.configuration[self.name]
         self.randomness = self.get_randomness_stream(builder)
         self.propensity = self.get_propensity_pipeline(builder)
         self.exposure = self.get_exposure_pipeline(builder)
@@ -157,6 +155,10 @@ class Risk(Component):
     #################
     # Setup methods #
     #################
+
+    def build_all_lookup_tables(self, builder: "Builder") -> None:
+        # exposure lookup tables are handled by the SimulationDistribution subcomponent
+        pass
 
     def get_randomness_stream(self, builder: Builder) -> RandomnessStream:
         return builder.randomness.get_stream(self.randomness_stream_name)

--- a/src/vivarium_public_health/risks/base_risk.py
+++ b/src/vivarium_public_health/risks/base_risk.py
@@ -7,6 +7,7 @@ This module contains tools for modeling categorical and continuous risk
 exposure.
 
 """
+
 from typing import Any, Dict, List
 
 import pandas as pd

--- a/src/vivarium_public_health/risks/data_transformations.py
+++ b/src/vivarium_public_health/risks/data_transformations.py
@@ -8,11 +8,12 @@ risk data and performing any necessary data transformations.
 
 """
 
-from typing import Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
 from loguru import logger
+from vivarium.framework.engine import Builder
 
 from vivarium_public_health.utilities import EntityString, TargetString
 
@@ -21,13 +22,36 @@ from vivarium_public_health.utilities import EntityString, TargetString
 #############
 
 
-def pivot_categorical(data: pd.DataFrame) -> pd.DataFrame:
+def is_data_from_artifact(data_source: str) -> bool:
+    return isinstance(data_source, str) and "::" not in data_source
+
+
+def pivot_categorical(
+    builder: Builder, risk: Optional[EntityString], data: pd.DataFrame
+) -> Tuple[pd.DataFrame, List[str]]:
     """Pivots data that is long on categories to be wide."""
-    key_cols = ["sex", "age_start", "age_end", "year_start", "year_end"]
-    key_cols = [k for k in key_cols if k in data.columns]
-    data = data.pivot_table(index=key_cols, columns="parameter", values="value").reset_index()
-    data.columns.name = None
-    return data
+    # todo remove if statement when relative risk has been updated
+    if risk:
+        # todo remove dependency on artifact manager having exactly one value column
+        value_column = builder.data.value_columns()(f"{risk}.exposure")[0]
+        pivot_column = "parameter"
+        index_cols = [
+            column for column in data.columns if column not in [value_column, pivot_column]
+        ]
+        data = data.pivot_table(
+            index=index_cols, columns=pivot_column, values=value_column
+        ).reset_index()
+        data.columns.name = None
+    else:
+        index_cols = ["sex", "age_start", "age_end", "year_start", "year_end"]
+        index_cols = [k for k in index_cols if k in data.columns]
+        data = data.pivot_table(
+            index=index_cols, columns="parameter", values="value"
+        ).reset_index()
+        data.columns.name = None
+
+    value_columns = [column for column in data.columns if column not in index_cols]
+    return data, value_columns
 
 
 ##########################
@@ -35,14 +59,15 @@ def pivot_categorical(data: pd.DataFrame) -> pd.DataFrame:
 ##########################
 
 
-def get_distribution_data(builder, risk: EntityString):
+def get_distribution_data(builder, risk: EntityString) -> Dict[str, Any]:
     validate_distribution_data_source(builder, risk)
     data = load_distribution_data(builder, risk)
+    validate_distribution_data(data)
     return data
 
 
 def get_exposure_post_processor(builder, risk: EntityString):
-    thresholds = builder.configuration[risk.name]["category_thresholds"]
+    thresholds = builder.configuration[risk]["category_thresholds"]
 
     if thresholds:
         thresholds = [-np.inf] + thresholds + [np.inf]
@@ -59,22 +84,27 @@ def get_exposure_post_processor(builder, risk: EntityString):
     return post_processor
 
 
-def load_distribution_data(builder, risk: EntityString):
-    exposure_data = get_exposure_data(builder, risk)
+def load_distribution_data(builder: Builder, risk: EntityString) -> Dict[str, Any]:
+    distribution_type = get_distribution_type(builder, risk)
+    exposure_data, value_columns = get_exposure_data(builder, risk, distribution_type)
 
     data = {
-        "distribution_type": get_distribution_type(builder, risk),
+        "distribution_type": distribution_type,
         "exposure": exposure_data,
-        "exposure_standard_deviation": get_exposure_standard_deviation_data(builder, risk),
-        "weights": get_exposure_distribution_weights(builder, risk),
+        "exposure_value_columns": value_columns,
+        "exposure_standard_deviation": get_exposure_standard_deviation_data(
+            builder, risk, distribution_type
+        ),
+        "weights": get_exposure_distribution_weights(builder, risk, distribution_type),
     }
     return data
 
 
 def get_distribution_type(builder, risk: EntityString):
-    risk_config = builder.configuration[risk.name]
+    risk_config = builder.configuration[risk]
+    exposure = risk_config["data_sources"]["exposure"]
 
-    if risk_config["exposure"]["value"] == "data" and not risk_config["rebinned_exposed"]:
+    if is_data_from_artifact(exposure) and not risk_config["rebinned_exposed"]:
         distribution_type = builder.data.load(f"{risk}.distribution")
     else:
         distribution_type = "dichotomous"
@@ -82,77 +112,74 @@ def get_distribution_type(builder, risk: EntityString):
     return distribution_type
 
 
-def get_exposure_data(builder, risk: EntityString):
+def get_exposure_data(
+    builder, risk: EntityString, distribution_type: str
+) -> Tuple[pd.DataFrame, List[str]]:
     exposure_data = load_exposure_data(builder, risk)
     exposure_data = rebin_exposure_data(builder, risk, exposure_data)
 
-    if get_distribution_type(builder, risk) in [
+    if distribution_type in [
         "dichotomous",
         "ordered_polytomous",
         "unordered_polytomous",
         "lbwsg",
     ]:
-        exposure_data = pivot_categorical(exposure_data)
-
-    return exposure_data
-
-
-def load_exposure_data(builder, risk: EntityString):
-    risk_config = builder.configuration[risk.name]
-    exposure_source = risk_config["exposure"]["value"]
-
-    if exposure_source == "data":
-        exposure_data = builder.data.load(risk_config["exposure"]["key_name"])
+        exposure_data, value_columns = pivot_categorical(builder, risk, exposure_data)
     else:
-        if isinstance(exposure_source, str):  # Build from covariate
-            cat1 = builder.data.load(f"{exposure_source}.estimate")
-            # TODO: Generate a draw.
-            cat1 = cat1[cat1["parameter"] == "mean_value"]
-            cat1["parameter"] = "cat1"
-        else:  # We have a numerical value
-            cat1 = builder.data.load("population.demographic_dimensions")
-            cat1["parameter"] = "cat1"
-            cat1["value"] = float(exposure_source)
+        value_columns = builder.data.value_columns()(f"{risk}.exposure")
+
+    return exposure_data, value_columns
+
+
+def load_exposure_data(builder: Builder, risk: EntityString) -> pd.DataFrame:
+    risk_component = builder.components.get_component(risk)
+    exposure_data = risk_component.get_data(
+        builder, builder.configuration[risk_component.name]["data_sources"]["exposure"]
+    )
+
+    if isinstance(exposure_data, (int, float)):
+        value_columns = builder.data.value_columns()(f"{risk}.exposure")
+        cat1 = builder.data.load("population.demographic_dimensions")
+        cat1["parameter"] = "cat1"
+        cat1[value_columns] = float(exposure_data)
+
         cat2 = cat1.copy()
         cat2["parameter"] = "cat2"
-        cat2["value"] = 1 - cat2["value"]
+        cat2[value_columns] = 1 - cat2["value"]
+
         exposure_data = pd.concat([cat1, cat2], ignore_index=True)
 
     return exposure_data
 
 
-def get_exposure_standard_deviation_data(builder, risk: EntityString):
-    configuration = builder.configuration[risk.name]
-    distribution_type = get_distribution_type(builder, risk)
-    if distribution_type in ["normal", "lognormal", "ensemble"]:
-        exposure_sd = builder.data.load(
-            configuration["exposure_standard_deviation"]["key_name"]
-        )
-    else:
-        exposure_sd = None
-    return exposure_sd
+def get_exposure_standard_deviation_data(
+    builder: Builder, risk: EntityString, distribution_type: str
+) -> Union[pd.DataFrame, None]:
+    if distribution_type not in ["normal", "lognormal", "ensemble"]:
+        return None
+    data_source = builder.configuration[risk]["data_sources"]["exposure_standard_deviation"]
+    return builder.data.load(data_source)
 
 
-def get_exposure_distribution_weights(builder, risk: EntityString):
-    configuration = builder.configuration[risk.name]
-    distribution_type = get_distribution_type(builder, risk)
-    if distribution_type == "ensemble":
-        weights = builder.data.load(
-            configuration["ensemble_distribution_weights"]["key_name"]
-        )
-        weights = pivot_categorical(weights)
-        if "glnorm" in weights.columns:
-            if np.any(weights["glnorm"]):
-                raise NotImplementedError("glnorm distribution is not supported")
-            weights = weights.drop(columns=["glnorm"])
-    else:
-        weights = None
-    return weights
+def get_exposure_distribution_weights(
+    builder: Builder, risk: EntityString, distribution_type: str
+) -> Union[Tuple[pd.DataFrame, List[str]], None]:
+    if distribution_type != "ensemble":
+        return None
+
+    data_source = builder.configuration[risk]["data_source"]["ensemble_distribution_weights"]
+    weights = builder.data.load(data_source)
+    weights, distributions = pivot_categorical(builder, risk, weights)
+    if "glnorm" in weights.columns:
+        if np.any(weights["glnorm"]):
+            raise NotImplementedError("glnorm distribution is not supported")
+        weights = weights.drop(columns=["glnorm"])
+    return weights, distributions
 
 
 def rebin_exposure_data(builder, risk: EntityString, exposure_data: pd.DataFrame):
     validate_rebin_source(builder, risk, exposure_data)
-    rebin_exposed_categories = set(builder.configuration[risk.name]["rebinned_exposed"])
+    rebin_exposed_categories = set(builder.configuration[risk]["rebinned_exposed"])
 
     if rebin_exposed_categories:
         exposure_data = _rebin_exposure_data(exposure_data, rebin_exposed_categories)
@@ -189,7 +216,7 @@ def get_relative_risk_data(builder, risk: EntityString, target: TargetString):
         "ordered_polytomous",
         "unordered_polytomous",
     ]:
-        relative_risk_data = pivot_categorical(relative_risk_data)
+        relative_risk_data, _ = pivot_categorical(builder, None, relative_risk_data)
         # Check if any values for relative risk are below expected boundary of 1.0
         category_columns = [c for c in relative_risk_data.columns if "cat" in c]
         if not relative_risk_data[
@@ -293,9 +320,10 @@ def rebin_relative_risk_data(
     for the matching rr = [rr1, rr2, rr3, 1], rebinned rr for the rebinned cat1 should be:
     (0.1 *rr1 + 0.2 * rr2 + 0.3* rr3) / (0.1+0.2+0.3)
     """
-    rebin_exposed_categories = set(builder.configuration[risk.name]["rebinned_exposed"])
+    rebin_exposed_categories = set(builder.configuration[risk]["rebinned_exposed"])
 
     if rebin_exposed_categories:
+        # todo make sure this works
         exposure_data = load_exposure_data(builder, risk)
         relative_risk_data = _rebin_relative_risk_data(
             relative_risk_data, exposure_data, rebin_exposed_categories
@@ -367,12 +395,15 @@ def get_exposure_effect(builder, risk: EntityString):
 def get_population_attributable_fraction_data(
     builder, risk: EntityString, target: TargetString
 ):
-    exposure_source = builder.configuration[f"{risk.name}"]["exposure"]["value"]
     rr_source_type = validate_relative_risk_data_source(builder, risk, target)
-
-    if exposure_source == "data" and rr_source_type == "data" and risk.type == "risk_factor":
+    exposure_source = builder.configuration[risk]["data_sources"]["exposure"]
+    if (
+        is_data_from_artifact(exposure_source)
+        and rr_source_type == "data"
+        and risk.type == "risk_factor"
+    ):
         paf_data = builder.data.load(
-            builder.configuration[risk.name]["population_attributable_fraction"]["key_name"]
+            builder.configuration[risk]["population_attributable_fraction"]["key_name"]
         )
         correct_target = (paf_data["affected_entity"] == target.name) & (
             paf_data["affected_measure"] == target.measure
@@ -394,11 +425,11 @@ def get_population_attributable_fraction_data(
 ##############
 
 
-def validate_distribution_data_source(builder, risk: EntityString):
+def validate_distribution_data_source(builder: Builder, risk: EntityString) -> None:
     """Checks that the exposure distribution specification is valid."""
-    exposure_type = builder.configuration[risk.name]["exposure"]["value"]
-    rebin = builder.configuration[risk.name]["rebinned_exposed"]
-    category_thresholds = builder.configuration[risk.name]["category_thresholds"]
+    exposure_type = builder.configuration[risk]["data_sources"]["exposure"]
+    rebin = builder.configuration[risk]["rebinned_exposed"]
+    category_thresholds = builder.configuration[risk]["category_thresholds"]
 
     if risk.type == "alternative_risk_factor":
         if exposure_type != "data" or rebin:
@@ -409,21 +440,21 @@ def validate_distribution_data_source(builder, risk: EntityString):
         if not category_thresholds:
             raise ValueError("Must specify category thresholds to use alternative risks.")
 
-    elif risk.type in ["risk_factor", "coverage_gap"]:
-        if isinstance(exposure_type, (int, float)) and not 0 <= exposure_type <= 1:
-            raise ValueError(f"Exposure should be in the range [0, 1]")
-        elif isinstance(exposure_type, str) and exposure_type.split(".")[0] not in [
-            "covariate",
-            "data",
-        ]:
-            raise ValueError(
-                f"Exposure must be specified as 'data', an integer or float value, "
-                f"or as a string in the format covariate.covariate_name"
-            )
-        else:
-            pass  # All good
-    else:
+    elif risk.type not in ["risk_factor", "coverage_gap"]:
         raise ValueError(f"Unknown risk type {risk.type} for risk {risk.name}")
+
+
+def validate_distribution_data(distribution_data: Dict[str, Any]) -> None:
+    exposure_data = distribution_data["exposure"]
+    val_cols = distribution_data["exposure_value_columns"]
+    if distribution_data["distribution_type"] == "dichotomous":
+        if ((exposure_data[val_cols] < 0) | exposure_data[val_cols] > 1).any().any():
+            raise ValueError(f"Exposure should be in the range [0, 1]")
+    # TODO: validate that weights, standard deviation, and exposure have the
+    #  same index cols for ensemble
+    # TODO: validate that standard deviation and exposure have the same index
+    #  cols for normal and lognormal
+    # TODO: add more data validations
 
 
 def validate_relative_risk_data_source(builder, risk: EntityString, target: TargetString):
@@ -490,9 +521,9 @@ def validate_relative_risk_rebin_source(
 
 
 def validate_rebin_source(builder, risk: EntityString, data: pd.DataFrame):
-    rebin_exposed_categories = set(builder.configuration[risk.name]["rebinned_exposed"])
+    rebin_exposed_categories = set(builder.configuration[risk]["rebinned_exposed"])
 
-    if rebin_exposed_categories and builder.configuration[risk.name]["category_thresholds"]:
+    if rebin_exposed_categories and builder.configuration[risk]["category_thresholds"]:
         raise ValueError(
             f"Rebinning and category thresholds are mutually exclusive. "
             f"You provided both for {risk.name}."
@@ -502,20 +533,23 @@ def validate_rebin_source(builder, risk: EntityString, data: pd.DataFrame):
         f"{risk}.distribution"
     ):
         raise ValueError(
-            f"Rebinning is only supported for polytomous risks. You provided rebinning exposed categories"
-            f'for {risk.name}, which is of type {builder.data.load(f"{risk}.distribution")}.'
+            f"Rebinning is only supported for polytomous risks. You provided "
+            f"rebinning exposed categoriesfor {risk.name}, which is of "
+            f"type {builder.data.load(f'{risk}.distribution')}."
         )
 
     invalid_cats = rebin_exposed_categories.difference(set(data.parameter))
     if invalid_cats:
         raise ValueError(
-            f"The following provided categories for the rebinned exposed category of {risk.name} "
-            f"are not found in the exposure data: {invalid_cats}."
+            f"The following provided categories for the rebinned exposed "
+            f"category of {risk.name} are not found in the exposure data: "
+            f"{invalid_cats}."
         )
 
     if rebin_exposed_categories == set(data.parameter):
         raise ValueError(
-            f"The provided categories for the rebinned exposed category of {risk.name} comprise all "
-            f"categories for the exposure data. At least one category must be left out of the provided "
-            f"categories to be rebinned into the unexposed category."
+            f"The provided categories for the rebinned exposed category of "
+            f"{risk.name} comprise all categories for the exposure data. "
+            f"At least one category must be left out of the provided categories "
+            f"to be rebinned into the unexposed category."
         )

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -7,6 +7,7 @@ This module contains tools for modeling several different risk
 exposure distributions.
 
 """
+
 from typing import Dict, List, Tuple
 
 import numpy as np

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -8,7 +8,7 @@ exposure distributions.
 
 """
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -19,10 +19,7 @@ from vivarium.framework.population import SimulantData
 from vivarium.framework.values import Pipeline, list_combiner, union_post_processor
 
 from vivarium_public_health.risks.data_transformations import get_distribution_data
-from vivarium_public_health.utilities import (
-    EntityString,
-    get_index_columns_from_lookup_configuration,
-)
+from vivarium_public_health.utilities import EntityString, get_lookup_columns
 
 
 class MissingDataError(Exception):
@@ -39,9 +36,9 @@ class SimulationDistribution(Component):
     # Lifecycle methods #
     #####################
 
-    def __init__(self, risk: str):
+    def __init__(self, risk: EntityString):
         super().__init__()
-        self.risk = EntityString(risk)
+        self.risk = risk
 
     def setup(self, builder: Builder) -> None:
         distribution_data = get_distribution_data(builder, self.risk)
@@ -80,43 +77,46 @@ class EnsembleSimulation(Component):
     def __init__(self, risk, weights, mean, sd):
         super().__init__()
         self.risk = EntityString(risk)
-        self._raw_weights = weights
+        self._raw_weights, self._distributions = weights
         self._mean = mean
         self._standard_deviation = sd
         self._propensity = f"ensemble_propensity_{self.risk}"
 
     def setup(self, builder: Builder) -> None:
         self.randomness = builder.randomness.get_stream(self._propensity)
-        self.input_weights, self._parameters = self.get_parameters(builder)
 
     ##########################
     # Initialization methods #
     ##########################
 
-    def build_lookup_tables(self, builder: Builder) -> None:
-        configuration = builder.configuration[self.risk.name]["exposure"]
-        self.lookup_tables["ensemble_distribution_weights"] = builder.lookup.build_table(
-            self.input_weights,
-            key_columns=configuration["categorical_columns"],
-            parameter_columns=configuration["continuous_columns"],
+    def build_all_lookup_tables(self, builder: Builder) -> None:
+        weights, parameters = self.get_parameters(builder)
+        distribution_weights_table = self.build_lookup_table(
+            builder, weights, self._distributions
         )
+        self.lookup_tables["ensemble_distribution_weights"] = distribution_weights_table
+        key_columns = distribution_weights_table.key_columns
+        parameter_columns = distribution_weights_table.parameter_columns
+
         self.parameters = {
-            k: builder.lookup.build_table(
-                v,
-                key_columns=configuration["categorical_columns"],
-                parameter_columns=configuration["continuous_columns"],
+            parameter: builder.lookup.build_table(
+                data, key_columns=key_columns, parameter_columns=parameter_columns
             )
-            for k, v in self._parameters.items()
+            for parameter, data in parameters.items()
         }
 
     def get_parameters(
         self, builder: Builder
     ) -> Tuple[pd.DataFrame, Dict[str, pd.DataFrame]]:
-        configuration = builder.configuration[self.risk.name]["exposure"]
-        index_cols = get_index_columns_from_lookup_configuration(configuration)
+        value_columns = builder.data.value_columns()(f"{self.risk}.exposure")
+        index_cols = [
+            column
+            for column in self._raw_weights.columns
+            if column not in self._distributions
+        ]
         weights = self._raw_weights.set_index(index_cols)
-        mean = self._mean.set_index(index_cols)["value"]
-        sd = self._standard_deviation.set_index(index_cols)["value"]
+        mean = self._mean.set_index(index_cols)[value_columns].squeeze(axis=1)
+        sd = self._standard_deviation.set_index(index_cols)[value_columns].squeeze(axis=1)
         weights, parameters = EnsembleDistribution.get_parameters(weights, mean=mean, sd=sd)
         return weights.reset_index(), {
             name: p.reset_index() for name, p in parameters.items()
@@ -160,29 +160,22 @@ class ContinuousDistribution(Component):
         super().__init__()
         self.risk = EntityString(risk)
         self._distribution = distribution
-        self._mean = mean
-        self._standard_deviation = sd
+        self._parameters = self.get_parameters(mean, sd)
 
     def setup(self, builder: Builder) -> None:
-        self._parameters = self.get_parameters(builder)
+        # todo update to have flexible columns for lookup table
+        self.parameters = builder.lookup.build_table(
+            self._parameters, key_columns=["sex"], parameter_columns=["age", "year"]
+        )
 
     ##########################
     # Initialization methods #
     ##########################
 
-    def build_lookup_tables(self, builder: Builder) -> None:
-        configuration = builder.configuration[self.risk.name]["exposure"]
-        self.parameters = builder.lookup.build_table(
-            self._parameters,
-            key_columns=configuration["categorical_columns"],
-            parameter_columns=configuration["continuous_columns"],
-        )
-
-    def get_parameters(self, builder: Builder) -> pd.DataFrame:
-        configuration = builder.configuration[self.risk.name]["exposure"]
-        index_cols = get_index_columns_from_lookup_configuration(configuration)
-        mean = self._mean.set_index(index_cols)["value"]
-        sd = self._standard_deviation.set_index(index_cols)["value"]
+    def get_parameters(self, mean, sd):
+        index = ["sex", "age_start", "age_end", "year_start", "year_end"]
+        mean = mean.set_index(index)["value"]
+        sd = sd.set_index(index)["value"]
         return self._distribution.get_parameters(mean=mean, sd=sd).reset_index()
 
     ##################
@@ -209,22 +202,19 @@ class PolytomousDistribution(Component):
         self.risk = EntityString(risk)
         self._exposure_data = exposure_data
         self.exposure_parameters_pipeline_name = f"{self.risk}.exposure_parameters"
+        self.categories = self.get_categories()
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        self.categories = self.get_categories()
         self.exposure = self.get_exposure_parameters(builder)
 
     #################
     # Setup methods #
     #################
 
-    def build_lookup_tables(self, builder: Builder) -> None:
-        configuration = builder.configuration[self.risk.name]["exposure"]
-        self.lookup_tables["exposure"] = builder.lookup.build_table(
-            self._exposure_data,
-            key_columns=configuration["categorical_columns"],
-            parameter_columns=configuration["continuous_columns"],
+    def build_all_lookup_tables(self, builder: Builder) -> None:
+        self.lookup_tables["exposure"] = self.build_lookup_table(
+            builder, self._exposure_data, self.categories
         )
 
     def get_categories(self) -> List[str]:
@@ -237,6 +227,7 @@ class PolytomousDistribution(Component):
         return builder.value.register_value_producer(
             self.exposure_parameters_pipeline_name,
             source=self.lookup_tables["exposure"],
+            requires_columns=get_lookup_columns([self.lookup_tables["exposure"]]),
         )
 
     ##################
@@ -266,19 +257,19 @@ class DichotomousDistribution(Component):
 
     def __init__(self, risk: str, exposure_data: pd.DataFrame):
         super().__init__()
-        self.risk = risk
+        self.risk = EntityString(risk)
         self._exposure_data = exposure_data.drop(columns="cat2")
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        self._base_exposure = self.lookup_tables["exposure"]
         self.exposure_proportion = builder.value.register_value_producer(
-            f"{self.risk}.exposure_parameters", source=self.exposure
+            f"{self.risk}.exposure_parameters",
+            source=self.exposure,
+            requires_columns=get_lookup_columns([self.lookup_tables["exposure"]]),
         )
-        base_paf = self.lookup_tables["paf"]
         self.joint_paf = builder.value.register_value_producer(
             f"{self.risk}.exposure_parameters.paf",
-            source=lambda index: [base_paf(index)],
+            source=lambda index: [self.lookup_tables["paf"](index)],
             preferred_combiner=list_combiner,
             preferred_post_processor=union_post_processor,
         )
@@ -287,21 +278,18 @@ class DichotomousDistribution(Component):
     # Initialization methods #
     ##########################
 
-    def build_lookup_tables(self, builder: Builder) -> None:
-        configuration = builder.configuration[self.risk.name]["exposure"]
-        self.lookup_tables["exposure"] = builder.lookup.build_table(
-            self._exposure_data,
-            key_columns=configuration["categorical_columns"],
-            parameter_columns=configuration["continuous_columns"],
+    def build_all_lookup_tables(self, builder: Builder) -> None:
+        self.lookup_tables["exposure"] = self.build_lookup_table(
+            builder, self._exposure_data, ["cat1"]
         )
-        self.lookup_tables["paf"] = builder.lookup.build_table(0)
+        self.lookup_tables["paf"] = self.build_lookup_table(builder, 0.0)
 
     ##################################
     # Pipeline sources and modifiers #
     ##################################
 
     def exposure(self, index: pd.Index) -> pd.Series:
-        base_exposure = self._base_exposure(index).values
+        base_exposure = self.lookup_tables["exposure"](index).values
         joint_paf = self.joint_paf(index).values
         return pd.Series(base_exposure * (1 - joint_paf), index=index, name="values")
 
@@ -318,7 +306,14 @@ class DichotomousDistribution(Component):
         )
 
 
-def get_distribution(risk, distribution_type, exposure, exposure_standard_deviation, weights):
+def get_distribution(
+    risk: EntityString,
+    distribution_type: str,
+    exposure: pd.DataFrame,
+    exposure_value_columns: List[str],
+    exposure_standard_deviation: Union[pd.DataFrame, None],
+    weights: Union[Tuple[pd.DataFrame, List[str]], None],
+) -> Component:
     if distribution_type == "dichotomous":
         distribution = DichotomousDistribution(risk, exposure)
     elif "polytomous" in distribution_type:

--- a/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
+++ b/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
@@ -6,6 +6,7 @@ Low Birth Weight and Short Gestation
 Low birth weight and short gestation (LBWSG) is a non-standard risk
 implementation that has been used in several public health models.
 """
+
 import pickle
 from typing import Callable, Dict, List, Optional
 

--- a/src/vivarium_public_health/testing/mock_artifact.py
+++ b/src/vivarium_public_health/testing/mock_artifact.py
@@ -7,6 +7,9 @@ This module contains a mock version of the artifact manager for use with
 testing vivarium_public_health components.
 
 """
+
+from typing import List
+
 import pandas as pd
 from vivarium.framework.artifact import ArtifactManager
 from vivarium.testing_utilities import build_table
@@ -126,6 +129,7 @@ class MockArtifact:
 
 class MockArtifactManager(ArtifactManager):
     def __init__(self):
+        super().__init__()
         self.artifact = self._load_artifact(None)
 
     @property

--- a/src/vivarium_public_health/testing/utils.py
+++ b/src/vivarium_public_health/testing/utils.py
@@ -7,6 +7,7 @@ This module contains data generation tools for testing vivarium_public_health
 components.
 
 """
+
 from itertools import product
 
 import numpy as np

--- a/src/vivarium_public_health/treatment/magic_wand.py
+++ b/src/vivarium_public_health/treatment/magic_wand.py
@@ -7,6 +7,7 @@ This module contains simple intervention models that work at the population
 level by providing direct shifts to epidemiological measures.
 
 """
+
 from typing import Any, Dict, List, Optional
 
 from vivarium import Component

--- a/src/vivarium_public_health/treatment/scale_up.py
+++ b/src/vivarium_public_health/treatment/scale_up.py
@@ -6,6 +6,7 @@ Linear Scale-Up Model
 This module contains tools for applying a linear scale-up to an intervention
 
 """
+
 from typing import Any, Callable, Dict, Tuple
 
 import pandas as pd

--- a/src/vivarium_public_health/treatment/therapeutic_inertia.py
+++ b/src/vivarium_public_health/treatment/therapeutic_inertia.py
@@ -7,6 +7,7 @@ This module contains a model for therapeutic inertia which represents the
 variety of reasons why a treatment algorithm might deviate from guidelines.
 
 """
+
 import pandas as pd
 import scipy.stats
 from vivarium import Component

--- a/src/vivarium_public_health/utilities.py
+++ b/src/vivarium_public_health/utilities.py
@@ -8,7 +8,7 @@ vivarium_public_health components.
 
 """
 
-from typing import Dict, Iterable, List, Union
+from typing import Iterable, List, Union
 
 import pandas as pd
 from vivarium.framework.lookup import LookupTable, ScalarValue
@@ -105,22 +105,9 @@ def get_lookup_columns(
 ) -> List[str]:
     necessary_columns = set(necessary_columns)
     for lookup_table in lookup_tables:
-        necessary_columns.update(lookup_table.key_columns)
-        necessary_columns.update(lookup_table.parameter_columns)
+        necessary_columns.update(set(lookup_table.key_columns))
+        necessary_columns.update(set(lookup_table.parameter_columns))
     if "year" in necessary_columns:
         necessary_columns.remove("year")
 
     return list(necessary_columns)
-
-
-def get_index_columns_from_lookup_configuration(
-    lookup_configuration: Dict[str, List[str]]
-) -> List[str]:
-    index_columns = []
-    for column in lookup_configuration["continuous_columns"]:
-        start_column = f"{column}_start"
-        end_column = f"{column}_end"
-        index_columns.extend([start_column, end_column])
-    for column in lookup_configuration["categorical_columns"]:
-        index_columns.append(column)
-    return index_columns

--- a/src/vivarium_public_health/utilities.py
+++ b/src/vivarium_public_health/utilities.py
@@ -7,6 +7,7 @@ This module contains utility classes and functions for use across
 vivarium_public_health components.
 
 """
+
 from typing import Dict, Iterable, List, Union
 
 import pandas as pd

--- a/tests/plugins/test_parser.py
+++ b/tests/plugins/test_parser.py
@@ -179,42 +179,42 @@ class MockArtifactManager(MockArtifactManager_):
     def _load_artifact(self, _: str) -> MockArtifact:
         artifact = MockArtifact()
 
-        artifact.mocks[
-            f"cause.{STATES.SIR_INFECTED.name}.prevalence"
-        ] = STATES.SIR_INFECTED.prevalence
-        artifact.mocks[
-            f"cause.{STATES.SIR_INFECTED.name}.disability_weight"
-        ] = STATES.SIR_INFECTED.disability_weight
-        artifact.mocks[
-            f"cause.{STATES.SIR_INFECTED.name}.excess_mortality_rate"
-        ] = STATES.SIR_INFECTED.emr
+        artifact.mocks[f"cause.{STATES.SIR_INFECTED.name}.prevalence"] = (
+            STATES.SIR_INFECTED.prevalence
+        )
+        artifact.mocks[f"cause.{STATES.SIR_INFECTED.name}.disability_weight"] = (
+            STATES.SIR_INFECTED.disability_weight
+        )
+        artifact.mocks[f"cause.{STATES.SIR_INFECTED.name}.excess_mortality_rate"] = (
+            STATES.SIR_INFECTED.emr
+        )
 
-        artifact.mocks[
-            "cause.some_custom_cause.disability_weight"
-        ] = STATES.COMPLEX_INFECTED_1.disability_weight
-        artifact.mocks[
-            "cause.some_custom_cause.excess_mortality_rate"
-        ] = STATES.COMPLEX_INFECTED_1.emr
+        artifact.mocks["cause.some_custom_cause.disability_weight"] = (
+            STATES.COMPLEX_INFECTED_1.disability_weight
+        )
+        artifact.mocks["cause.some_custom_cause.excess_mortality_rate"] = (
+            STATES.COMPLEX_INFECTED_1.emr
+        )
 
-        artifact.mocks[
-            f"cause.{STATES.COMPLEX_INFECTED_2.name}.prevalence"
-        ] = STATES.COMPLEX_INFECTED_2.prevalence
-        artifact.mocks[
-            f"cause.{STATES.COMPLEX_INFECTED_2.name}.disability_weight"
-        ] = STATES.COMPLEX_INFECTED_2.disability_weight
-        artifact.mocks[
-            f"cause.{STATES.COMPLEX_INFECTED_2.name}.excess_mortality_rate"
-        ] = STATES.COMPLEX_INFECTED_2.emr
+        artifact.mocks[f"cause.{STATES.COMPLEX_INFECTED_2.name}.prevalence"] = (
+            STATES.COMPLEX_INFECTED_2.prevalence
+        )
+        artifact.mocks[f"cause.{STATES.COMPLEX_INFECTED_2.name}.disability_weight"] = (
+            STATES.COMPLEX_INFECTED_2.disability_weight
+        )
+        artifact.mocks[f"cause.{STATES.COMPLEX_INFECTED_2.name}.excess_mortality_rate"] = (
+            STATES.COMPLEX_INFECTED_2.emr
+        )
 
-        artifact.mocks[
-            f"cause.{STATES.COMPLEX_INFECTED_3.name}.prevalence"
-        ] = STATES.COMPLEX_INFECTED_3.prevalence
-        artifact.mocks[
-            f"cause.{STATES.COMPLEX_INFECTED_3.name}.disability_weight"
-        ] = STATES.COMPLEX_INFECTED_3.disability_weight
-        artifact.mocks[
-            f"cause.{STATES.COMPLEX_INFECTED_3.name}.excess_mortality_rate"
-        ] = STATES.COMPLEX_INFECTED_3.emr
+        artifact.mocks[f"cause.{STATES.COMPLEX_INFECTED_3.name}.prevalence"] = (
+            STATES.COMPLEX_INFECTED_3.prevalence
+        )
+        artifact.mocks[f"cause.{STATES.COMPLEX_INFECTED_3.name}.disability_weight"] = (
+            STATES.COMPLEX_INFECTED_3.disability_weight
+        )
+        artifact.mocks[f"cause.{STATES.COMPLEX_INFECTED_3.name}.excess_mortality_rate"] = (
+            STATES.COMPLEX_INFECTED_3.emr
+        )
 
         return artifact
 

--- a/tests/plugins/test_parser.py
+++ b/tests/plugins/test_parser.py
@@ -179,42 +179,42 @@ class MockArtifactManager(MockArtifactManager_):
     def _load_artifact(self, _: str) -> MockArtifact:
         artifact = MockArtifact()
 
-        artifact.mocks[f"cause.{STATES.SIR_INFECTED.name}.prevalence"] = (
-            STATES.SIR_INFECTED.prevalence
-        )
-        artifact.mocks[f"cause.{STATES.SIR_INFECTED.name}.disability_weight"] = (
-            STATES.SIR_INFECTED.disability_weight
-        )
-        artifact.mocks[f"cause.{STATES.SIR_INFECTED.name}.excess_mortality_rate"] = (
-            STATES.SIR_INFECTED.emr
-        )
+        artifact.mocks[
+            f"cause.{STATES.SIR_INFECTED.name}.prevalence"
+        ] = STATES.SIR_INFECTED.prevalence
+        artifact.mocks[
+            f"cause.{STATES.SIR_INFECTED.name}.disability_weight"
+        ] = STATES.SIR_INFECTED.disability_weight
+        artifact.mocks[
+            f"cause.{STATES.SIR_INFECTED.name}.excess_mortality_rate"
+        ] = STATES.SIR_INFECTED.emr
 
-        artifact.mocks["cause.some_custom_cause.disability_weight"] = (
-            STATES.COMPLEX_INFECTED_1.disability_weight
-        )
-        artifact.mocks["cause.some_custom_cause.excess_mortality_rate"] = (
-            STATES.COMPLEX_INFECTED_1.emr
-        )
+        artifact.mocks[
+            "cause.some_custom_cause.disability_weight"
+        ] = STATES.COMPLEX_INFECTED_1.disability_weight
+        artifact.mocks[
+            "cause.some_custom_cause.excess_mortality_rate"
+        ] = STATES.COMPLEX_INFECTED_1.emr
 
-        artifact.mocks[f"cause.{STATES.COMPLEX_INFECTED_2.name}.prevalence"] = (
-            STATES.COMPLEX_INFECTED_2.prevalence
-        )
-        artifact.mocks[f"cause.{STATES.COMPLEX_INFECTED_2.name}.disability_weight"] = (
-            STATES.COMPLEX_INFECTED_2.disability_weight
-        )
-        artifact.mocks[f"cause.{STATES.COMPLEX_INFECTED_2.name}.excess_mortality_rate"] = (
-            STATES.COMPLEX_INFECTED_2.emr
-        )
+        artifact.mocks[
+            f"cause.{STATES.COMPLEX_INFECTED_2.name}.prevalence"
+        ] = STATES.COMPLEX_INFECTED_2.prevalence
+        artifact.mocks[
+            f"cause.{STATES.COMPLEX_INFECTED_2.name}.disability_weight"
+        ] = STATES.COMPLEX_INFECTED_2.disability_weight
+        artifact.mocks[
+            f"cause.{STATES.COMPLEX_INFECTED_2.name}.excess_mortality_rate"
+        ] = STATES.COMPLEX_INFECTED_2.emr
 
-        artifact.mocks[f"cause.{STATES.COMPLEX_INFECTED_3.name}.prevalence"] = (
-            STATES.COMPLEX_INFECTED_3.prevalence
-        )
-        artifact.mocks[f"cause.{STATES.COMPLEX_INFECTED_3.name}.disability_weight"] = (
-            STATES.COMPLEX_INFECTED_3.disability_weight
-        )
-        artifact.mocks[f"cause.{STATES.COMPLEX_INFECTED_3.name}.excess_mortality_rate"] = (
-            STATES.COMPLEX_INFECTED_3.emr
-        )
+        artifact.mocks[
+            f"cause.{STATES.COMPLEX_INFECTED_3.name}.prevalence"
+        ] = STATES.COMPLEX_INFECTED_3.prevalence
+        artifact.mocks[
+            f"cause.{STATES.COMPLEX_INFECTED_3.name}.disability_weight"
+        ] = STATES.COMPLEX_INFECTED_3.disability_weight
+        artifact.mocks[
+            f"cause.{STATES.COMPLEX_INFECTED_3.name}.excess_mortality_rate"
+        ] = STATES.COMPLEX_INFECTED_3.emr
 
         return artifact
 

--- a/tests/population/test_mortality.py
+++ b/tests/population/test_mortality.py
@@ -1,10 +1,6 @@
-import numpy as np
-import pandas as pd
-import pytest
-from vivarium import Component, InteractiveContext
+from vivarium import InteractiveContext
 
 from vivarium_public_health.population import BasePopulation, Mortality
-from vivarium_public_health.testing.mock_artifact import MockArtifact
 
 
 def test_mortality_default_lookup_configuration(
@@ -24,6 +20,8 @@ def test_mortality_default_lookup_configuration(
             "population_size": start_population_size,
             "include_sex": "Male",
         },
+        # todo test with actual unmodeled causes and non-zero mortality rates
+        "mortality": {"unmodeled_causes": []},
     }
     sim.configuration.update(override_config)
     sim.setup()


### PR DESCRIPTION
## Improve Mortality component LookupTable configuration
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5011

### Changes and notes
You can ignore all files except for `mortality.py` and `test_mortality.py`. The rests are due to black
-  Implement new lookup table configuration in Mortality component

Note: the tests fail, since I split up the Mortality and Risk components into separate PRs. They will pass once the Risk PR is merged into this one.

### Testing
All automated tests work.