### PR TITLE
don't install vivarium inside vph package directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,10 +82,11 @@ jobs:
         if: env.vivarium_branch_name != 'main'
         run: |
           echo "Cloning upstream branch: ${vivarium_branch_name}"
+          pushd ..
           git clone --branch=${vivarium_branch_name} https://github.com/ihmeuw/vivarium.git
           pushd vivarium
           pip install .
-          popd
+          popd && popd
       - name: Lint
         run: |
           pip install black==22.3.0 isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,6 @@
 [tool.black]
 line_length = 94
-exclude = '''
-/(
-   vivarium
-)/
-
-'''
 
 [tool.isort]
 profile = "black"
-skip = ["vivarium"]
 known_third_party = ["vivarium"]


### PR DESCRIPTION
## Don't install vivarium inside vph package directory
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: CI/infrastructure
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5209

### Changes and notes
- Don't install vivarium inside vph package directory 

### Testing
CI works with upstream vivarium branch

