### PR TITLE
nonloglinear risk effect initialization bugfix

### DIFF
--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -354,7 +354,7 @@ class NonLogLinearRiskEffect(RiskEffect):
     #####################
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
-        exposure_col = pd.DataFrame(columns=self.columns_created)
+        exposure_col = pd.DataFrame(columns=self.columns_created, index=pop_data.index)
         self.population_view.update(exposure_col)
 
     def on_time_step_prepare(self, event: Event) -> None:


### PR DESCRIPTION
## nonloglinear risk effect initialization bugfix

### Description
- *Category*: bugfix
- *JIRA issue*: hotfix

### Changes and notes
Add index when defining initial exposure column.

### Testing
Ran sim for a few time steps in an interactive context.

