### PR TITLE
Raise if bin index is out of range

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**4.3.7 - 09/09/25**
+**4.3.7 - 09/10/25**
 
   - Bugfix: raise an error if simulation start year is earlier than population data.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**4.3.7 - 09/09/25**
+
+  - Bugfix: raise an error if simulation start year is earlier than population data.
+
 **4.3.6 - 08/28/25**
 
   - Feature: ScaledPopulation can handle multiple year data inputs.

--- a/src/vivarium_public_health/population/base_population.py
+++ b/src/vivarium_public_health/population/base_population.py
@@ -257,22 +257,22 @@ class ScaledPopulation(BasePopulation):
         if "year_start" not in scaling_factor.index.names:
             return population_structure, scaling_factor
 
-        # Subset to start year of simulation or closest year
+        # Subset the population structure and scaling factors to the simulation
+        # start year. If the data does not contain the exact simulation start
+        # year, subset to the closest year less than the simulation start year.
         pop_reference_years = sorted(
             set(population_structure.index.get_level_values("year_start"))
         )
         pop_year_index = _find_bin_start_index(year, pop_reference_years)
-        scale_reference_years = sorted(
-            set(scaling_factor.index.get_level_values("year_start"))
-        )
-        scale_year_index = _find_bin_start_index(year, scale_reference_years)
-        # Subset to start year of simulation or earliest year. E.g. if start year = 2021 and pop
-        # structure has 2021, we will subset to 2021. If pop structure minimum year is 2025, we
-        # will subset to 2025.
         population_structure = population_structure.loc[
             population_structure.index.get_level_values("year_start")
             == pop_reference_years[pop_year_index]
         ]
+
+        scale_reference_years = sorted(
+            set(scaling_factor.index.get_level_values("year_start"))
+        )
+        scale_year_index = _find_bin_start_index(year, scale_reference_years)
         scaling_factor = scaling_factor.loc[
             scaling_factor.index.get_level_values("year_start")
             == scale_reference_years[scale_year_index]

--- a/tests/population/test_base_population.py
+++ b/tests/population/test_base_population.py
@@ -296,7 +296,11 @@ def test_scaled_population(
                 "population_size": 1_000_000,
                 "include_sex": "Both",
             },
-            "time": {"step_size": 1},
+            "time": {
+                "step_size": 1,
+                # Update the start year to fall within the population structure data.
+                "start": {"year": 2021},
+            },
         },
         layer="override",
     )

--- a/tests/population/test_base_population.py
+++ b/tests/population/test_base_population.py
@@ -4,7 +4,6 @@ from itertools import product
 import numpy as np
 import pandas as pd
 import pytest
-from layered_config_tree import LayeredConfigTree
 from vivarium import InteractiveContext
 from vivarium.testing_utilities import get_randomness
 from vivarium_testing_utils import FuzzyChecker
@@ -472,6 +471,22 @@ def test_scaled_population__format_data_inputs(
         expected = (formatted[0] * formatted[1]).reset_index()
         data = (formatted_pop_structure * formatted_scalar_data).reset_index()
         pd.testing.assert_frame_equal(data, expected)
+
+
+def test__find_bin_start_index():
+    sorted_values = [10, 20, 30]
+    assert bp._find_bin_start_index(10, sorted_values) == 0
+    assert bp._find_bin_start_index(19, sorted_values) == 0
+    assert bp._find_bin_start_index(20, sorted_values) == 1
+    assert bp._find_bin_start_index(29, sorted_values) == 1
+    assert bp._find_bin_start_index(30, sorted_values) == 2
+    assert bp._find_bin_start_index(99999, sorted_values) == 2
+
+    # Edge case
+    with pytest.raises(
+        ValueError, match="The provided value 9 is less than the minimum reference value 10."
+    ):
+        bp._find_bin_start_index(9, sorted_values)
 
 
 def _check_population(simulants, initial_age, step_size, include_sex):


### PR DESCRIPTION
## Bugfix bin index calculation

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

np.digitize - 1 will return -1 if the year is less than the minimum reference
year. The problem is that pd.Series[-1] is a valid thing - it returns the 
_last_ value (which is precisely the worst thing to return in this case).

This checks for that and raises.

NOTE: [vivarium does this sort of thing in one location](https://github.com/ihmeuw/vivarium/blob/main/src/vivarium/framework/lookup/interpolation.py#L372) (though it's used on
a series rather than a single value). It handles the case where values fall
below the reference values by grabbing the minimum reference instead
of raising. I'm happy to implement that instead of raising if preferred.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

We actually had a failing test that I had to update. All tests pass.
I did not create a new test just for this - lmk if you think I should.
