### PR TITLE
refactor risk exposure code into risk distributions

### DIFF
--- a/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
+++ b/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
@@ -8,7 +8,7 @@ implementation that has been used in several public health models.
 """
 
 import pickle
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -165,6 +165,8 @@ class LBWSGDistribution(PolytomousDistribution):
 class LBWSGRisk(Risk):
     AXES = [BIRTH_WEIGHT, GESTATIONAL_AGE]
 
+    exposure_distributions = {"lbwsg": LBWSGDistribution}
+
     @staticmethod
     def birth_exposure_pipeline_name(axis: str) -> str:
         return f"{axis}.birth_exposure"
@@ -176,6 +178,12 @@ class LBWSGRisk(Risk):
     ##############
     # Properties #
     ##############
+
+    @property
+    def configuration_defaults(self) -> Dict[str, Any]:
+        configuration_defaults = super().configuration_defaults
+        configuration_defaults[self.name]["distribution_type"] = "lbwsg"
+        return configuration_defaults
 
     @property
     def columns_created(self) -> List[str]:
@@ -192,15 +200,6 @@ class LBWSGRisk(Risk):
     def setup(self, builder: Builder) -> None:
         super().setup(builder)
         self.birth_exposures = self.get_birth_exposure_pipelines(builder)
-
-    ##########################
-    # Initialization methods #
-    ##########################
-
-    def get_exposure_distribution(self, builder: Builder) -> LBWSGDistribution:
-        exposure_distribution = LBWSGDistribution(self)
-        exposure_distribution.setup_component(builder)
-        return exposure_distribution
 
     #################
     # Setup methods #

--- a/tests/risks/test_base_risk.py
+++ b/tests/risks/test_base_risk.py
@@ -199,7 +199,8 @@ def test_polytomous_risk(polytomous_risk, base_config, base_plugins):
     )
 
 
-def test_dichotomous_risk(base_config, base_plugins):
+@pytest.mark.parametrize("scalar_exposure", [True, False])
+def test_dichotomous_risk(base_config, base_plugins, scalar_exposure):
     risk = Risk("risk_factor.test_risk")
     rr_data = pd.DataFrame(
         {
@@ -213,6 +214,15 @@ def test_dichotomous_risk(base_config, base_plugins):
     )
 
     data = {
+        f"{risk.name}.exposure": pd.DataFrame(
+            {
+                "year_start": 1990,
+                "year_end": 1991,
+                "sex": ["Male"] * 2 + ["Female"] * 2,
+                "parameter": ["cat1", "cat2"] * 2,
+                "value": [0.25, 0.75] * 2,
+            }
+        ),
         f"{risk.name}.relative_risk": rr_data.reset_index(),
         f"{risk.name}.population_attributable_fraction": pd.DataFrame(
             {
@@ -226,12 +236,13 @@ def test_dichotomous_risk(base_config, base_plugins):
         ),
     }
 
+    data_sources = {"data_sources": {"exposure": 0.25}} if scalar_exposure else {}
     base_config.update(
         {
             "population": {"population_size": 50000},
             "risk_factor.test_risk": {
-                "data_sources": {"exposure": 0.25},
-                "distribution_type": "dichotomous",
+                **data_sources,
+                **{"distribution_type": "dichotomous"},
             },
         }
     )

--- a/tests/risks/test_data_transformations.py
+++ b/tests/risks/test_data_transformations.py
@@ -4,10 +4,10 @@ from vivarium.interface.interactive import InteractiveContext
 
 from vivarium_public_health.risks.base_risk import Risk
 from vivarium_public_health.risks.data_transformations import (
-    _rebin_exposure_data,
     _rebin_relative_risk_data,
     get_relative_risk_data,
 )
+from vivarium_public_health.risks.distributions import DichotomousDistribution
 from vivarium_public_health.risks.effect import RiskEffect
 from vivarium_public_health.utilities import TargetString
 
@@ -31,11 +31,11 @@ def test__rebin_exposure_data(rebin_categories, rebinned_values):
             "value": [0.5] * 4 + [0.2] * 4 + [0.3] * 4,
         }
     )
-    rebinned_df = _rebin_exposure_data(df, rebin_categories)
+    rebinned_df = DichotomousDistribution._rebin_exposure_data(df, rebin_categories)
 
-    assert rebinned_df.shape == (8, 4)
-    assert (rebinned_df[rebinned_df.parameter == "cat1"].value == rebinned_values[0]).all()
-    assert (rebinned_df[rebinned_df.parameter == "cat2"].value == rebinned_values[1]).all()
+    assert rebinned_df.shape == (4, 4)
+    assert (rebinned_df.value == rebinned_values[0]).all()
+    assert (rebinned_df["parameter"] == "cat1").all()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Refactor risk exposure code into risk distributions
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor/test
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5075

### Changes and notes
- Moved code from `data_transformations.py` to the appropriate `RiskExposureDistribution` class
- Moved rebinned exposure config validation into `risk.get_distribution_type()`
- Made exposure distributions map an attribute of Risk for easier subclassing and utilized this in LBWSG
- Updated `RiskExposureDistribution` constructor to take the risk name and distribution type rather than `Risk` object

### Testing
- All existing tests pass
- Introduced new integration tests for non-scalar dichotomous risk exposure data