### PR TITLE
wrap the stratification and observation registrations in DiseaseObserver

### DIFF
--- a/src/vivarium_public_health/results/disease.py
+++ b/src/vivarium_public_health/results/disease.py
@@ -94,11 +94,21 @@ class DiseaseObserver(PublicHealthObserver):
 
     def register_observations(self, builder: Builder) -> None:
 
+        self.register_disease_state_stratification(builder)
+        self.register_transition_stratification(builder)
+
+        pop_filter = 'alive == "alive" and tracked==True'
+        self.register_person_time_observation(builder, pop_filter)
+        self.register_transition_count_observation(builder, pop_filter)
+
+    def register_disease_state_stratification(self, builder: Builder) -> None:
         builder.results.register_stratification(
             self.disease,
             [state.state_id for state in self.disease_model.states],
             requires_columns=[self.disease],
         )
+
+    def register_transition_stratification(self, builder: Builder) -> None:
         transitions = [str(transition) for transition in self.disease_model.transition_names]
         builder.results.register_stratification(
             self.transition_stratification_name,
@@ -108,8 +118,7 @@ class DiseaseObserver(PublicHealthObserver):
             is_vectorized=True,
         )
 
-        pop_filter = 'alive == "alive" and tracked==True'
-
+    def register_person_time_observation(self, builder: Builder, pop_filter: str) -> None:
         self.register_adding_observation(
             builder=builder,
             name=f"person_time_{self.disease}",
@@ -121,6 +130,9 @@ class DiseaseObserver(PublicHealthObserver):
             aggregator=self.aggregate_state_person_time,
         )
 
+    def register_transition_count_observation(
+        self, builder: Builder, pop_filter: str
+    ) -> None:
         self.register_adding_observation(
             builder=builder,
             name=f"transition_count_{self.disease}",


### PR DESCRIPTION
## Wrap DiseaseObserver stratification and observation registrations
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> refactor
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
DiseaseObserver is a bit messy b/c the single observer registers two
new stratifications and two new observations (ideally each observer
registers one of each only - and often no new stratifications)

this PR simply wraps each registration to make it easier to
inherit and modify as needed.

(I did NOT do this w/ the other classes b/c they are not as complicated
and so to modify you can just modify the entire `register_observations`
abstract method.)

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
ran psimulate on mnch child model
