### PR TITLE
enable github actions to find parent branch in vivarium for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
         shell: bash -le {0}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -32,30 +34,50 @@ jobs:
           else
             echo "branch_name=${GITHUB_REF_NAME}" >> $GITHUB_ENV
           fi
+      - name: Install dependencies
+        run: |
+          pip install .[dev]
       - name: check for upstream branch
         run: |
-          if git ls-remote --exit-code --heads https://github.com/ihmeuw/vivarium.git ${branch_name} == "0"; then
-            echo "upstream_exist=true" >> $GITHUB_ENV
-          else
-            echo "upstream_exist=false" >> $GITHUB_ENV
-          fi
+          vivarium_branch_name='main'
+          branch_name_to_check=${branch_name}
+          while [ "$branch_name_to_check" != "$vivarium_branch_name" ]
+          do
+            echo "Checking for vivarium branch: ${branch_name_to_check}"
+            if
+              git ls-remote --exit-code \
+              --heads https://github.com/ihmeuw/vivarium.git ${branch_name_to_check} == "0"
+            then
+              vivarium_branch_name=${branch_name_to_check}
+              echo "vivarium_branch_name=${branch_name_to_check}" >> $GITHUB_ENV
+            else
+              branch_name_to_check="$( \
+                git show-branch -a \
+                | grep '\*' \
+                | grep -v `git rev-parse --abbrev-ref HEAD` \
+                | head -n1 \
+                | sed 's/[^\[]*//' \
+                | awk 'match($0, /\[[a-zA-Z0-9\/.-]+\]/) { print substr( $0, RSTART+1, RLENGTH-2 )}' \
+                | sed 's/^origin\///' \
+              )"
+              git checkout ${branch_name_to_check}
+            fi
+          done
+          git checkout ${branch_name}
       - name: print environment values
         run: |
           cat $GITHUB_ENV
       - name: Update pip
         run: |
           python -m pip install --upgrade pip
-      - name: Retrieve upstream branch if exists
-        if: env.upstream_exist == 'true'
+      - name: Retrieve vivarium branch
+        if: env.vivarium_branch_name != 'main'
         run: |
-          echo "Cloning upstream branch: ${branch_name}"
-          git clone --branch=${branch_name} https://github.com/ihmeuw/vivarium.git
+          echo "Cloning upstream branch: ${vivarium_branch_name}"
+          git clone --branch=${vivarium_branch_name} https://github.com/ihmeuw/vivarium.git
           pushd vivarium
           pip install .
           popd
-      - name: Install dependencies
-        run: |
-          pip install .[dev]
       - name: Lint
         run: |
           pip install black==22.3.0 isort

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,6 @@ jobs:
         run: |
           pip install .[dev]
           git checkout ${branch_name}
-          echo "branch_name=${branch_name}"
       - name: check for upstream branch
         run: |
           vivarium_branch_name='main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .[dev]
+          git checkout ${branch_name}
+          echo "branch_name=${branch_name}"
       - name: check for upstream branch
         run: |
           vivarium_branch_name='main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
           else
             echo "branch_name=${GITHUB_REF_NAME}" >> $GITHUB_ENV
           fi
+      - name: Update pip
+        run: |
+          python -m pip install --upgrade pip
       - name: Install dependencies
         run: |
           pip install .[dev]
@@ -67,9 +70,6 @@ jobs:
       - name: print environment values
         run: |
           cat $GITHUB_ENV
-      - name: Update pip
-        run: |
-          python -m pip install --upgrade pip
       - name: Retrieve vivarium branch
         if: env.vivarium_branch_name != 'main'
         run: |


### PR DESCRIPTION
## Enable github actions to find parent branch in vivarium for builds
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: CI/infrastructure
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5066

### Changes and notes
Enables the build command to find the "closest" parent branch that is also present in vivarium and check that out in vivarium

### Testing
Successfully ran CI
