### PR TITLE
Mic-5121/Pin numpy below 2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.3.3 - 06/17/24**
+
+ - Hotfix pin numpy below 2.0
+
 **2.3.2 - 3/13/24**
 
  - Update to Mortality Observer to make subclassing easier.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     install_requirements = [
         "vivarium>=2.0.0",
         "loguru",
-        "numpy",
+        "numpy<2.0.0",
         "pandas",
         "scipy",
         "tables",


### PR DESCRIPTION
## Mic-5121/Pin numpy below 2.0

### Pin numpy below 2.0 until we can move to major version at a later date.
- *Category*: Build
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5121

### Changes and notes
-Pin numpy below 2.0

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

