### PR TITLE
build non log linear RR lookup table

### DIFF
--- a/src/vivarium_public_health/risks/__init__.py
+++ b/src/vivarium_public_health/risks/__init__.py
@@ -1,5 +1,5 @@
 from .base_risk import Risk
-from .effect import RiskEffect, NonLogLinearRiskEffect
+from .effect import NonLogLinearRiskEffect, RiskEffect
 from .implementations.low_birth_weight_and_short_gestation import (
     LBWSGDistribution,
     LBWSGRisk,

--- a/src/vivarium_public_health/risks/__init__.py
+++ b/src/vivarium_public_health/risks/__init__.py
@@ -1,5 +1,5 @@
 from .base_risk import Risk
-from .effect import RiskEffect
+from .effect import RiskEffect, NonLogLinearRiskEffect
 from .implementations.low_birth_weight_and_short_gestation import (
     LBWSGDistribution,
     LBWSGRisk,

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -481,8 +481,8 @@ def get_risk_distribution_parameter(
                 "Expected a single value column for risk data, but found "
                 f"{len(value_columns)}: {value_columns}."
             )
-        if 'parameter' in data.columns and set(data['parameter']) == {'continuous'}:
-            data = data.drop('parameter', axis=1)
+        if "parameter" in data.columns and set(data["parameter"]) == {"continuous"}:
+            data = data.drop("parameter", axis=1)
         index = [col for col in data.columns if col not in value_columns]
         data = data.set_index(index)[value_columns].squeeze(axis=1)
 

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -481,6 +481,8 @@ def get_risk_distribution_parameter(
                 "Expected a single value column for risk data, but found "
                 f"{len(value_columns)}: {value_columns}."
             )
+        if 'parameter' in data.columns and set(data['parameter']) == {'continuous'}:
+            data = data.drop('parameter', axis=1)
         index = [col for col in data.columns if col not in value_columns]
         data = data.set_index(index)[value_columns].squeeze(axis=1)
 

--- a/src/vivarium_public_health/risks/distributions.py
+++ b/src/vivarium_public_health/risks/distributions.py
@@ -481,6 +481,8 @@ def get_risk_distribution_parameter(
                 "Expected a single value column for risk data, but found "
                 f"{len(value_columns)}: {value_columns}."
             )
+        # don't return parameter col in continuous and ensemble distribution
+        # means to match standard deviation index
         if "parameter" in data.columns and set(data["parameter"]) == {"continuous"}:
             data = data.drop("parameter", axis=1)
         index = [col for col in data.columns if col not in value_columns]

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -344,7 +344,6 @@ class NonLogLinearRiskEffect(RiskEffect):
 
     def build_all_lookup_tables(self, builder: Builder) -> None:
         rr_data = self.get_relative_risk_data(builder)
-
         # check that rr_data is parametrize by exposure
         #rr_value_cols = [rr_col_1, rr_col_2, exposure_col_1, exposure_col_2]
         new_row = rr_data.tail(1).copy()
@@ -354,7 +353,7 @@ class NonLogLinearRiskEffect(RiskEffect):
         rr_data['left_rr'] = [rr_data['value'].min()] + rr_data['value'][:-1].tolist()
         rr_data['right_exposure'] = rr_data['parameter']
         rr_data['right_rr'] = rr_data['value']
-        import pdb; pdb.set_trace()
+
         self.lookup_tables["relative_risk"] = self.build_lookup_table(
             builder, rr_data, rr_value_cols
         )
@@ -407,6 +406,7 @@ class NonLogLinearRiskEffect(RiskEffect):
         rr_data = original_rrs.merge(rrs_at_tmrel.reset_index())
         rr_data['value'] = rr_data['value'] / rr_data['rr_at_tmrel']
         rr_data['value'] = np.clip(rr_data['value'], 1.0, np.inf)
+        rr_data = rr_data.drop('rr_at_tmrel', axis=1)
 
         return rr_data
 

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -406,13 +406,12 @@ class NonLogLinearRiskEffect(RiskEffect):
             builder, rr_data, rr_value_cols
         )
 
-        # paf_data = self.get_filtered_data(
-        #    builder, self.configuration.data_sources.population_attributable_fraction
-        # )
-        # self.lookup_tables["population_attributable_fraction"] = self.build_lookup_table(
-        #    builder, paf_data
-        # )
-        self.lookup_tables["population_attributable_fraction"] = builder.lookup.build_table(1)
+        paf_data = self.get_filtered_data(
+           builder, self.configuration.data_sources.population_attributable_fraction
+        )
+        self.lookup_tables["population_attributable_fraction"] = self.build_lookup_table(
+           builder, paf_data
+        )
 
     def get_relative_risk_data(
         self,

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -407,10 +407,10 @@ class NonLogLinearRiskEffect(RiskEffect):
         )
 
         paf_data = self.get_filtered_data(
-           builder, self.configuration.data_sources.population_attributable_fraction
+            builder, self.configuration.data_sources.population_attributable_fraction
         )
         self.lookup_tables["population_attributable_fraction"] = self.build_lookup_table(
-           builder, paf_data
+            builder, paf_data
         )
 
     def get_relative_risk_data(


### PR DESCRIPTION
## build non log linear RR lookup table

### Description
- *Category*: feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5161

### Changes and notes
Subclass risk effect to non log linear risk effect.
Initialize and define exposure column.
Build lookup table which 
 1) gets TMREL from artifact
 2) takes RR data from artifact, linearly interpolates over this data and evaluates at TMREL
 3) divide RR data from artifact by RR at TMREL and clips to be greater than 1
 3) returns exposure and RR points at the endpoints of the bin containing simulant exposure 

### Testing
Added diet high in sodium to child nutrition model repo and put in breakpoint to check that correct endpoints were returned given simulant exposure.
