### PR TITLE
fix broken test due to population_view setter restrictions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.0.8 - 09/12/24**
+
+ - Fix broken tests in RiskAttributableDisease due to changes in how to set population_view
+
 **3.0.7 - 09/10/24**
 
  - Properly create the population_view in RateTransition

--- a/tests/disease/test_special_disease.py
+++ b/tests/disease/test_special_disease.py
@@ -13,7 +13,7 @@ def disease_mock(mocker):
     def disease_with_distribution(distribution):
         test_disease = RiskAttributableDisease("cause.test_cause", "risk_factor.test_risk")
         test_disease.distribution = distribution
-        test_disease.population_view = mocker.Mock()
+        test_disease._population_view = mocker.Mock()
         test_disease.excess_mortality_rate = mocker.Mock()
         return test_disease
 


### PR DESCRIPTION
## Fix broken test due to population_view setter restrictions
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-8329

### Changes and notes
Properly set population view in test 

### Testing
Tests pass