### PR TITLE
Albrja/mic-5621/observer-get-configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**4.1.1 - 05/27/25**
+
+  - Feature: Update Observer to use super class get_configuration method
+
 **4.1.0 - 05/20/25**
 
   - Feature: Update RateTransition to have configuration key for rate conversion type

--- a/src/vivarium_public_health/results/disability.py
+++ b/src/vivarium_public_health/results/disability.py
@@ -34,7 +34,7 @@ class DisabilityObserver(PublicHealthObserver):
     .. code-block:: yaml
 
         configuration:
-            observers:
+            stratification:
                 disability:
                     exclude:
                         - "sex"
@@ -127,20 +127,6 @@ class DisabilityObserver(PublicHealthObserver):
         self.causes_of_disability = [
             cause for cause in causes_of_disability if cause.state_id not in excluded_causes
         ]
-
-    def get_configuration(self, builder: Builder) -> LayeredConfigTree:
-        """Get the stratification configuration for this observer.
-
-        Parameters
-        ----------
-        builder
-            The builder object for the simulation.
-
-        Returns
-        -------
-            The stratification configuration for this observer.
-        """
-        return builder.configuration.stratification.disability
 
     def register_observations(self, builder: Builder) -> None:
         """Register an observation for years lived with disability."""

--- a/src/vivarium_public_health/results/mortality.py
+++ b/src/vivarium_public_health/results/mortality.py
@@ -136,20 +136,6 @@ class MortalityObserver(PublicHealthObserver):
             SimpleCause("other_causes", "other_causes", "cause"),
         ]
 
-    def get_configuration(self, builder: Builder) -> LayeredConfigTree:
-        """Get the stratification configuration for this observer.
-
-        Parameters
-        ----------
-        builder
-            The builder object for the simulation.
-
-        Returns
-        -------
-            The stratification configuration for this observer.
-        """
-        return builder.configuration.stratification[self.get_configuration_name()]
-
     def register_observations(self, builder: Builder) -> None:
         """Register stratifications and observations.
 

--- a/tests/results/test_disability_observer.py
+++ b/tests/results/test_disability_observer.py
@@ -39,7 +39,7 @@ def test_disability_observer_setup(mocker):
     observer = DisabilityObserver_()
     builder = mocker.Mock()
     mocker.patch("vivarium.component.Component.build_all_lookup_tables")
-    mocker.patch("vivarium.component.Component.get_configuration")
+    mocker.patch("vivarium.framework.results.observer.Observer.get_configuration")
     builder.results.register_adding_observation = mocker.Mock()
     builder.configuration.time.step_size = 28
     builder.configuration.output_data.results_directory = "some/results/directory"
@@ -239,6 +239,7 @@ def test_set_causes_of_disability(exclusions, mocker):
 
     builder = mocker.Mock()
     mocker.patch("vivarium.component.Component.build_all_lookup_tables")
+    mocker.patch("vivarium.framework.results.observer.Observer.get_configuration")
     builder.configuration.time.step_size = 28
     builder.configuration.stratification.excluded_categories = LayeredConfigTree(
         {"disability": exclusions}
@@ -260,6 +261,7 @@ def test_set_causes_of_disability_raises(mocker):
 
     builder = mocker.Mock()
     mocker.patch("vivarium.component.Component.build_all_lookup_tables")
+    mocker.patch("vivarium.framework.results.observer.Observer.get_configuration")
     builder.configuration.time.step_size = 28
     builder.configuration.stratification.excluded_categories = LayeredConfigTree(
         {"disability": ["arthritis"]}  # not an instantiated disease


### PR DESCRIPTION
## Albrja/mic-5621/observer-get-configuration

### Overrides get_configuration in observers to use super class method
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5621

### Changes and notes
-override get_configuration for observer classes
-DOES NOT update method for disease and risk observers due to their configuration via self.cause and self.risk and not the observer component name

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

