### PR TITLE
Albrja/mic 5539/bugfix/population-age-bounds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
     with:
       dependencies: "layered_config_tree,vivarium"
       skip_mypy: true
+      python_version: ${{ matrix.python-version }}
     secrets:
       NOTIFY_EMAIL: ${{ secrets.NOTIFY_EMAIL }}
       NOTIFY_PASSWORD: ${{ secrets.NOTIFY_PASSWORD }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.1.4 - TBD/TBD/TBD**
+
+ - Bugfix: Generate population within specified age bounds
+
 **3.1.3 - 12/03/24**
 
  - Feature: Create relative risk pipeline

--- a/src/vivarium_public_health/population/base_population.py
+++ b/src/vivarium_public_health/population/base_population.py
@@ -490,4 +490,5 @@ def _assign_demography_with_age_bounds(
         simulants, pop_data, randomness_streams["age_smoothing_age_bounds"]
     )
     register_simulants(simulants[list(key_columns)])
+
     return simulants

--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -111,7 +111,6 @@ def rescale_binned_proportions(
         raise ValueError(
             "Provided population data is insufficient to model the requested age range."
         )
-
     age_start = max(pop_data["age_start"].min(), age_start)
     age_end = min(pop_data["age_end"].max(), age_end) - 1e-8
     pop_data = _add_edge_age_groups(pop_data.copy())
@@ -126,7 +125,6 @@ def rescale_binned_proportions(
             (sub_pop["age_start"] <= age_start) & (age_start < sub_pop["age_end"])
         ]
         padding_bin = sub_pop[sub_pop["age_end"] == float(min_bin["age_start"].iloc[0])]
-
         min_scale = (float(min_bin["age_end"].iloc[0]) - age_start) / float(
             min_bin["age_end"].iloc[0] - min_bin["age_start"].iloc[0]
         )
@@ -165,6 +163,21 @@ def rescale_binned_proportions(
 
         pop_data.loc[max_bin.index, "age_end"] = age_end
         pop_data.loc[padding_bin.index, "age_start"] = age_end
+        # Update age to be within bounds
+        pop_data.loc[max_bin.index, "age"] = float(
+            (
+                pop_data.loc[max_bin.index, "age_start"].iloc[0]
+                + pop_data.loc[max_bin.index, "age_end"].iloc[0]
+            )
+            / 2
+        )
+        pop_data.loc[padding_bin.index, "age"] = float(
+            (
+                pop_data.loc[padding_bin.index, "age_start"].iloc[0]
+                + pop_data.loc[padding_bin.index, "age_end"].iloc[0]
+            )
+            / 2
+        )
 
     return pop_data[col_order].sort_values(_SORT_ORDER).reset_index(drop=True)
 
@@ -177,7 +190,6 @@ def _add_edge_age_groups(pop_data: pd.DataFrame) -> pd.DataFrame:
     age_cols = ["age", "age_start", "age_end"]
     other_cols = [c for c in pop_data.columns if c not in index_cols + age_cols]
     pop_data = pop_data.set_index(index_cols)
-
     # For the lower bin, we want constant interpolation off the left side
     min_valid_age = pop_data["age_start"].min()
     # This bin width needs to be the same as the lowest bin.

--- a/tests/population/test_base_population.py
+++ b/tests/population/test_base_population.py
@@ -378,3 +378,26 @@ def _check_locations(simulants):
             1 / len(simulants.location.unique()),
             abs_tol=0.01,
         )
+
+
+@pytest.mark.parametrize("age_start, age_end", [(0, 100), (2, 52), (21, 67), (12, 48)])
+def test_population_age_start_end(base_config, base_plugins, age_start, age_end):
+    components = [bp.BasePopulation()]
+    base_config.update(
+        {
+            "population": {
+                "initialization_age_min": age_start,
+                "initialization_age_max": age_end,
+            },
+        },
+    )
+
+    simulation = InteractiveContext(
+        components=components,
+        configuration=base_config,
+        plugin_configuration=base_plugins,
+    )
+
+    pop = simulation.get_population()
+    assert pop.age.min() >= age_start
+    assert pop.age.max() <= age_end


### PR DESCRIPTION
## Albrja/mic 5539/bugfix/population-age-bounds

### Bugfix so simulants are initialized within the configured age bounds
- *Category*: Bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5539

### Changes and notes
-fix bug where simulants were getting initialized outside of the configured age bounds

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

