### PR TITLE
refactor distribution components to remove references to setup_component

### DIFF
--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -12,9 +12,11 @@ py:class pandas.core.generic.PandasObject
 # layered-config-tree
 py:class layered_config_tree.main.LayeredConfigTree
 
-# TODO: Need to revisit this. Nitpicking here to avoid failing builds on 3.8 and 3.9 in LBWSGRisk
+# TODO: Need to revisit this. Nitpicking here to avoid failing builds on 3.9 in LBWSGRisk
 py:class PopulationView
 py:class Logger
+py:class pd.DataFrame
+py:class LayeredConfigTree
 # TODO: Need to revisit this. Nitpicking here to avoid failing everywhere
 py:class Builder
 py:class SimulantData

--- a/src/vivarium_public_health/risks/base_risk.py
+++ b/src/vivarium_public_health/risks/base_risk.py
@@ -153,16 +153,22 @@ class Risk(Component):
         self.propensity_pipeline_name = f"{self.risk.name}.propensity"
         self.exposure_pipeline_name = f"{self.risk.name}.exposure"
 
-    # noinspection PyAttributeOutsideInit
-    def setup_component(self, builder: "Builder") -> None:
-        self.configuration = builder.configuration[self.name]
-        self.distribution_type = self.get_distribution_type(builder)
-        self.exposure_distribution = self.get_exposure_distribution(builder)
-        super().setup_component(builder)
-
     #################
     # Setup methods #
     #################
+
+    def build_all_lookup_tables(self, builder: "Builder") -> None:
+        # All lookup tables are built in the exposure distribution
+        pass
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder) -> None:
+        self.distribution_type = self.get_distribution_type(builder)
+        self.exposure_distribution = self.get_exposure_distribution(builder)
+
+        self.randomness = self.get_randomness_stream(builder)
+        self.propensity = self.get_propensity_pipeline(builder)
+        self.exposure = self.get_exposure_pipeline(builder)
 
     def get_distribution_type(self, builder: Builder) -> str:
         """
@@ -228,16 +234,6 @@ class Risk(Component):
 
         exposure_distribution.setup_component(builder)
         return exposure_distribution
-
-    def build_all_lookup_tables(self, builder: "Builder") -> None:
-        # All lookup tables are built in the exposure distribution
-        pass
-
-    # noinspection PyAttributeOutsideInit
-    def setup(self, builder: Builder) -> None:
-        self.randomness = self.get_randomness_stream(builder)
-        self.propensity = self.get_propensity_pipeline(builder)
-        self.exposure = self.get_exposure_pipeline(builder)
 
     def get_randomness_stream(self, builder: Builder) -> RandomnessStream:
         return builder.randomness.get_stream(self.randomness_stream_name)

--- a/src/vivarium_public_health/risks/data_transformations.py
+++ b/src/vivarium_public_health/risks/data_transformations.py
@@ -117,32 +117,6 @@ def load_exposure_data(builder: Builder, risk: EntityString) -> pd.DataFrame:
     )
 
 
-def get_exposure_standard_deviation_data(
-    builder: Builder, risk: EntityString, distribution_type: str
-) -> Union[pd.DataFrame, None]:
-    if distribution_type not in ["normal", "lognormal", "ensemble"]:
-        return None
-    data_source = builder.configuration[risk]["data_sources"]["exposure_standard_deviation"]
-    return builder.data.load(data_source)
-
-
-def get_exposure_distribution_weights(
-    builder: Builder, risk: EntityString, distribution_type: str
-) -> Union[Tuple[pd.DataFrame, List[str]], None]:
-    if distribution_type != "ensemble":
-        return None
-
-    data_source = builder.configuration[risk]["data_sources"]["ensemble_distribution_weights"]
-    weights = builder.data.load(data_source)
-    weights, distributions = pivot_categorical(builder, risk, weights)
-    if "glnorm" in weights.columns:
-        if np.any(weights["glnorm"]):
-            raise NotImplementedError("glnorm distribution is not supported")
-        weights = weights.drop(columns=["glnorm"])
-        distributions.remove("glnorm")
-    return weights, distributions
-
-
 def rebin_exposure_data(builder, risk: EntityString, exposure_data: pd.DataFrame):
     validate_rebin_source(builder, risk, exposure_data)
     rebin_exposed_categories = set(builder.configuration[risk]["rebinned_exposed"])

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -69,25 +69,6 @@ class RiskExposureDistribution(Component, ABC):
     def get_exposure_parameter_pipeline(self, builder: Builder) -> Pipeline:
         raise NotImplementedError
 
-    ##############
-    # Validators #
-    ##############
-
-    def validate_distribution_data_source(self) -> None:
-        """Checks that the exposure distribution specification is valid."""
-        # todo some of these validations are distribution specific
-        if self.risk.type == "alternative_risk_factor":
-            if self.configuration["rebinned_exposed"]:
-                raise ValueError(
-                    "Parameterized risk components are not available for alternative risks."
-                )
-
-            if not self.configuration["category_thresholds"]:
-                raise ValueError("Must specify category thresholds to use alternative risks.")
-
-        elif self.risk.type not in ["risk_factor", "coverage_gap"]:
-            raise ValueError(f"Unknown risk type {self.risk.type} for risk {self.risk.name}")
-
     ##################
     # Public methods #
     ##################

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -122,6 +122,7 @@ class EnsembleDistribution(RiskExposureDistribution):
     # Lifecycle methods #
     #####################
 
+    # todo shouldn't distribution type not be an argument?
     def __init__(self, risk: EntityString, distribution_type: str = "ensemble") -> None:
         super().__init__(risk, distribution_type)
         self._propensity = f"ensemble_propensity_{self.risk}"

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -34,10 +34,16 @@ class RiskExposureDistribution(Component, ABC):
     # Lifecycle methods #
     #####################
 
-    def __init__(self, risk: EntityString, distribution_type: str) -> None:
+    def __init__(
+        self,
+        risk: EntityString,
+        distribution_type: str,
+        exposure_data: Optional[Union[int, float, pd.DataFrame]] = None,
+    ) -> None:
         super().__init__()
         self.risk = risk
         self.distribution_type = distribution_type
+        self._exposure_data = exposure_data
 
         self.parameters_pipeline_name = f"{self.risk}.exposure_parameters"
 
@@ -53,6 +59,8 @@ class RiskExposureDistribution(Component, ABC):
         raise NotImplementedError
 
     def get_exposure_data(self, builder: Builder) -> Union[int, float, pd.DataFrame]:
+        if self._exposure_data is not None:
+            return self._exposure_data
         return self.get_data(builder, self.configuration["data_sources"]["exposure"])
 
     # noinspection PyAttributeOutsideInit


### PR DESCRIPTION
## Refactor distribution components to remove references to setup_component
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5099

### Changes and notes
- Refactor to make it so that no risk components need to override the `setup_component` method.

### Testing
Automated tests pass