### PR TITLE
add linting dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,11 @@ if __name__ == "__main__":
         "matplotlib",
     ]
 
+    lint_requirements = [
+        "black==22.3.0",
+        "isort",
+    ]
+
     setup(
         name=about["__title__"],
         description=about["__summary__"],
@@ -80,7 +85,7 @@ if __name__ == "__main__":
         extras_require={
             "docs": doc_requirements,
             "test": test_requirements,
-            "dev": doc_requirements + test_requirements,
+            "dev": doc_requirements + test_requirements + lint_requirements,
         },
         zip_safe=False,
         use_scm_version={


### PR DESCRIPTION
## Add linting dependencies to setup.py
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: CI/infrastructure
- *JIRA issue*: N/A

### Changes and notes
Add linting dependencies to setup.py so we will have the same version of black as the CI

### Testing
Successfully installed the correct version of black