### PR TITLE
use callables in lookup table data config defaults

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.1.1 - 11/12/24**
+
+ - Refactor: Use callables rather than strings to define lookup table builders
+
 **3.1.0 - 11/07/24**
 
  - Drop support for python 3.9

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -11,6 +11,7 @@ py:class pandas.core.series.Series
 py:class pandas.core.generic.PandasObject
 # layered-config-tree
 py:class layered_config_tree.main.LayeredConfigTree
+py:class vivarium.framework.values.pipeline.Pipeline
 
 # TODO: Need to revisit this. Nitpicking here to avoid failing builds on 3.9 in LBWSGRisk
 py:class PopulationView
@@ -22,4 +23,3 @@ py:class Builder
 py:class SimulantData
 py:class Event
 py:class LookupTable
-py:class Pipeline

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
         long_description = f.read()
 
     install_requirements = [
-        "vivarium>=3.0.3",
+        "vivarium>=3.2.0",
         "layered_config_tree>=1.0.1",
         "loguru",
         "numpy<2.0.0",

--- a/src/vivarium_public_health/disease/model.py
+++ b/src/vivarium_public_health/disease/model.py
@@ -38,7 +38,7 @@ class DiseaseModel(Machine):
         return {
             f"{self.name}": {
                 "data_sources": {
-                    "cause_specific_mortality_rate": "self::load_cause_specific_mortality_rate"
+                    "cause_specific_mortality_rate": self.load_cause_specific_mortality_rate,
                 },
             },
         }

--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 from vivarium import Component
-from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import SimulantData
 from vivarium.framework.values import list_combiner, union_post_processor
@@ -101,8 +100,8 @@ class RiskAttributableDisease(Component):
             self.name: {
                 "data_sources": {
                     "raw_disability_weight": f"{self.cause}.disability_weight",
-                    "cause_specific_mortality_rate": "self::load_cause_specific_mortality_rate_data",
-                    "excess_mortality_rate": "self::load_excess_mortality_rate_data",
+                    "cause_specific_mortality_rate": self.load_cause_specific_mortality_rate_data,
+                    "excess_mortality_rate": self.load_excess_mortality_rate_data,
                     "population_attributable_fraction": 0,
                 },
                 "threshold": None,

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -282,11 +282,11 @@ class DiseaseState(BaseDiseaseState):
         return {
             f"{self.name}": {
                 "data_sources": {
-                    "prevalence": "self::load_prevalence",
-                    "birth_prevalence": "self::load_birth_prevalence",
-                    "dwell_time": "self::load_dwell_time",
-                    "disability_weight": "self::load_disability_weight",
-                    "excess_mortality_rate": "self::load_excess_mortality_rate",
+                    "prevalence": self.load_prevalence,
+                    "birth_prevalence": self.load_birth_prevalence,
+                    "dwell_time": self.load_dwell_time,
+                    "disability_weight": self.load_disability_weight,
+                    "excess_mortality_rate": self.load_excess_mortality_rate,
                 },
             },
         }

--- a/src/vivarium_public_health/disease/transition.py
+++ b/src/vivarium_public_health/disease/transition.py
@@ -43,7 +43,7 @@ class RateTransition(Transition):
         return {
             f"{self.name}": {
                 "data_sources": {
-                    "transition_rate": "self::load_transition_rate",
+                    "transition_rate": self.load_transition_rate,
                 },
             },
         }
@@ -156,7 +156,7 @@ class ProportionTransition(Transition):
         return {
             f"{self.name}": {
                 "data_sources": {
-                    "proportion": "self::load_proportion",
+                    "proportion": self.load_proportion,
                 },
             },
         }

--- a/src/vivarium_public_health/population/mortality.py
+++ b/src/vivarium_public_health/population/mortality.py
@@ -105,7 +105,7 @@ class Mortality(Component):
             "mortality": {
                 "data_sources": {
                     "all_cause_mortality_rate": "cause.all_causes.cause_specific_mortality_rate",
-                    "unmodeled_cause_specific_mortality_rate": "self::load_unmodeled_csmr",
+                    "unmodeled_cause_specific_mortality_rate": self.load_unmodeled_csmr,
                     "life_expectancy": "population.theoretical_minimum_risk_life_expectancy",
                 },
                 "unmodeled_causes": [],


### PR DESCRIPTION
## Use callables in lookup table data config defaults
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5551

### Changes and notes
- Use callables instead of strings to define lookup table builders

Note: this should wait until vivarium is merged, so I can set a lower bound pin.

### Testing
All tests pass
Jenkins failures are due to requiring an unreleased version of vivarium
