### PR TITLE
rr_source bugfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.0.6 - 09/04/24**
+
+ - Fix bug that was occurring when RiskEffect's rr_source was a float or DataFrame
+
 **3.0.5 - 08/29/24**
 
  - Add missing results module-level docstrings

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -201,8 +201,8 @@ class RiskEffect(Component):
             cat2["parameter"] = "cat2"
             cat2["value"] = 1
             rr_data = pd.concat([cat1, cat2], ignore_index=True)
-        if 'parameter' in rr_data.index.names:
-            rr_data = rr_data.reset_index('parameter')
+        if "parameter" in rr_data.index.names:
+            rr_data = rr_data.reset_index("parameter")
 
         rr_value_cols = list(rr_data["parameter"].unique())
         rr_data = pivot_categorical(builder, self.risk, rr_data, "parameter")

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -201,6 +201,8 @@ class RiskEffect(Component):
             cat2["parameter"] = "cat2"
             cat2["value"] = 1
             rr_data = pd.concat([cat1, cat2], ignore_index=True)
+        if 'parameter' in rr_data.index.names:
+            rr_data = rr_data.reset_index('parameter')
 
         rr_value_cols = list(rr_data["parameter"].unique())
         rr_data = pivot_categorical(builder, self.risk, rr_data, "parameter")

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -157,16 +157,19 @@ class RiskEffect(Component):
         rr_source = configuration.data_sources.relative_risk
         rr_dist_parameters = configuration.data_source_parameters.relative_risk.to_dict()
 
-        try:
-            distribution = getattr(import_module("scipy.stats"), rr_source)
-            rng = np.random.default_rng(builder.randomness.get_seed(self.name))
-            rr_data = distribution(**rr_dist_parameters).ppf(rng.random())
-        except AttributeError:
+        if isinstance(rr_source, str):
+            try:
+                distribution = getattr(import_module("scipy.stats"), rr_source)
+                rng = np.random.default_rng(builder.randomness.get_seed(self.name))
+                rr_data = distribution(**rr_dist_parameters).ppf(rng.random())
+            except AttributeError:
+                rr_data = self.get_filtered_data(builder, rr_source)
+            except TypeError:
+                raise ConfigurationError(
+                    f"Parameters {rr_dist_parameters} are not valid for distribution {rr_source}."
+                )
+        else:
             rr_data = self.get_filtered_data(builder, rr_source)
-        except TypeError:
-            raise ConfigurationError(
-                f"Parameters {rr_dist_parameters} are not valid for distribution {rr_source}."
-            )
         return rr_data
 
     def get_filtered_data(

--- a/tests/mock_artifact.py
+++ b/tests/mock_artifact.py
@@ -77,7 +77,7 @@ MOCKERS = {
     "population": {
         "age_bins": make_age_bins(),
         "structure": make_uniform_pop_data(),
-        "demographic_dimensions": make_uniform_pop_data().drop(['location','value'], axis=1),
+        "demographic_dimensions": make_uniform_pop_data().drop(["location", "value"], axis=1),
         "theoretical_minimum_risk_life_expectancy": (
             build_table_with_age(
                 98.0,

--- a/tests/mock_artifact.py
+++ b/tests/mock_artifact.py
@@ -77,6 +77,7 @@ MOCKERS = {
     "population": {
         "age_bins": make_age_bins(),
         "structure": make_uniform_pop_data(),
+        "demographic_dimensions": make_uniform_pop_data().drop(['location','value'], axis=1),
         "theoretical_minimum_risk_life_expectancy": (
             build_table_with_age(
                 98.0,

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -560,13 +560,13 @@ class CustomExposureRisk(Component):
 def test_non_loglinear_effect(rr_parameter_data, error_message, base_config, base_plugins):
     risk = CustomExposureRisk("risk_factor.test_risk")
     effect = NonLogLinearRiskEffect(
-        "risk_factor.test_risk", "cause.some_disease.incidence_rate"
+        risk.name, "cause.test_cause.incidence_rate"
     )
 
     risk_effect_rrs = [2.0, 2.4, 4.0]
     rr_data = pd.DataFrame(
         {
-            "affected_entity": "some_disease",
+            "affected_entity": "test_cause",
             "affected_measure": "incidence_rate",
             "year_start": 1990,
             "year_end": 1991,
@@ -581,7 +581,7 @@ def test_non_loglinear_effect(rr_parameter_data, error_message, base_config, bas
         f"{risk.name}.relative_risk": rr_data,
         f"{risk.name}.tmred": tmred,
         f"{risk.name}.population_attributable_fraction": 0,
-        "cause.some_disease.incidence_rate": 1,
+        "cause.test_cause.incidence_rate": 1,
     }
 
     base_config.update({"population": {"population_size": 10}})
@@ -598,7 +598,7 @@ def test_non_loglinear_effect(rr_parameter_data, error_message, base_config, bas
         )
 
     pop = simulation.get_population()
-    rate = simulation.get_value("some_disease.incidence_rate")(
+    rate = simulation.get_value("test_cause.incidence_rate")(
         pop.index, skip_post_processor=True
     )
     expected_values = np.interp(

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -468,7 +468,7 @@ def _setup_risk_effect_simulation(
     components = [
         TestPopulation(),
         risk,
-        SI("some_disease"),
+        SI("test_cause"),
         risk_effect,
     ]
 
@@ -545,11 +545,12 @@ def test_non_loglinear_effect(rr_parameter_data, error_message, base_config, bas
 
 
 @pytest.mark.parametrize(
-    "rr_source", ["str", "float", "DataFrame"],
+    "rr_source, rr_value", [("str", 2.0), ("float", 0.9), ("DataFrame", 0.5)],
 )
 def test_rr_sources(rr_source, dichotomous_risk, base_config, base_plugins):
-    risk = dichotomous_risk
-    effect = RiskEffect(risk.name, "cause.some_disease.incidence_rate")
+    risk = dichotomous_risk[0]
+    effect = RiskEffect(risk.name, "cause.test_cause.incidence_rate")
+    base_config.update({'risk_factor.test_risk': {'data_sources': {'exposure': 1.0}}})
 
     # TMREL of 1
     tmred = {"distribution": "uniform", "min": 1, "max": 1, "inverted": False}
@@ -557,34 +558,39 @@ def test_rr_sources(rr_source, dichotomous_risk, base_config, base_plugins):
     data = {
         f"{risk.name}.tmred": tmred,
         f"{risk.name}.population_attributable_fraction": 0,
-        "cause.some_disease.incidence_rate": 1,
+        "cause.test_cause.incidence_rate": 1,
     }
 
     if rr_source == "DataFrame":
         rr_data = pd.DataFrame(
             {
-                "affected_entity": "some_disease",
+                "affected_entity": "test_cause",
                 "affected_measure": "incidence_rate",
                 "year_start": 1990,
                 "year_end": 1991,
-                "value": [2.0, 1.0],
+                "value": [rr_value, 1.0],
             },
             index=pd.Index(["cat1", "cat2"], name="parameter"),
         )
-        base_config.update({'test_risk': {'data_sources': {'relative_risk': rr_data}}})
+        base_config.update({'risk_effect.test_risk_on_cause.test_cause.incidence_rate': {'data_sources': {'relative_risk': rr_data}}})
     elif rr_source == "float":
-        base_config.update({'test_risk': {'data_sources': {'relative_risk': 0.9}}})
+        base_config.update({'risk_effect.test_risk_on_cause.test_cause.incidence_rate': {'data_sources': {'relative_risk': rr_value}}})
     else: # rr_source is a string because it reads from RiskEffect's configuration defaults
         rr_data = pd.DataFrame(
             {
-                "affected_entity": "some_disease",
+                "affected_entity": "test_cause",
                 "affected_measure": "incidence_rate",
                 "year_start": 1990,
                 "year_end": 1991,
-                "value": [1.5, 1.0],
+                "value": [rr_value, 1.0],
             },
             index=pd.Index(["cat1", "cat2"], name="parameter"),
         )
         data[f"{risk.name}.relative_risk"] = rr_data
 
-    simulation = _setup_risk_effect_simulation(base_config, base_plugins, risk, data)
+    base_config.update({'risk_factor.test_risk': {'distribution_type': 'dichotomous'}})
+    simulation = _setup_risk_effect_simulation(base_config, base_plugins, risk, effect, data)
+
+    pop = simulation.get_population()
+    rate = simulation.get_value("test_cause.incidence_rate")(pop.index, skip_post_processor=True)
+    

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -413,7 +413,46 @@ from vivarium_public_health.utilities import EntityString
 #                                                   source=lambda index: pd.Series(0.1, index=index))
 #
 #     assert np.allclose(from_yearly(0.1, time_step)*50, em(simulation.get_population().index))
+def _setup_risk_effect_simulation(
+    config: LayeredConfigTree,
+    plugins: LayeredConfigTree,
+    risk: Union[str, Risk],
+    risk_effect: RiskEffect,
+    data: Dict[str, Any],
+) -> InteractiveContext:
+    components = [
+        TestPopulation(),
+        risk,
+        SI("test_cause"),
+        risk_effect,
+    ]
 
+    simulation = InteractiveContext(
+        components=components,
+        configuration=config,
+        plugin_configuration=plugins,
+        setup=False,
+    )
+
+    for key, value in data.items():
+        simulation._data.write(key, value)
+
+    simulation.setup()
+    return simulation
+
+
+def build_dichotomous_risk_effect_data(rr_value: float) -> pd.DataFrame:
+    df = pd.DataFrame(
+            {
+                "affected_entity": "test_cause",
+                "affected_measure": "incidence_rate",
+                "year_start": 1990,
+                "year_end": 1991,
+                "value": [rr_value, 1.0],
+            },
+            index=pd.Index(["cat1", "cat2"], name="parameter"),
+        )
+    return df
 
 ##############################
 # Non Log-Linear Risk Effect #
@@ -456,34 +495,6 @@ class CustomExposureRisk(Component):
     def get_exposure(self, index: pd.Index) -> pd.Series:
         data = pd.Series(custom_exposure_values, index=index)
         return data
-
-
-def _setup_risk_effect_simulation(
-    config: LayeredConfigTree,
-    plugins: LayeredConfigTree,
-    risk: Union[str, Risk],
-    risk_effect: RiskEffect,
-    data: Dict[str, Any],
-) -> InteractiveContext:
-    components = [
-        TestPopulation(),
-        risk,
-        SI("test_cause"),
-        risk_effect,
-    ]
-
-    simulation = InteractiveContext(
-        components=components,
-        configuration=config,
-        plugin_configuration=plugins,
-        setup=False,
-    )
-
-    for key, value in data.items():
-        simulation._data.write(key, value)
-
-    simulation.setup()
-    return simulation
 
 
 @pytest.mark.parametrize(
@@ -547,7 +558,7 @@ def test_non_loglinear_effect(rr_parameter_data, error_message, base_config, bas
 @pytest.mark.parametrize(
     "rr_source, rr_value", [("str", 2.0), ("float", 0.9), ("DataFrame", 0.5)],
 )
-def test_rr_sources(rr_source, dichotomous_risk, base_config, base_plugins):
+def test_rr_sources(rr_source, rr_value, dichotomous_risk, base_config, base_plugins):
     risk = dichotomous_risk[0]
     effect = RiskEffect(risk.name, "cause.test_cause.incidence_rate")
     base_config.update({'risk_factor.test_risk': {'data_sources': {'exposure': 1.0}}})
@@ -562,30 +573,12 @@ def test_rr_sources(rr_source, dichotomous_risk, base_config, base_plugins):
     }
 
     if rr_source == "DataFrame":
-        rr_data = pd.DataFrame(
-            {
-                "affected_entity": "test_cause",
-                "affected_measure": "incidence_rate",
-                "year_start": 1990,
-                "year_end": 1991,
-                "value": [rr_value, 1.0],
-            },
-            index=pd.Index(["cat1", "cat2"], name="parameter"),
-        )
+        rr_data = build_dichotomous_risk_effect_data(rr_value)
         base_config.update({'risk_effect.test_risk_on_cause.test_cause.incidence_rate': {'data_sources': {'relative_risk': rr_data}}})
     elif rr_source == "float":
         base_config.update({'risk_effect.test_risk_on_cause.test_cause.incidence_rate': {'data_sources': {'relative_risk': rr_value}}})
     else: # rr_source is a string because it reads from RiskEffect's configuration defaults
-        rr_data = pd.DataFrame(
-            {
-                "affected_entity": "test_cause",
-                "affected_measure": "incidence_rate",
-                "year_start": 1990,
-                "year_end": 1991,
-                "value": [rr_value, 1.0],
-            },
-            index=pd.Index(["cat1", "cat2"], name="parameter"),
-        )
+        rr_data = build_dichotomous_risk_effect_data(rr_value)
         data[f"{risk.name}.relative_risk"] = rr_data
 
     base_config.update({'risk_factor.test_risk': {'distribution_type': 'dichotomous'}})
@@ -593,4 +586,4 @@ def test_rr_sources(rr_source, dichotomous_risk, base_config, base_plugins):
 
     pop = simulation.get_population()
     rate = simulation.get_value("test_cause.incidence_rate")(pop.index, skip_post_processor=True)
-    
+    assert rate.unique()

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -586,4 +586,4 @@ def test_rr_sources(rr_source, rr_value, dichotomous_risk, base_config, base_plu
 
     pop = simulation.get_population()
     rate = simulation.get_value("test_cause.incidence_rate")(pop.index, skip_post_processor=True)
-    assert rate.unique()
+    assert set(rate.unique()) == {rr_value}

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -559,9 +559,7 @@ class CustomExposureRisk(Component):
 )
 def test_non_loglinear_effect(rr_parameter_data, error_message, base_config, base_plugins):
     risk = CustomExposureRisk("risk_factor.test_risk")
-    effect = NonLogLinearRiskEffect(
-        risk.name, "cause.test_cause.incidence_rate"
-    )
+    effect = NonLogLinearRiskEffect(risk.name, "cause.test_cause.incidence_rate")
 
     risk_effect_rrs = [2.0, 2.4, 4.0]
     rr_data = pd.DataFrame(

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -491,7 +491,7 @@ def test_rr_sources(rr_source, rr_value, dichotomous_risk, base_config, base_plu
                 }
             }
         )
-    else:  # rr_source is a string because it reads from RiskEffect's configuration defaults
+    else:  # rr_source is a string because it gets read from RiskEffect's configuration defaults
         rr_data = build_dichotomous_risk_effect_data(rr_value)
         data[f"{risk.name}.relative_risk"] = rr_data
 


### PR DESCRIPTION
## rr_source bugfix

### Description
fix bug when defining rr_source in RiskEffect
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5281

### Changes and notes
Only try getting relative risk data from a distribution when rr_source is a string. Otherwise (meaning rr_source is a float of dataframe) use get_filtered_data.
Move parameter from the index to columns when processing categorical data.
Add demographic dimensions key to mock artifact. 
Replace setup_risk_simulation with setup_risk_effect_simulation which is the same but uses a risk effect provided by the user instead of defaulting to NonLogLinearRiskEffect.
Add tests for when rr_source is a string, float, or DataFrame.

### Testing
Tests pass.