### PR TITLE
fix bug in build script when the upstream vivarium branch should be main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,38 +43,7 @@ jobs:
           git checkout ${branch_name}
       - name: check for upstream branch
         run: |
-          vivarium_branch_name='main'
-          branch_name_to_check=${branch_name}
-          iterations=0
-          while [ "$branch_name_to_check" != "$vivarium_branch_name" ]
-          do
-            echo "Checking for vivarium branch: ${branch_name_to_check}"
-            if [ $iterations -gt 20 ]; then
-              echo "Could not find upstream branch"
-              exit 1
-            fi
-            if
-              git ls-remote --exit-code \
-              --heads https://github.com/ihmeuw/vivarium.git ${branch_name_to_check} == "0"
-            then
-              vivarium_branch_name=${branch_name_to_check}
-              echo "Found matching branch: ${vivarium_branch_name}"
-              echo "vivarium_branch_name=${branch_name_to_check}" >> $GITHUB_ENV
-            else
-              branch_name_to_check="$( \
-                git show-branch -a \
-                | grep '\*' \
-                | grep -v `git rev-parse --abbrev-ref HEAD` \
-                | head -n1 \
-                | sed 's/[^\[]*//' \
-                | awk 'match($0, /\[[a-zA-Z0-9\/.-]+\]/) { print substr( $0, RSTART+1, RLENGTH-2 )}' \
-                | sed 's/^origin\///' \
-              )"
-              git checkout ${branch_name_to_check}
-              iterations=$((iterations+1))
-            fi
-          done
-          git checkout ${branch_name}
+          sh get_upstream_branch.sh ${branch_name}
       - name: print environment values
         run: |
           cat $GITHUB_ENV

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**3.0.1 - 08/16/24**
+**3.0.1 - 08/19/24**
 
  - Fix bug in build script when the upstream vivarium branch should be main
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.0.1 - 08/16/24**
+
+ - Fix bug in build script when the upstream vivarium branch should be main
+
 **3.0.0 - 08/13/24**
 
 Breaking changes:

--- a/get_upstream_branch.sh
+++ b/get_upstream_branch.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Define variables
+branch_name=$1
+
+vivarium_branch_name='main'
+branch_name_to_check=${branch_name}
+iterations=0
+
+while [ "$branch_name_to_check" != "$vivarium_branch_name" ] && [ $iterations -lt 20 ]
+do
+  echo "Checking for vivarium branch: '${branch_name_to_check}'"
+  if
+    git ls-remote --exit-code \
+    --heads https://github.com/ihmeuw/vivarium.git ${branch_name_to_check} == "0"
+  then
+    vivarium_branch_name=${branch_name_to_check}
+    echo "Found matching branch: ${vivarium_branch_name}"
+  else
+    echo "Could not find upstream branch '${branch_name_to_check}'. Finding parent branch."
+    branch_name_to_check="$( \
+      git show-branch -a \
+      | grep '\*' \
+      | grep -v `git rev-parse --abbrev-ref HEAD` \
+      | head -n1 \
+      | sed 's/[^\[]*//' \
+      | awk 'match($0, /\[[a-zA-Z0-9\/.-]+\]/) { print substr( $0, RSTART+1, RLENGTH-2 )}' \
+      | sed 's/^origin\///' \
+    )"
+    if [ -z "$branch_name_to_check" ]; then
+      echo "Could not find upstream branch. Will use released version."
+      branch_name_to_check="main"
+    fi
+    echo "Checking out branch: ${branch_name_to_check}"
+    git checkout ${branch_name_to_check}
+    iterations=$((iterations+1))
+  fi
+  done
+  echo "vivarium_branch_name=${vivarium_branch_name}" >> $GITHUB_ENV
+  git checkout ${branch_name}


### PR DESCRIPTION
## Fix bug in build script when the upstream vivarium branch should be main
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: one of bugfix/CI/infrastructure
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5248

### Changes and notes
Fix bug in build script when the upstream vivarium branch should be main 

### Testing
CI passes in three cases
- the VPH branch being PRed exists on vivarium
- the parent of the VPH branch being PRed exists on vivarium
- neither branch exists