### PR TITLE
Reintroduce deprecated risk property to RiskEffect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,8 @@
-**4.3.1 - 08/01/25**
+**4.3.2 - 07/30/25**
+
+  - Support RiskEffect backwards compatibility with v4.2.x
+
+**4.3.1 - 07/30/25**
 
   - Bugfix: reference correct entity name in LBWSG get_current_exposure method
   - Support backwards compatibility with v4.2.x

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -5,6 +5,7 @@ Risk Effect Models
 
 """
 
+import warnings
 from collections.abc import Callable
 from typing import Any
 
@@ -25,6 +26,24 @@ class RiskEffect(ExposureEffect):
     supplied in the configuration.
 
     """
+
+    @property
+    def risk(self) -> str:
+        warnings.warn(
+            "The 'risk' attribute is deprecated. Use 'entity' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.entity
+
+    @risk.setter
+    def risk(self, value: str) -> None:
+        warnings.warn(
+            "The 'risk' attribute is deprecated. Use 'entity' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.entity = value
 
     def get_name(self, risk: EntityString, target: TargetString) -> str:
         return f"risk_effect.{risk.name}_on_{target}"


### PR DESCRIPTION
## Reintroduce deprecated risk property to RiskEffect
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6249

### Changes and notes
Added risk property to RiskEffect 

### Testing
Ran make check