### PR TITLE
add typing to metrics modules

### DIFF
--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -9,7 +9,7 @@ in the simulation.
 """
 
 from functools import partial
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import pandas as pd
 from vivarium.framework.engine import Builder
@@ -46,14 +46,14 @@ class DisabilityObserver(StratifiedObserver):
     ##############
 
     @property
-    def disease_classes(self) -> List:
+    def disease_classes(self) -> List[Any]:
         return [DiseaseState, RiskAttributableDisease]
 
     #####################
     # Lifecycle methods #
     #####################
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.disability_weight_pipeline_name = "disability_weight"
 

--- a/src/vivarium_public_health/metrics/disease.py
+++ b/src/vivarium_public_health/metrics/disease.py
@@ -67,7 +67,7 @@ class DiseaseObserver(StratifiedObserver):
     # Lifecycle methods #
     #####################
 
-    def __init__(self, disease: str):
+    def __init__(self, disease: str) -> None:
         super().__init__()
         self.disease = disease
         self.current_state_column_name = self.disease
@@ -82,7 +82,7 @@ class DiseaseObserver(StratifiedObserver):
     # Setup methods #
     #################
 
-    def register_observations(self, builder):
+    def register_observations(self, builder: Builder) -> None:
         disease_model = builder.components.get_component(f"disease_model.{self.disease}")
         entity_type = disease_model.cause_type
         entity = disease_model.cause
@@ -161,7 +161,7 @@ class DiseaseObserver(StratifiedObserver):
         sub_entity: str,
         measure: str,
         results: pd.DataFrame,
-    ):
+    ) -> None:
         """Combine each observation's results and save to a single file"""
         write_dataframe_to_parquet(
             results=results,

--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -47,7 +47,7 @@ class MortalityObserver(StratifiedObserver):
     As a result, the model specification should list this observer after causes.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.causes_of_death = ["other_causes"]
         self.required_death_columns = ["alive", "exit_time"]

--- a/src/vivarium_public_health/metrics/reporters.py
+++ b/src/vivarium_public_health/metrics/reporters.py
@@ -19,7 +19,7 @@ class __Columns(NamedTuple):
     ENTITY: str = "entity"
 
     @property
-    def name(self):
+    def name(self) -> str:
         return "columns"
 
 

--- a/src/vivarium_public_health/metrics/risk.py
+++ b/src/vivarium_public_health/metrics/risk.py
@@ -68,7 +68,7 @@ class CategoricalRiskObserver(StratifiedObserver):
     # Lifecycle methods #
     #####################
 
-    def __init__(self, risk: str):
+    def __init__(self, risk: str) -> None:
         """
         Parameters
         ----------
@@ -89,7 +89,7 @@ class CategoricalRiskObserver(StratifiedObserver):
     # Setup methods #
     #################
 
-    def register_observations(self, builder):
+    def register_observations(self, builder: Builder) -> None:
         for category in self.categories:
             builder.results.register_observation(
                 name=f"{self.risk}_{category}_person_time",

--- a/src/vivarium_public_health/metrics/stratification.py
+++ b/src/vivarium_public_health/metrics/stratification.py
@@ -7,6 +7,8 @@ This module contains tools for stratifying observed quantities
 by specified characteristics through the vivarium results interface.
 """
 
+from __future__ import annotations
+
 import pandas as pd
 from vivarium import Component
 from vivarium.framework.engine import Builder
@@ -78,7 +80,7 @@ class ResultsStratifier(Component):
     # Mappers #
     ###########
 
-    def map_age_groups(self, pop: pd.DataFrame) -> pd.Series:
+    def map_age_groups(self, pop: pd.DataFrame) -> pd.Series[str]:
         """Map age with age group name strings
 
         Parameters
@@ -97,7 +99,7 @@ class ResultsStratifier(Component):
         return age_group
 
     @staticmethod
-    def map_year(pop: pd.DataFrame) -> pd.Series:
+    def map_year(pop: pd.DataFrame) -> pd.Series[str]:
         """Map datetime with year
 
         Parameters

--- a/tests/metrics/test_categorical_risk_observer.py
+++ b/tests/metrics/test_categorical_risk_observer.py
@@ -105,6 +105,25 @@ def test_observation_correctness(base_config, simulation_after_one_step, categor
     assert set(file.name for file in results_files) == set(["person_time_test_risk.parquet"])
     results = pd.read_parquet(results_files[0])
 
+    # Check columns
+    assert set(results.columns) == set(
+        [
+            "sex",
+            COLUMNS.MEASURE,
+            COLUMNS.ENTITY_TYPE,
+            COLUMNS.ENTITY,
+            COLUMNS.SUB_ENTITY,
+            COLUMNS.SEED,
+            COLUMNS.DRAW,
+            COLUMNS.VALUE,
+        ]
+    )
+
+    assert (results[COLUMNS.MEASURE] == "person_time").all()
+    assert (results[COLUMNS.ENTITY_TYPE] == "rei").all()
+    assert (results[COLUMNS.ENTITY] == "test_risk").all()
+    assert (results[COLUMNS.SEED] == 0).all()
+    assert results[COLUMNS.DRAW].isna().all()
     for category in exposure_categories:
         for sex in ["Male", "Female"]:
             expected_person_time = sum(

--- a/tests/metrics/test_mortality_observer.py
+++ b/tests/metrics/test_mortality_observer.py
@@ -139,6 +139,29 @@ def test_observation_correctness(simulation_after_one_step):
     results_dir = Path(simulation_after_one_step.configuration.output_data.results_directory)
     deaths = pd.read_parquet(results_dir / "deaths.parquet")
     ylls = pd.read_parquet(results_dir / "ylls.parquet")
+
+    # Check columns
+    for measure in ["deaths", "ylls"]:
+        df = eval(measure)
+        assert set(df.columns) == set(
+            [
+                "sex",
+                COLUMNS.MEASURE,
+                COLUMNS.ENTITY_TYPE,
+                COLUMNS.ENTITY,
+                COLUMNS.SUB_ENTITY,
+                COLUMNS.SEED,
+                COLUMNS.DRAW,
+                COLUMNS.VALUE,
+            ]
+        )
+        assert (df[COLUMNS.MEASURE] == measure).all()
+        assert (df[COLUMNS.ENTITY_TYPE] == "cause").all()
+        assert set(df[COLUMNS.ENTITY]) == set(["other_causes", "flu", "mumps"])
+        assert (df[COLUMNS.SEED] == 0).all()
+        assert df[COLUMNS.DRAW].isna().all()
+
+    # Check values. We already checked correctness of pipeline, so let's compare to that.
     metrics_df = pd.concat([df for df in simulation_after_one_step.get_results().values()])
     assert metrics_df.loc[metrics_df["measure"] == "deaths", "value"].equals(
         deaths.set_index("sex")["value"]


### PR DESCRIPTION
## Add typing to the metrics modules

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5016

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This adds typing to the metrics modules. Note that it does NOT
fix all mypy errors; it just adds the low-hanging fruit.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass
