### PR TITLE
fail workflow if matching branch can't be found within 20 iterations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,9 +45,14 @@ jobs:
         run: |
           vivarium_branch_name='main'
           branch_name_to_check=${branch_name}
+          iterations=0
           while [ "$branch_name_to_check" != "$vivarium_branch_name" ]
           do
             echo "Checking for vivarium branch: ${branch_name_to_check}"
+            if [ $iterations -gt 20 ]; then
+              echo "Could not find upstream branch"
+              exit 1
+            fi
             if
               git ls-remote --exit-code \
               --heads https://github.com/ihmeuw/vivarium.git ${branch_name_to_check} == "0"
@@ -65,6 +70,7 @@ jobs:
                 | sed 's/^origin\///' \
               )"
               git checkout ${branch_name_to_check}
+              iterations=$((iterations+1))
             fi
           done
           git checkout ${branch_name}


### PR DESCRIPTION
## Fail workflow if matching branch can't be found within 20 iterations
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: CI/infrastructure
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5066

### Changes and notes
Break infinite loop in build action 

### Testing
Tested that the workflow succeeds if matching branch is found.
Tested that the workflow fails after 20 iterations
