### PR TITLE
Bugfix/sbachmei/mic 5296 exposure column for nonloglinear risk effects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 **3.0.6 - 09/04/24**
 
  - Fix bug that was occurring when RiskEffect's rr_source was a float or DataFrame
+ - Better handle exposure column creation in Risk component
+ - Rename LBWSRisk 'exposure_column_name()' staticmethod to not collide with Risk attr
 
 **3.0.5 - 08/29/24**
 

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -366,6 +366,10 @@ class NonLogLinearRiskEffect(RiskEffect):
     # Setup methods #
     #################
 
+    @staticmethod
+    def get_name(risk: EntityString, target: TargetString) -> str:
+        return f"non_log_linear_risk_effect.{risk.name}_on_{target}"
+
     def build_all_lookup_tables(self, builder: Builder) -> None:
         rr_data = self.get_relative_risk_data(builder)
         self.validate_rr_data(rr_data)

--- a/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
+++ b/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
@@ -191,7 +191,7 @@ class LBWSGRisk(Risk):
         return f"{axis}.birth_exposure"
 
     @staticmethod
-    def exposure_column_name(axis: str) -> str:
+    def get_exposure_column_name(axis: str) -> str:
         return f"{axis}_exposure"
 
     ##############
@@ -206,7 +206,7 @@ class LBWSGRisk(Risk):
 
     @property
     def columns_created(self) -> List[str]:
-        return [self.exposure_column_name(axis) for axis in self.AXES]
+        return [self.get_exposure_column_name(axis) for axis in self.AXES]
 
     #####################
     # Lifecycle methods #
@@ -256,7 +256,7 @@ class LBWSGRisk(Risk):
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         birth_exposures = {
-            self.exposure_column_name(axis): self.birth_exposures[
+            self.get_exposure_column_name(axis): self.birth_exposures[
                 self.birth_exposure_pipeline_name(axis)
             ](pop_data.index)
             for axis in self.AXES
@@ -318,7 +318,7 @@ class LBWSGRiskEffect(RiskEffect):
         super().__init__("risk_factor.low_birth_weight_and_short_gestation", target)
 
         self.lbwsg_exposure_column_names = [
-            LBWSGRisk.exposure_column_name(axis) for axis in LBWSGRisk.AXES
+            LBWSGRisk.get_exposure_column_name(axis) for axis in LBWSGRisk.AXES
         ]
         self.relative_risk_pipeline_name = (
             f"effect_of_{self.risk.name}_on_{self.target.name}.relative_risk"
@@ -433,8 +433,8 @@ class LBWSGRiskEffect(RiskEffect):
         pop = self.population_view.subview(["sex"] + self.lbwsg_exposure_column_names).get(
             pop_data.index
         )
-        birth_weight = pop[LBWSGRisk.exposure_column_name(BIRTH_WEIGHT)]
-        gestational_age = pop[LBWSGRisk.exposure_column_name(GESTATIONAL_AGE)]
+        birth_weight = pop[LBWSGRisk.get_exposure_column_name(BIRTH_WEIGHT)]
+        gestational_age = pop[LBWSGRisk.get_exposure_column_name(GESTATIONAL_AGE)]
 
         is_male = pop["sex"] == "Male"
         is_tmrel = (self.TMREL_GESTATIONAL_AGE_INTERVAL.left <= gestational_age) & (


### PR DESCRIPTION
## Better handle exposure column creation

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5296

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> The mnch maternal model started breaking. There were two issues
1. the LBWSG `exposure_column_name` staticmethod was colliding with
  the super Risk `exposure_column_name` attr. Renamed it.
2. We were creating the exposure column for every single Risk when in
  reality we only want them for Risks with NonLogLinearRiskEffects. This was
  somehow causing an issue of requiring the column in some instances where
  it didn't yet exist. Here we add logic to better handle that.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Ran a few time steps on the mnch child model (no NonLogLinearRiskEffects)
as well as a simplified version of the sodium intake model that _does_
include some NonLogLinearRiskEffects.