### PR TITLE
Mic-5108/Bugfix/sort categories

### DIFF
--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -129,7 +129,7 @@ class EnsembleDistribution(RiskExposureDistribution):
             raise NotImplementedError("glnorm distribution is not supported")
         raw_weights = raw_weights[~glnorm_mask]
 
-        distributions = list(raw_weights["parameter"].unique())
+        distributions = sorted(list(raw_weights["parameter"].unique()))
 
         raw_weights = pivot_categorical(
             builder, self.risk, raw_weights, pivot_column="parameter", reset_index=False
@@ -287,7 +287,7 @@ class PolytomousDistribution(RiskExposureDistribution):
         self, exposure_data: Union[int, float, pd.DataFrame]
     ) -> Optional[List[str]]:
         if isinstance(exposure_data, pd.DataFrame):
-            return list(exposure_data["parameter"].unique())
+            return sorted(list(exposure_data["parameter"].unique()))
         return None
 
     def get_exposure_parameter_pipeline(self, builder: Builder) -> Pipeline:

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -266,7 +266,7 @@ class ContinuousDistribution(RiskExposureDistribution):
 class PolytomousDistribution(RiskExposureDistribution):
     @property
     def categories(self) -> List[str]:
-        return self.lookup_tables["exposure"].value_columns
+        return sorted(self.lookup_tables["exposure"].value_columns)
 
     #################
     # Setup methods #

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -129,7 +129,7 @@ class EnsembleDistribution(RiskExposureDistribution):
             raise NotImplementedError("glnorm distribution is not supported")
         raw_weights = raw_weights[~glnorm_mask]
 
-        distributions = sorted(list(raw_weights["parameter"].unique()))
+        distributions = list(raw_weights["parameter"].unique())
 
         raw_weights = pivot_categorical(
             builder, self.risk, raw_weights, pivot_column="parameter", reset_index=False
@@ -287,7 +287,7 @@ class PolytomousDistribution(RiskExposureDistribution):
         self, exposure_data: Union[int, float, pd.DataFrame]
     ) -> Optional[List[str]]:
         if isinstance(exposure_data, pd.DataFrame):
-            return sorted(list(exposure_data["parameter"].unique()))
+            return list(exposure_data["parameter"].unique())
         return None
 
     def get_exposure_parameter_pipeline(self, builder: Builder) -> Pipeline:

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -266,6 +266,8 @@ class ContinuousDistribution(RiskExposureDistribution):
 class PolytomousDistribution(RiskExposureDistribution):
     @property
     def categories(self) -> List[str]:
+        # These need to be sorted so the cumulative sum is in the ocrrect order of categories
+        # and results are therefore reproducible and correct
         return sorted(self.lookup_tables["exposure"].value_columns)
 
     #################


### PR DESCRIPTION
## Mic-5108/Bugfix/sort categories

### Fixes bug where categories of risks were not being sorted correctly resulting in results that could not be reproduced.
- *Category*: Bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5108

### Changes and notes
-correctly sorts risk categories so results can be reproduced

### Testing
Ran two simulations back to back and output.hdf matched between both simulations.

