### PR TITLE
Mic-4911Add distribution type arg to relative risk

### DIFF
--- a/src/vivarium_public_health/risks/data_transformations.py
+++ b/src/vivarium_public_health/risks/data_transformations.py
@@ -209,7 +209,10 @@ def _rebin_exposure_data(
 
 
 def get_relative_risk_data(
-    builder, risk: EntityString, target: TargetString, distribution_type: str = None,
+    builder,
+    risk: EntityString,
+    target: TargetString,
+    distribution_type: str = None,
 ) -> Tuple[pd.DataFrame, List[str]]:
     source_type = validate_relative_risk_data_source(builder, risk, target)
     relative_risk_data = load_relative_risk_data(builder, risk, target, source_type)

--- a/src/vivarium_public_health/risks/data_transformations.py
+++ b/src/vivarium_public_health/risks/data_transformations.py
@@ -209,14 +209,16 @@ def _rebin_exposure_data(
 
 
 def get_relative_risk_data(
-    builder, risk: EntityString, target: TargetString
+    builder, risk: EntityString, target: TargetString, distribution_type: str = None,
 ) -> Tuple[pd.DataFrame, List[str]]:
     source_type = validate_relative_risk_data_source(builder, risk, target)
     relative_risk_data = load_relative_risk_data(builder, risk, target, source_type)
     validate_relative_risk_rebin_source(builder, risk, target, relative_risk_data)
     relative_risk_data = rebin_relative_risk_data(builder, risk, relative_risk_data)
 
-    if get_distribution_type(builder, risk) in [
+    if distribution_type is None:
+        distribution_type = get_distribution_type(builder, risk)
+    if distribution_type in [
         "dichotomous",
         "ordered_polytomous",
         "unordered_polytomous",


### PR DESCRIPTION
## Mic-4911Add distribution type arg to relative risk

### Adds additional argument to get relative risk data to pass distribution type
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4911

### Changes and notes
-Adds additional argument to get relative risk
-Note: this is a temporary fix until we refactor risks and makes subclassing easier.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

