### PR TITLE
Albrja/mic-5878/Use RR data to get age intervals for LBWSGRiskEffect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**3.2.2 - 2/20/25**
+**3.2.2 - 2/21/25**
 
  - Bugfix: Use relative risk data to get age intervals for LBWSGRiskEffect
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.2.2 - 2/20/25**
+
+ - Bugfix: Use relative risk data to get age intervals for LBWSGRiskEffect
+
 **3.2.1 - 1/30/25**
 
  - Get python versions from python_versions.json

--- a/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
+++ b/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
@@ -371,11 +371,9 @@ class LBWSGRiskEffect(RiskEffect):
 
     def get_age_intervals(self, builder: Builder) -> dict[str, pd.Interval]:
         age_bins = builder.data.load("population.age_bins").set_index("age_start")
-        exposure = builder.data.load(f"{self.risk}.exposure")
-        exposure = exposure[exposure["age_end"] > 0]
-
+        relative_risks = builder.data.load(f"{self.risk}.relative_risk")
         exposed_age_group_starts = (
-            exposure.groupby("age_start")["value"].any().reset_index()["age_start"]
+            relative_risks.groupby("age_start")["value"].any().reset_index()["age_start"]
         )
 
         return {

--- a/tests/risks/test_low_birth_weight_and_short_gestation.py
+++ b/tests/risks/test_low_birth_weight_and_short_gestation.py
@@ -56,11 +56,15 @@ def test_lbwsg_risk_effect_rr_pipeline(
     # Create exposure with matching demograph index as age_bins
     age_bins = make_age_bins()
     agees = age_bins.drop(columns="age_group_name")
-    exposure_data = make_categorical_exposure_data(agees)
+    # Have to match age bins and rr data to make age intervals
+    rr_data = make_categorical_data(agees)
+    # Exposure data used for risk component
+    exposure = make_categorical_data(agees)
 
     # Add data dict to add to artifact
     data = {
-        f"{risk.name}.exposure": exposure_data,
+        f"{risk.name}.exposure": exposure,
+        f"{risk.name}.relative_risk": rr_data,
         f"{risk.name}.population_attributable_fraction": 0,
         f"{risk.name}.categories": categories,
         f"{risk.name}.relative_risk_interpolator": mock_rr_interpolators,
@@ -118,9 +122,9 @@ def test_lbwsg_risk_effect_rr_pipeline(
                 assert (actual_rr == 1.0).all()
 
 
-def make_categorical_exposure_data(data: pd.DataFrame) -> pd.DataFrame:
+def make_categorical_data(data: pd.DataFrame) -> pd.DataFrame:
     # Takes age gropus and adds sex, years, categories, and values
-    exposure_dfs = []
+    rr_dfs = []
     for year in range(1990, 2017):
         tmp = data.copy()
         tmp["year_start"] = year
@@ -137,6 +141,6 @@ def make_categorical_exposure_data(data: pd.DataFrame) -> pd.DataFrame:
         female_tmp = categories_df.copy()
         female_tmp["sex"] = "Female"
         age_sex_df = pd.concat([male_tmp, female_tmp])
-        exposure_dfs.append(age_sex_df)
+        rr_dfs.append(age_sex_df)
 
-    return pd.concat(exposure_dfs)
+    return pd.concat(rr_dfs)

--- a/tests/risks/test_low_birth_weight_and_short_gestation.py
+++ b/tests/risks/test_low_birth_weight_and_short_gestation.py
@@ -124,7 +124,7 @@ def test_lbwsg_risk_effect_rr_pipeline(
 
 def make_categorical_data(data: pd.DataFrame) -> pd.DataFrame:
     # Takes age gropus and adds sex, years, categories, and values
-    rr_dfs = []
+    dfs = []
     for year in range(1990, 2017):
         tmp = data.copy()
         tmp["year_start"] = year
@@ -141,6 +141,6 @@ def make_categorical_data(data: pd.DataFrame) -> pd.DataFrame:
         female_tmp = categories_df.copy()
         female_tmp["sex"] = "Female"
         age_sex_df = pd.concat([male_tmp, female_tmp])
-        rr_dfs.append(age_sex_df)
+        dfs.append(age_sex_df)
 
-    return pd.concat(rr_dfs)
+    return pd.concat(dfs)


### PR DESCRIPTION
## Albrja/mic-5878/Use RR data to get age intervals for LBWSGRiskEffect

### Use relative risk data to get age intervals.
- *Category*: Bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5878

### Changes and notes
-uses RR data to get age intervals so there is not a data dependency on exposure and relative risk data.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

