### PR TITLE
Bugfix/sbachmei/transition names to str

### DIFF
--- a/src/vivarium_public_health/results/__init__.py
+++ b/src/vivarium_public_health/results/__init__.py
@@ -1,3 +1,4 @@
+from .columns import COLUMNS
 from .disability import DisabilityObserver
 from .disease import DiseaseObserver
 from .mortality import MortalityObserver

--- a/src/vivarium_public_health/results/disease.py
+++ b/src/vivarium_public_health/results/disease.py
@@ -99,10 +99,10 @@ class DiseaseObserver(PublicHealthObserver):
             [state.state_id for state in self.disease_model.states],
             requires_columns=[self.disease],
         )
-
+        transitions = [str(transition) for transition in self.disease_model.transition_names]
         builder.results.register_stratification(
             self.transition_stratification_name,
-            categories=self.disease_model.transition_names + ["no_transition"],
+            categories=transitions + ["no_transition"],
             mapper=self.map_transitions,
             requires_columns=[self.disease, self.previous_state_column_name],
             is_vectorized=True,

--- a/src/vivarium_public_health/results/mortality.py
+++ b/src/vivarium_public_health/results/mortality.py
@@ -99,21 +99,21 @@ class MortalityObserver(PublicHealthObserver):
             )
             if cause.has_excess_mortality
         ]
-        self.causes_to_stratify = [cause.state_id for cause in self.causes_of_death] + [
-            "not_dead",
-            "other_causes",
-        ]
 
     def register_observations(self, builder: Builder) -> None:
         pop_filter = 'alive == "dead" and tracked == True'
         additional_stratifications = self.config.include
         if not self.config.aggregate:
-            additional_stratifications += ["cause_of_death"]
+            stratification_categories = [cause.state_id for cause in self.causes_of_death] + [
+                "not_dead",
+                "other_causes",
+            ]
             builder.results.register_stratification(
                 "cause_of_death",
-                self.causes_to_stratify,
+                stratification_categories,
                 requires_columns=["cause_of_death"],
             )
+            additional_stratifications += ["cause_of_death"]
         self.register_adding_observation(
             builder=builder,
             name="deaths",

--- a/tests/results/test_disability_observer.py
+++ b/tests/results/test_disability_observer.py
@@ -7,8 +7,6 @@ from vivarium import InteractiveContext
 from vivarium.testing_utilities import TestPopulation
 
 from tests.test_utilities import build_table_with_age
-from vivarium.testing_utilities import TestPopulation
-
 from vivarium_public_health.disease import (
     DiseaseModel,
     DiseaseState,

--- a/tests/results/test_disability_observer.py
+++ b/tests/results/test_disability_observer.py
@@ -41,6 +41,7 @@ def test_disability_observer_setup(mocker):
     observer = DisabilityObserver_()
     builder = mocker.Mock()
     mocker.patch("vivarium.component.Component.build_all_lookup_tables")
+    mocker.patch("vivarium.component.Component.get_configuration")
     builder.results.register_adding_observation = mocker.Mock()
     builder.configuration.time.step_size = 28
     builder.configuration.output_data.results_directory = "some/results/directory"

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,11 +1,9 @@
 from itertools import product
+from pathlib import Path
 from typing import Any, Dict, List
 
 import hypothesis.strategies as st
 import numpy as np
-from pathlib import Path
-
-import hypothesis.strategies as st
 import pandas as pd
 import pytest
 from hypothesis import given

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,5 +1,4 @@
 from itertools import product
-from pathlib import Path
 from typing import Any, Dict, List
 
 import hypothesis.strategies as st


### PR DESCRIPTION
## Coerce transition names to str

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
We found that when using psimulate, we were getting a runtime error
when deserializing. It seems that the DiseaseObserver categories
(which were TransitionSTrings) were getting instantiated again
using their repr which causes an error - see https://jira.ihme.washington.edu/browse/MIC-5149


### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Ran a small psimulate with the mnch maternal model
