### PR TITLE
Register a single observation for ylds

### DIFF
--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -144,9 +144,9 @@ class DisabilityObserver(StratifiedObserver):
 
         results[COLUMNS.MEASURE] = measure
         results[COLUMNS.ENTITY_TYPE] = "cause"
-        results.loc[results[COLUMNS.SUB_ENTITY] == "all_causes", COLUMNS.ENTITY] = (
-            "all_causes"
-        )
+        results.loc[
+            results[COLUMNS.SUB_ENTITY] == "all_causes", COLUMNS.ENTITY
+        ] = "all_causes"
         for cause in self.causes_of_disease:
             cause_mask = results[COLUMNS.SUB_ENTITY] == cause.state_id
             results.loc[cause_mask, COLUMNS.ENTITY] = cause.model

--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -142,9 +142,9 @@ class DisabilityObserver(StratifiedObserver):
 
         results[COLUMNS.MEASURE] = measure
         results[COLUMNS.ENTITY_TYPE] = "cause"
-        results.loc[results[COLUMNS.SUB_ENTITY] == "all_causes", COLUMNS.ENTITY] = (
-            "all_causes"
-        )
+        results.loc[
+            results[COLUMNS.SUB_ENTITY] == "all_causes", COLUMNS.ENTITY
+        ] = "all_causes"
         for cause in self.causes_of_disease:
             cause_mask = results[COLUMNS.SUB_ENTITY] == cause.state_id
             results.loc[cause_mask, COLUMNS.ENTITY] = cause.model

--- a/src/vivarium_public_health/metrics/disability.py
+++ b/src/vivarium_public_health/metrics/disability.py
@@ -8,8 +8,6 @@ in the simulation.
 
 """
 
-from __future__ import annotations
-
 from typing import Any, List, Union
 
 import pandas as pd
@@ -103,9 +101,7 @@ class DisabilityObserver(StratifiedObserver):
     # Aggregators #
     ###############
 
-    def disability_weight_aggregator(
-        self, dw: pd.DataFrame
-    ) -> Union[float, pd.Series[float]]:
+    def disability_weight_aggregator(self, dw: pd.DataFrame) -> Union[float, pd.Series]:
         aggregated_dw = (dw * to_years(self.step_size)).sum().squeeze()
         if isinstance(aggregated_dw, pd.Series):
             aggregated_dw.index.name = "cause_of_disability"

--- a/src/vivarium_public_health/metrics/mortality.py
+++ b/src/vivarium_public_health/metrics/mortality.py
@@ -75,7 +75,7 @@ class MortalityObserver(StratifiedObserver):
         return config_defaults
 
     @property
-    def columns_required(self) -> Optional[List[str]]:
+    def columns_required(self) -> List[str]:
         return [
             "alive",
             "years_of_life_lost",

--- a/tests/metrics/test_disability_observer.py
+++ b/tests/metrics/test_disability_observer.py
@@ -149,6 +149,9 @@ def test_disability_accumulation(
         configuration=base_config,
         plugin_configuration=base_plugins,
     )
+
+    # Take two time steps (not just one in order to ensure metrics are updating properly)
+    simulation.step()
     simulation.step()
 
     pop = simulation.get_population()
@@ -222,7 +225,7 @@ def test_disability_accumulation(
     assert results[COLUMNS.DRAW].isna().all()
 
     # Check that all the yld values are as expected
-    time_scale = time_step / pd.Timedelta("365.25 days")
+    time_scale = time_step / pd.Timedelta("365.25 days") * 2
     for cause, (state, pop_filter, dw) in yld_masks.items():
         cause_specific_pop = pop[pop_filter]
         for sex in ["Female", "Male"]:


### PR DESCRIPTION
## Register a single observation for ylds
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> refactor, feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4968

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> We currently register a different observation for each disease (plus
"all_causes"). This PR allows for a single observation registration. The primary
change is to pass in all required pipelines to the register_observation
call at once and then add some special formatting to stack
the columns to make the data long on disease.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass
