### PR TITLE
rely on Machine's on_time_step and on_time_step_cleanup method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.1.2 - 11/13/24**
+
+ - Refactor: Update DiseaseModel to rely on Machine's time-step and time-step-cleanup methods
+
 **3.1.1 - 11/12/24**
 
  - Feature: Rename DiseaseModel initial_state to residual_state

--- a/src/vivarium_public_health/disease/model.py
+++ b/src/vivarium_public_health/disease/model.py
@@ -200,12 +200,6 @@ class DiseaseModel(Machine):
             )
         self.population_view.update(condition_column)
 
-    def on_time_step(self, event: Event) -> None:
-        self.transition(event.index, event.time)
-
-    def on_time_step_cleanup(self, event: Event) -> None:
-        self.cleanup(event.index, event.time)
-
     ##################################
     # Pipeline sources and modifiers #
     ##################################


### PR DESCRIPTION
## Rely on Machine's on_time_step and on_time_step_cleanup method
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5564

### Changes and notes
- Rely on Machine's on_time_step and on_time_step_cleanup method 

### Testing
Tests pass