### PR TITLE
Feature/sbachmei/reformat output datasets

### DIFF
--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -126,22 +126,17 @@ class DisabilityObserver(StratifiedObserver):
         results: pd.DataFrame,
     ) -> None:
         """Combine each observation's results and save to a single file"""
-        measure = "ylds"
-        if not cause_state:
-            entity_type = "cause"
-            entity = "all_causes"
-            sub_entity = None
-        else:
-            entity_type = cause_state.cause_type
-            entity = cause_state.model
-            sub_entity = cause_state.state_id
+
+        kwargs = {
+            "entity_type": cause_state.cause_type if cause_state else "cause",
+            "entity": cause_state.model if cause_state else "all_causes",
+            "sub_entity": cause_state.state_id if cause_state else None,
+            "results_dir": self.results_dir,
+            "random_seed": self.random_seed,
+            "input_draw": self.input_draw,
+        }
         write_dataframe_to_parquet(
             results=results,
-            measure=measure,
-            entity_type=entity_type,
-            entity=entity,
-            sub_entity=sub_entity,
-            results_dir=self.results_dir,
-            random_seed=self.random_seed,
-            input_draw=self.input_draw,
+            measure="ylds",
+            **kwargs,
         )

--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -126,10 +126,12 @@ class DisabilityObserver(StratifiedObserver):
         """Combine the measure-specific observer results and save to a single file."""
         measure, cause = [s.strip("_") for s in measure.split("due_to")]
         write_dataframe_to_parquet(
-            measure,
-            results,
-            self.results_dir,
-            self.random_seed,
-            self.input_draw,
-            {COLUMNS.CAUSE: cause},
+            results=results,
+            measure=measure,
+            entity_type="cause",
+            entity=cause,
+            sub_entity=None,
+            results_dir=self.results_dir,
+            random_seed=self.random_seed,
+            input_draw=self.input_draw,
         )

--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -80,7 +80,7 @@ class DisabilityObserver(StratifiedObserver):
             additional_stratifications=self.config.include,
             excluded_stratifications=self.config.exclude,
             when="time_step__prepare",
-            report=partial(self.report, None),
+            report=partial(self.write_disability_results, None),
         )
 
         for cause_state in cause_states:
@@ -97,7 +97,7 @@ class DisabilityObserver(StratifiedObserver):
                 additional_stratifications=self.config.include,
                 excluded_stratifications=self.config.exclude,
                 when="time_step__prepare",
-                report=partial(self.report, cause_state),
+                report=partial(self.write_disability_results, cause_state),
             )
 
     def get_disability_weight_pipeline(self, builder: Builder) -> Pipeline:
@@ -119,7 +119,7 @@ class DisabilityObserver(StratifiedObserver):
     # Report methods #
     ##################
 
-    def report(
+    def write_disability_results(
         self,
         cause_state: Optional[DiseaseState],
         measure: str,

--- a/src/vivarium_public_health/metrics/disease.py
+++ b/src/vivarium_public_health/metrics/disease.py
@@ -96,7 +96,7 @@ class DiseaseObserver(StratifiedObserver):
                 excluded_stratifications=self.config.exclude,
                 when="time_step__prepare",
                 report=partial(
-                    self.report,
+                    self.write_disease_results,
                     measure_name="person_time",
                     entity_type=entity_type,
                     entity=entity,
@@ -119,7 +119,7 @@ class DiseaseObserver(StratifiedObserver):
                 excluded_stratifications=self.config.exclude,
                 when="collect_metrics",
                 report=partial(
-                    self.report,
+                    self.write_disease_results,
                     measure_name="transition_count",
                     entity_type=entity_type,
                     entity=entity,
@@ -153,7 +153,7 @@ class DiseaseObserver(StratifiedObserver):
     # Report methods #
     ##################
 
-    def report(
+    def write_disease_results(
         self,
         measure_name: str,
         entity_type: str,

--- a/src/vivarium_public_health/metrics/disease.py
+++ b/src/vivarium_public_health/metrics/disease.py
@@ -140,20 +140,21 @@ class DiseaseObserver(StratifiedObserver):
     ##################
 
     def report(self, splitter: str, measure: str, results: pd.DataFrame):
-        extra_metric = measure.split(splitter)[0]
+        sub_entity = measure.split(splitter)[0]
         if "person_time" in measure:
-            measure_name = "state_person_time"
-            extra_col = {COLUMNS.STATE: extra_metric}
+            measure_name = "person_time"
         elif "event_count" in measure:
             measure_name = "transition_count"
-            extra_col = {COLUMNS.TRANSITION: extra_metric}
         else:
             raise ValueError(f"Unknown measure: {measure}")
         write_dataframe_to_parquet(
-            measure_name,
-            results,
-            self.results_dir,
-            self.random_seed,
-            self.input_draw,
-            extra_col,
+            results=results,
+            measure=measure_name,
+            entity_type="cause",
+            entity=self.disease,
+            sub_entity=sub_entity,
+            results_dir=self.results_dir,
+            random_seed=self.random_seed,
+            input_draw=self.input_draw,
+            output_filename=f"{measure_name}_{self.disease}",
         )

--- a/tests/metrics/test_disability_observer.py
+++ b/tests/metrics/test_disability_observer.py
@@ -1,5 +1,6 @@
 import itertools
 from collections import namedtuple
+from functools import partial
 from pathlib import Path
 
 import numpy as np
@@ -46,53 +47,40 @@ def test_disability_observer_setup(mocker):
     builder.configuration.output_data.results_directory = "some/results/directory"
 
     # Set up fake calls for cause-specific register_observation args
-    MockCause = namedtuple("MockCause", "state_id")
-    builder.components.get_components_by_type = lambda n: [
-        MockCause("flu"),
-        MockCause("measles"),
-    ]
+    flu = DiseaseState("flu")
+    measles = DiseaseState("measles")
+    builder.components.get_components_by_type = lambda n: [flu, measles]
     builder.value.get_value = lambda n: n
 
     builder.results.register_observation.assert_not_called()
     observer.setup_component(builder)
-    # Need to mock the results_dir since we didn't run this from cli
-    builder.results.register_observation.assert_any_call(
-        name="ylds_due_to_all_causes",
-        pop_filter='tracked == True and alive == "alive"',
-        aggregator_sources=["disability_weight"],
-        aggregator=observer.disability_weight_aggregator,
-        requires_columns=["alive"],
-        requires_values=["disability_weight"],
-        additional_stratifications=observer.config.include,
-        excluded_stratifications=observer.config.exclude,
-        when="time_step__prepare",
-        report=observer.report,
-    )
-    builder.results.register_observation.assert_any_call(
-        name="ylds_due_to_flu",
-        pop_filter='tracked == True and alive == "alive"',
-        aggregator_sources=["flu.disability_weight"],
-        aggregator=observer.disability_weight_aggregator,
-        requires_columns=["alive"],
-        requires_values=["flu.disability_weight"],
-        additional_stratifications=observer.config.include,
-        excluded_stratifications=observer.config.exclude,
-        when="time_step__prepare",
-        report=observer.report,
-    )
-    builder.results.register_observation.assert_any_call(
-        name="ylds_due_to_measles",
-        pop_filter='tracked == True and alive == "alive"',
-        aggregator_sources=["measles.disability_weight"],
-        aggregator=observer.disability_weight_aggregator,
-        requires_columns=["alive"],
-        requires_values=["measles.disability_weight"],
-        additional_stratifications=observer.config.include,
-        excluded_stratifications=observer.config.exclude,
-        when="time_step__prepare",
-        report=observer.report,
-    )
+
+    # Cannot use mocker.assert_any_call() with partial functions as an arg so
+    # instead check each kwarg individually
     assert builder.results.register_observation.call_count == 3
+    for _, kwargs in builder.results.register_observation.call_args_list:
+        assert len(kwargs) == 10
+        assert kwargs["pop_filter"] == 'tracked == True and alive == "alive"'
+        assert kwargs["aggregator"] == observer.disability_weight_aggregator
+        assert kwargs["requires_columns"] == ["alive"]
+        assert kwargs["additional_stratifications"] == observer.config.include
+        assert kwargs["excluded_stratifications"] == observer.config.exclude
+        assert kwargs["when"] == "time_step__prepare"
+        report = kwargs["report"]
+        assert isinstance(report, partial) and report.func == observer.report
+        if kwargs["name"] == "ylds_due_to_all_causes":
+            assert kwargs["aggregator_sources"] == ["disability_weight"]
+            assert kwargs["requires_values"] == ["disability_weight"]
+            assert report.args == (None,)
+        elif kwargs["name"] == "ylds_due_to_flu":
+            assert kwargs["aggregator_sources"] == ["flu.disability_weight"]
+            assert kwargs["requires_values"] == ["flu.disability_weight"]
+            assert report.args == (flu,)
+        elif kwargs["name"] == "ylds_due_to_measles":
+            assert kwargs["aggregator_sources"] == ["measles.disability_weight"]
+            assert kwargs["requires_values"] == ["measles.disability_weight"]
+            assert report.args == (measles,)
+
     assert DiseaseState in observer.disease_classes
     assert RiskAttributableDisease in observer.disease_classes
 
@@ -204,19 +192,27 @@ def test_disability_accumulation(
     assert set(file.name for file in results_files) == set(["ylds.parquet"])
     results = pd.read_parquet(results_files[0])
 
-    # yld_masks format: {cause: (filter, dw_pipeline)}
+    # yld_masks format: {cause: (state, filter, dw_pipeline)}
     yld_masks = {
-        "all_causes": (slice(None), disability_weight),
-        "sick_cause_0": (pop["model_0"] == "sick_cause_0", disability_weight_0),
-        "sick_cause_1": (pop["model_1"] == "sick_cause_1", disability_weight_1),
+        "all_causes": (None, slice(None), disability_weight),
+        "model_0": ("sick_cause_0", pop["model_0"] == "sick_cause_0", disability_weight_0),
+        "model_1": ("sick_cause_1", pop["model_1"] == "sick_cause_1", disability_weight_1),
     }
 
     # Check that all expected observations are there
     assert set(zip(results["sex"], results[COLUMNS.ENTITY])) == set(
         itertools.product(*[["Female", "Male"], list(yld_masks)])
     )
+    for cause, (state, *_) in yld_masks.items():
+        if state:
+            assert (
+                results.loc[results[COLUMNS.ENTITY] == cause, COLUMNS.SUB_ENTITY] == state
+            ).all()
+        else:
+            assert (
+                results.loc[results[COLUMNS.ENTITY] == cause, COLUMNS.SUB_ENTITY].isna().all()
+            )
 
-    # Check other columns (NOTE: no input_draw defined so shouldn't be there)
     assert set(results.columns) == set(
         [
             "sex",
@@ -231,14 +227,12 @@ def test_disability_accumulation(
     )
     assert (results[COLUMNS.MEASURE] == "ylds").all()
     assert (results[COLUMNS.ENTITY_TYPE] == "cause").all()
-    assert results[COLUMNS.SUB_ENTITY].isna().all()
     assert (results[COLUMNS.SEED] == 0).all()
     assert results[COLUMNS.DRAW].isna().all()
 
     # Check that all the yld values are as expected
     time_scale = time_step / pd.Timedelta("365.25 days")
-    for cause in ["all_causes", "sick_cause_0", "sick_cause_1"]:
-        pop_filter, dw = yld_masks[cause]
+    for cause, (state, pop_filter, dw) in yld_masks.items():
         cause_specific_pop = pop[pop_filter]
         for sex in ["Female", "Male"]:
             sub_pop = cause_specific_pop[cause_specific_pop["sex"] == sex]

--- a/tests/metrics/test_disability_observer.py
+++ b/tests/metrics/test_disability_observer.py
@@ -67,7 +67,9 @@ def test_disability_observer_setup(mocker):
         assert kwargs["excluded_stratifications"] == observer.config.exclude
         assert kwargs["when"] == "time_step__prepare"
         report = kwargs["report"]
-        assert isinstance(report, partial) and report.func == observer.report
+        assert (
+            isinstance(report, partial) and report.func == observer.write_disability_results
+        )
         if kwargs["name"] == "ylds_due_to_all_causes":
             assert kwargs["aggregator_sources"] == ["disability_weight"]
             assert kwargs["requires_values"] == ["disability_weight"]

--- a/tests/metrics/test_disability_observer.py
+++ b/tests/metrics/test_disability_observer.py
@@ -212,16 +212,28 @@ def test_disability_accumulation(
     }
 
     # Check that all expected observations are there
-    assert set(zip(results["sex"], results["cause"])) == set(
+    assert set(zip(results["sex"], results[COLUMNS.ENTITY])) == set(
         itertools.product(*[["Female", "Male"], list(yld_masks)])
     )
 
     # Check other columns (NOTE: no input_draw defined so shouldn't be there)
     assert set(results.columns) == set(
-        ["sex", COLUMNS.CAUSE, COLUMNS.MEASURE, COLUMNS.SEED, COLUMNS.VALUE]
+        [
+            "sex",
+            COLUMNS.MEASURE,
+            COLUMNS.ENTITY_TYPE,
+            COLUMNS.ENTITY,
+            COLUMNS.SUB_ENTITY,
+            COLUMNS.SEED,
+            COLUMNS.DRAW,
+            COLUMNS.VALUE,
+        ]
     )
     assert (results[COLUMNS.MEASURE] == "ylds").all()
+    assert (results[COLUMNS.ENTITY_TYPE] == "cause").all()
+    assert results[COLUMNS.SUB_ENTITY].isna().all()
     assert (results[COLUMNS.SEED] == 0).all()
+    assert results[COLUMNS.DRAW].isna().all()
 
     # Check that all the yld values are as expected
     time_scale = time_step / pd.Timedelta("365.25 days")
@@ -232,7 +244,7 @@ def test_disability_accumulation(
             sub_pop = cause_specific_pop[cause_specific_pop["sex"] == sex]
             expected_ylds = (dw(sub_pop.index) * time_scale).sum()
             actual_ylds = results.loc[
-                (results[COLUMNS.CAUSE] == cause) & (results["sex"] == sex), COLUMNS.VALUE
+                (results[COLUMNS.ENTITY] == cause) & (results["sex"] == sex), COLUMNS.VALUE
             ].values
             assert len(actual_ylds) == 1
             assert np.isclose(expected_ylds, actual_ylds[0], rtol=0.0000001)

--- a/tests/metrics/test_disease_observer.py
+++ b/tests/metrics/test_disease_observer.py
@@ -231,26 +231,6 @@ def test_observation_correctness(base_config, base_plugins, disease, model, tmpd
 
 def test_different_results_per_disease(base_config, base_plugins, tmpdir):
     """Test that all eash disease observer saves out its own results."""
-    # Set up models
-
-    # year_start = base_config.time.start.year
-    # year_end = base_config.time.end.year
-    # healthy = SusceptibleState("with_condition")
-    # disease_get_data_funcs = {
-    #     "disability_weight": lambda _, __: build_table(0.0, year_start - 1, year_end),
-    #     "prevalence": lambda _, __: build_table(
-    #         0.2, year_start - 1, year_end, ["age", "year", "sex", "value"]
-    #     ),
-    # }
-    # transition_get_data_funcs = {
-    #     "incidence_rate": lambda _, __: build_table(
-    #         0.9, year_start - 1, year_end, ["age", "year", "sex", "value"]
-    #     ),
-    # }
-    # with_condition = DiseaseState("with_condition", get_data_functions=disease_get_data_funcs)
-    # healthy.add_rate_transition(with_condition, transition_get_data_funcs)
-    # return DiseaseModel(disease, initial_state=healthy, states=[healthy, with_condition])
-
     vampiris_healthy_state = SusceptibleState("not_a_vampire")
     vampiris_infected_state = DiseaseState("a_vampire")
     vampiris_healthy_state.add_rate_transition(vampiris_infected_state)


### PR DESCRIPTION
## Reformat DisabilityObserver and DiseaseObserver outputs

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> refactor
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Instead of saving all measure results in a single file regardless of
where they came from (e.g. transition counts and person time from
different diseases or person time from diseases and risks), we
want to save each specific observer as its own dataset (e.g.
each disease gets its own specific person_time_{disease}.parquet
and transtion_count_{disease}.parquet.

This also streamlines the datasets so that they always have `measure`,
`entity_type`, `entity`, and `sub_entity` columns per RT's [design doc](https://vivarium-research.readthedocs.io/en/latest/model_design/vivarium_features/standard_results_formats/index.html)

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
all tests pass


