### PR TITLE
Fix dataframegroupby.apply future warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@
   - Add Intervention and InterventionEffect classes
   - Refactor to pass Exposure component to RiskExposureDistribution classes
   - Update exposure category names for DichotomousRiskExposureDistribution
+  - Hush FutureWarnings: add include_groups=False to apply call in StratifiedObservation
 
 **4.2.3 - 07/10/25**
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         "layered_config_tree>=3.2.0",
         "loguru",
         "numpy<2.0.0",
-        "pandas",
+        "pandas>=2.2.0",
         "scipy",
         "tables",
         "risk_distributions>=2.0.11",

--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -54,21 +54,21 @@ def assign_demographic_proportions(
 
     population_data["P(sex, location, age| year)"] = (
         population_data.groupby("year_start", as_index=False)
-        .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum())
+        .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum(), include_groups=False)
         .reset_index(level=0)["value"]
         .fillna(0.0)
     )
 
     population_data["P(sex, location | age, year)"] = (
         population_data.groupby(["age", "year_start"], as_index=False)
-        .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum())
+        .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum(), include_groups=False)
         .reset_index(level=0)["value"]
         .fillna(0.0)
     )
 
     population_data["P(age | year, sex, location)"] = (
         population_data.groupby(["year_start", "sex", "location"], as_index=False)
-        .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum())
+        .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum(), include_groups=False)
         .reset_index(level=0)["value"]
         .fillna(0.0)
     )

--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -54,21 +54,27 @@ def assign_demographic_proportions(
 
     population_data["P(sex, location, age| year)"] = (
         population_data.groupby("year_start", as_index=False)
-        .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum(), include_groups=False)
+        .apply(
+            lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum(), include_groups=False
+        )
         .reset_index(level=0)["value"]
         .fillna(0.0)
     )
 
     population_data["P(sex, location | age, year)"] = (
         population_data.groupby(["age", "year_start"], as_index=False)
-        .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum(), include_groups=False)
+        .apply(
+            lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum(), include_groups=False
+        )
         .reset_index(level=0)["value"]
         .fillna(0.0)
     )
 
     population_data["P(age | year, sex, location)"] = (
         population_data.groupby(["year_start", "sex", "location"], as_index=False)
-        .apply(lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum(), include_groups=False)
+        .apply(
+            lambda sub_pop: sub_pop[["value"]] / sub_pop["value"].sum(), include_groups=False
+        )
         .reset_index(level=0)["value"]
         .fillna(0.0)
     )


### PR DESCRIPTION
## Fix dataframegroupby.apply future warnings

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6165

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

The issue:
https://stackoverflow.com/questions/77969964/deprecation-warning-with-groupby-apply
https://pandas.pydata.org/docs/reference/api/pandas.core.groupby.DataFrameGroupBy.apply.html

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
All tests pass w/ the changes