### PR TITLE
Support additive causal effects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+**5.1.8 - 05/08/26**
+
+- Feature: Enable additive effects in addition to multiplicative effects 
+- Refactor: Rename internal CausalFactorEffect methods for clarity
+- Feature: enable risk-affected pipelines to modify multi-column attribute pipelines
+- Minor bugfixes
+
 **5.1.7 - 04/30/26**
 
 - Add disease tutorial

--- a/src/vivarium_public_health/causal_factor/calibration_constant.py
+++ b/src/vivarium_public_health/causal_factor/calibration_constant.py
@@ -62,8 +62,13 @@ def register_risk_affected_attribute_producer(
         in addition to the calibration constant post-processor. These will be
         applied after the calibration constant post-processor.
     """
+    post_processors = (
+        additional_post_processors
+        if isinstance(additional_post_processors, Sequence)
+        else [additional_post_processors]
+    )
     _RiskAffectedPipeline.create(
-        builder, name, source, required_resources, additional_post_processors, is_rate=False
+        builder, name, source, required_resources, post_processors, is_rate=False
     )
 
 
@@ -96,8 +101,13 @@ def register_risk_affected_rate_producer(
         in addition to the calibration constant post-processor. These will be
         applied after the calibration constant post-processor.
     """
+    post_processors = (
+        additional_post_processors
+        if isinstance(additional_post_processors, Sequence)
+        else [additional_post_processors]
+    )
     _RiskAffectedPipeline.create(
-        builder, name, source, required_resources, additional_post_processors, is_rate=True
+        builder, name, source, required_resources, post_processors, is_rate=True
     )
 
 
@@ -111,7 +121,7 @@ class _RiskAffectedPipeline(Component):
         name: str,
         source: Callable[..., pd.Series],
         required_resources: Sequence[str],
-        additional_post_processors: AttributePostProcessor | Sequence[AttributePostProcessor],
+        additional_post_processors: Sequence[AttributePostProcessor],
         is_rate: bool,
     ) -> None:
         """Factory method to create and set up the class."""
@@ -124,7 +134,7 @@ class _RiskAffectedPipeline(Component):
         target_pipeline_name: str,
         target_pipeline_source: Callable[..., pd.Series],
         required_resources: Sequence[str | Resource],
-        additional_post_processors: AttributePostProcessor | Sequence[AttributePostProcessor],
+        additional_post_processors: Sequence[AttributePostProcessor],
         is_rate: bool,
     ):
         super().__init__()
@@ -158,12 +168,6 @@ class _RiskAffectedPipeline(Component):
             else builder.value.register_attribute_producer
         )
 
-        preferred_post_processor_list = (
-            list(self._additional_post_processors)
-            if isinstance(self._additional_post_processors, Sequence)
-            else [self._additional_post_processors]
-        )
-
         register_pipeline(
             self._target_pipeline_name,
             source=self._target_pipeline_source,
@@ -171,7 +175,7 @@ class _RiskAffectedPipeline(Component):
             preferred_combiner=multiplication_combiner,
             preferred_post_processor=[
                 self._apply_calibration_constant,
-                *preferred_post_processor_list,
+                *self._additional_post_processors,
             ],
         )
 

--- a/src/vivarium_public_health/causal_factor/calibration_constant.py
+++ b/src/vivarium_public_health/causal_factor/calibration_constant.py
@@ -10,7 +10,7 @@ constants.
 
 """
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Any, Literal
 from typing import SupportsFloat as Numeric
 
 import pandas as pd
@@ -22,6 +22,7 @@ from vivarium.framework.resource import Resource
 from vivarium.framework.values import (
     AttributePostProcessor,
     ValuesManager,
+    addition_combiner,
     multiplication_combiner,
     raw_union_post_processor,
 )
@@ -37,11 +38,11 @@ def register_risk_affected_attribute_producer(
     builder: Builder,
     name: str,
     source: Callable[..., pd.Series],
-    required_resources: Sequence[str] = (),
-    additional_post_processors: AttributePostProcessor
-    | Sequence[AttributePostProcessor] = (),
+    effect_type: Literal["multiplicative", "additive"] = "multiplicative",
+    required_resources: Sequence[str | Resource] = (),
+    post_processors: AttributePostProcessor | Sequence[AttributePostProcessor] = (),
 ) -> None:
-    """Helper function to register a pipeline that can be modified by RiskEffect components.
+    """Helper function to register a pipeline that can be modified by CausalFactorEffect components.
 
     Parameters
     ----------
@@ -54,21 +55,28 @@ def register_risk_affected_attribute_producer(
         or a list of column names. If a list of column names is provided,
         the component that is registering this attribute producer must be the
         one that creates those columns.
+    effect_type
+        The type of effect that CausalFactorEffect components will have on this pipeline.
+        Supported values are "multiplicative" and "additive". This will determine how
+        modifiers are applied to the pipeline in conjunction with the calibration constant.
     required_resources
         A list of resources that the producer requires. A string represents
         a population attribute.
-    additional_post_processors
+    post_processors
         An AttributePostProcessor or list of AttributePostProcessors to apply
-        in addition to the calibration constant post-processor. These will be
-        applied after the calibration constant post-processor.
+        to the attribute pipeline.
     """
     post_processors = (
-        additional_post_processors
-        if isinstance(additional_post_processors, Sequence)
-        else [additional_post_processors]
+        post_processors if isinstance(post_processors, Sequence) else [post_processors]
     )
     _RiskAffectedPipeline.create(
-        builder, name, source, required_resources, post_processors, is_rate=False
+        builder,
+        name,
+        source,
+        effect_type,
+        required_resources,
+        post_processors,
+        is_rate=False,
     )
 
 
@@ -76,11 +84,11 @@ def register_risk_affected_rate_producer(
     builder: Builder,
     name: str,
     source: Callable[..., pd.Series],
-    required_resources: Sequence[str] = (),
-    additional_post_processors: AttributePostProcessor
-    | Sequence[AttributePostProcessor] = (),
+    effect_type: Literal["multiplicative", "additive"] = "multiplicative",
+    required_resources: Sequence[str | Resource] = (),
+    post_processors: AttributePostProcessor | Sequence[AttributePostProcessor] = (),
 ) -> None:
-    """Helper function to register a rate pipeline that can be modified by RiskEffect components.
+    """Helper function to register a rate pipeline that can be modified by CausalFactorEffect components.
 
     Parameters
     ----------
@@ -93,26 +101,27 @@ def register_risk_affected_rate_producer(
         or a list of column names. If a list of column names is provided,
         the component that is registering this rate producer must be the
         one that creates those columns.
+    effect_type
+        The type of effect that CausalFactorEffect components will have on this pipeline.
+        Supported values are "multiplicative" and "additive". This will determine how
+        modifiers are applied to the pipeline in conjunction with the calibration constant.
     required_resources
         A list of resources that the producer requires. A string represents
         a population attribute.
-    additional_post_processors
+    post_processors
         An AttributePostProcessor or list of AttributePostProcessors to apply
-        in addition to the calibration constant post-processor. These will be
-        applied after the calibration constant post-processor.
+        to the attribute pipeline.
     """
     post_processors = (
-        additional_post_processors
-        if isinstance(additional_post_processors, Sequence)
-        else [additional_post_processors]
+        post_processors if isinstance(post_processors, Sequence) else [post_processors]
     )
     _RiskAffectedPipeline.create(
-        builder, name, source, required_resources, post_processors, is_rate=True
+        builder, name, source, effect_type, required_resources, post_processors, is_rate=True
     )
 
 
 class _RiskAffectedPipeline(Component):
-    """Convenience class to package pipelines that can be targeted by RiskEffect."""
+    """Convenience class to package pipelines that can be targeted by CausalFactorEffect."""
 
     @classmethod
     def create(
@@ -120,28 +129,31 @@ class _RiskAffectedPipeline(Component):
         builder: Builder,
         name: str,
         source: Callable[..., pd.Series],
-        required_resources: Sequence[str],
-        additional_post_processors: Sequence[AttributePostProcessor],
+        effect_type: Literal["multiplicative", "additive"],
+        required_resources: Sequence[str | Resource],
+        post_processors: Sequence[AttributePostProcessor],
         is_rate: bool,
     ) -> None:
         """Factory method to create and set up the class."""
         cls(
-            name, source, required_resources, additional_post_processors, is_rate
+            name, source, effect_type, required_resources, post_processors, is_rate
         ).setup_component(builder)
 
     def __init__(
         self,
         target_pipeline_name: str,
         target_pipeline_source: Callable[..., pd.Series],
+        effect_type: Literal["multiplicative", "additive"],
         required_resources: Sequence[str | Resource],
-        additional_post_processors: Sequence[AttributePostProcessor],
+        post_processors: Sequence[AttributePostProcessor],
         is_rate: bool,
     ):
         super().__init__()
         self._target_pipeline_name = target_pipeline_name
         self._target_pipeline_source = target_pipeline_source
+        self._effect_type = effect_type
         self._required_resources = required_resources
-        self._additional_post_processors = additional_post_processors
+        self._post_processors = post_processors
         self._is_rate = is_rate
 
     def setup(self, builder: Builder) -> None:
@@ -167,16 +179,22 @@ class _RiskAffectedPipeline(Component):
             if self._is_rate
             else builder.value.register_attribute_producer
         )
+        combiner = (
+            multiplication_combiner
+            if self._effect_type == "multiplicative"
+            else addition_combiner
+        )
 
         register_pipeline(
             self._target_pipeline_name,
             source=self._target_pipeline_source,
-            required_resources=[self._calibration_constant_table, *self._required_resources],
-            preferred_combiner=multiplication_combiner,
-            preferred_post_processor=[
-                self._apply_calibration_constant,
-                *self._additional_post_processors,
-            ],
+            required_resources=self._required_resources,
+            preferred_combiner=combiner,
+            preferred_post_processor=self._post_processors,
+        )
+
+        builder.value.register_attribute_modifier(
+            self._target_pipeline_name, modifier=self._calibration_constant_table
         )
 
     def on_post_setup(self, event: Event) -> None:
@@ -210,25 +228,22 @@ class _RiskAffectedPipeline(Component):
         value.append(calibration_constant)
         return value
 
-    @staticmethod
     def _calibration_constant_post_processor(
-        value: list[NumberLike], manager: ValuesManager
+        self, value: list[NumberLike], manager: ValuesManager
     ) -> LookupTableData:
-        """Compute the joint calibration constant via raw union."""
-        joint_calibration_constant = raw_union_post_processor(value, manager)
-        if isinstance(joint_calibration_constant, pd.Series):
-            joint_calibration_constant = joint_calibration_constant.reset_index()
-        return joint_calibration_constant
+        """Compute the joint calibration constant.
 
-    def _apply_calibration_constant(
-        self,
-        index: pd.Index,
-        value: pd.Series,
-        manager: ValuesManager,
-    ) -> pd.Series:
-        """Multiply non-zero values by ``(1 - calibration_constant)``."""
-        non_zero_index = value[value != 0].index
-        if not non_zero_index.empty:
-            calibration_constant = self._calibration_constant_table(non_zero_index)
-            value.loc[non_zero_index] = value.loc[non_zero_index] * (1 - calibration_constant)
-        return value
+        Uses a union post processor if the effect type is multiplicative and an addition
+        post processor if the effect type is additive.
+
+
+        """
+        if self._effect_type == "multiplicative":
+            joint_calibration_constant = 1 - raw_union_post_processor(value, manager)
+            if isinstance(joint_calibration_constant, pd.Series):
+                joint_calibration_constant = joint_calibration_constant.reset_index()
+            return joint_calibration_constant
+        elif self._effect_type == "additive":
+            return -sum(value)
+        else:
+            raise ValueError(f"Unsupported effect type: {self._effect_type}")

--- a/src/vivarium_public_health/causal_factor/calibration_constant.py
+++ b/src/vivarium_public_health/causal_factor/calibration_constant.py
@@ -62,13 +62,8 @@ def register_risk_affected_attribute_producer(
         in addition to the calibration constant post-processor. These will be
         applied after the calibration constant post-processor.
     """
-    post_processors = (
-        additional_post_processors
-        if isinstance(additional_post_processors, Sequence)
-        else [additional_post_processors]
-    )
     _RiskAffectedPipeline.create(
-        builder, name, source, required_resources, post_processors, is_rate=False
+        builder, name, source, required_resources, additional_post_processors, is_rate=False
     )
 
 
@@ -101,13 +96,8 @@ def register_risk_affected_rate_producer(
         in addition to the calibration constant post-processor. These will be
         applied after the calibration constant post-processor.
     """
-    post_processors = (
-        additional_post_processors
-        if isinstance(additional_post_processors, Sequence)
-        else [additional_post_processors]
-    )
     _RiskAffectedPipeline.create(
-        builder, name, source, required_resources, post_processors, is_rate=True
+        builder, name, source, required_resources, additional_post_processors, is_rate=True
     )
 
 
@@ -121,7 +111,7 @@ class _RiskAffectedPipeline(Component):
         name: str,
         source: Callable[..., pd.Series],
         required_resources: Sequence[str],
-        additional_post_processors: Sequence[AttributePostProcessor],
+        additional_post_processors: AttributePostProcessor | Sequence[AttributePostProcessor],
         is_rate: bool,
     ) -> None:
         """Factory method to create and set up the class."""
@@ -134,7 +124,7 @@ class _RiskAffectedPipeline(Component):
         target_pipeline_name: str,
         target_pipeline_source: Callable[..., pd.Series],
         required_resources: Sequence[str | Resource],
-        additional_post_processors: Sequence[AttributePostProcessor],
+        additional_post_processors: AttributePostProcessor | Sequence[AttributePostProcessor],
         is_rate: bool,
     ):
         super().__init__()
@@ -168,6 +158,12 @@ class _RiskAffectedPipeline(Component):
             else builder.value.register_attribute_producer
         )
 
+        preferred_post_processor_list = (
+            list(self._additional_post_processors)
+            if isinstance(self._additional_post_processors, Sequence)
+            else [self._additional_post_processors]
+        )
+
         register_pipeline(
             self._target_pipeline_name,
             source=self._target_pipeline_source,
@@ -175,7 +171,7 @@ class _RiskAffectedPipeline(Component):
             preferred_combiner=multiplication_combiner,
             preferred_post_processor=[
                 self._apply_calibration_constant,
-                *self._additional_post_processors,
+                *preferred_post_processor_list,
             ],
         )
 

--- a/src/vivarium_public_health/causal_factor/calibration_constant.py
+++ b/src/vivarium_public_health/causal_factor/calibration_constant.py
@@ -12,7 +12,7 @@ calibration constants.
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import Any, Literal
+from typing import Any, Literal, overload
 from typing import SupportsFloat as Numeric
 
 import pandas as pd
@@ -36,6 +36,7 @@ def get_calibration_constant_pipeline_name(target_pipeline_name: str) -> str:
     return f"{target_pipeline_name}.calibration_constant"
 
 
+@overload
 def register_risk_affected_attribute_producer(
     builder: Builder,
     name: str,
@@ -43,6 +44,30 @@ def register_risk_affected_attribute_producer(
     effect_type: Literal["multiplicative", "additive"] = "multiplicative",
     required_resources: Sequence[str | Resource] = (),
     post_processors: AttributePostProcessor | Sequence[AttributePostProcessor] = (),
+    columns: None = None,
+) -> None:
+    ...
+
+@overload
+def register_risk_affected_attribute_producer(
+    builder: Builder,
+    name: str,
+    source: Callable[..., pd.DataFrame],
+    effect_type: Literal["multiplicative", "additive"] = "multiplicative",
+    required_resources: Sequence[str | Resource] = (),
+    post_processors: AttributePostProcessor | Sequence[AttributePostProcessor] = (),
+    columns: list[str] = ...,
+) -> None:
+    ...
+
+def register_risk_affected_attribute_producer(
+    builder: Builder,
+    name: str,
+    source: Callable[..., pd.Series] | Callable[..., pd.DataFrame],
+    effect_type: Literal["multiplicative", "additive"] = "multiplicative",
+    required_resources: Sequence[str | Resource] = (),
+    post_processors: AttributePostProcessor | Sequence[AttributePostProcessor] = (),
+    columns: list[str] | None = None,
 ) -> None:
     """Register a pair of pipelines for an attribute targetable by CausalFactorEffect components.
 
@@ -90,12 +115,16 @@ def register_risk_affected_attribute_producer(
     post_processors
         An AttributePostProcessor or list of AttributePostProcessors to apply
         to the attribute pipeline.
+    columns
+        If the pipeline should produce a DataFrame, the columns that DataFrame should include.
+        None if the pipeline produces a Series.
     """
     _RiskAffectedPipeline.create(
-        builder, name, source, effect_type, required_resources, post_processors, is_rate=False
+        builder, name, source, effect_type, required_resources, post_processors, columns, is_rate=False
     )
 
 
+@overload
 def register_risk_affected_rate_producer(
     builder: Builder,
     name: str,
@@ -103,6 +132,29 @@ def register_risk_affected_rate_producer(
     effect_type: Literal["multiplicative", "additive"] = "multiplicative",
     required_resources: Sequence[str | Resource] = (),
     post_processors: AttributePostProcessor | Sequence[AttributePostProcessor] = (),
+    columns: None = None,
+) -> None:
+    ...
+
+@overload
+def register_risk_affected_rate_producer(
+    builder: Builder,
+    name: str,
+    source: Callable[..., pd.DataFrame],
+    effect_type: Literal["multiplicative", "additive"] = "multiplicative",
+    required_resources: Sequence[str | Resource] = (),
+    post_processors: AttributePostProcessor | Sequence[AttributePostProcessor] = (),
+    columns: list[str] = ...,
+) -> None:
+    ...
+def register_risk_affected_rate_producer(
+    builder: Builder,
+    name: str,
+    source: Callable[..., pd.Series],
+    effect_type: Literal["multiplicative", "additive"] = "multiplicative",
+    required_resources: Sequence[str | Resource] = (),
+    post_processors: AttributePostProcessor | Sequence[AttributePostProcessor] = (),
+    columns: list[str] | None = None,
 ) -> None:
     """Register a pair of pipelines for a rate targetable by CausalFactorEffect components.
 
@@ -150,9 +202,12 @@ def register_risk_affected_rate_producer(
     post_processors
         An AttributePostProcessor or list of AttributePostProcessors to apply
         to the attribute pipeline.
+    columns
+        If the pipeline should produce a DataFrame, the columns that DataFrame should include.
+        None if the pipeline produces a Series.
     """
     _RiskAffectedPipeline.create(
-        builder, name, source, effect_type, required_resources, post_processors, is_rate=True
+        builder, name, source, effect_type, required_resources, post_processors, columns, is_rate=True
     )
 
 
@@ -196,11 +251,12 @@ class _RiskAffectedPipeline(Component):
         effect_type: Literal["multiplicative", "additive"],
         required_resources: Sequence[str | Resource],
         post_processors: AttributePostProcessor | Sequence[AttributePostProcessor],
+        columns: list[str] | None,
         is_rate: bool,
     ) -> _RiskAffectedPipeline:
         """Factory method to create and set up the class."""
         pipeline = cls(
-            name, source, effect_type, required_resources, post_processors, is_rate
+            name, source, effect_type, required_resources, post_processors, columns, is_rate
         )
         pipeline.setup_component(builder)
         return pipeline
@@ -212,6 +268,7 @@ class _RiskAffectedPipeline(Component):
         effect_type: Literal["multiplicative", "additive"],
         required_resources: Sequence[str | Resource],
         post_processors: AttributePostProcessor | Sequence[AttributePostProcessor],
+        columns: list[str] | None,
         is_rate: bool,
     ):
         super().__init__()
@@ -230,10 +287,13 @@ class _RiskAffectedPipeline(Component):
         )
         """AttributePostProcessors applied to the target pipeline after the combiner
         runs. Normalized to a sequence even when a single post-processor is supplied."""
+        self._columns = columns if columns is not None else DEFAULT_VALUE_COLUMN
+        """If the pipeline should produce a DataFrame, the columns that DataFrame should include.
+        ``DEFAULT_VALUE_COLUMN`` if the pipeline produces a Series."""
         self._is_rate = is_rate
         """``True`` if the target pipeline is a rate, ``False`` if it is an attribute.
         Selects between ``register_rate_producer`` and ``register_attribute_producer``."""
-
+    
     def setup(self, builder: Builder) -> None:
         """Register the calibration constant and target pipelines.
 
@@ -242,8 +302,14 @@ class _RiskAffectedPipeline(Component):
         builder
             Access point for utilizing framework interfaces during setup.
         """
+        initial_data: int | list[int] = (
+            0 if isinstance(self._columns, str) else [0] * len(self._columns)
+        )
         self._calibration_constant_table = self.build_lookup_table(
-            builder, "calibration_constant", data_source=0
+            builder,
+            "calibration_constant",
+            data_source=initial_data,
+            value_columns=self._columns,
         )
         """Lookup table populated in ``on_post_setup`` with the precomputed joint
         calibration constant. Registered as a modifier on the target pipeline so the
@@ -297,8 +363,8 @@ class _RiskAffectedPipeline(Component):
     # Combiners and post-processors #
     #################################
 
-    @staticmethod
     def _calibration_constant_combiner(
+        self,
         value: list[Numeric | pd.DataFrame],
         mutator: Callable[..., Numeric | pd.DataFrame],
         *args: Any,
@@ -307,8 +373,9 @@ class _RiskAffectedPipeline(Component):
         """Append the mutator result to the calibration constant list."""
         calibration_constant = mutator(*args, **kwargs)
         if isinstance(calibration_constant, pd.DataFrame):
+            value_columns = self._columns if not isinstance(self._columns, str) else [self._columns]
             index_columns = [
-                col for col in calibration_constant.columns if col != DEFAULT_VALUE_COLUMN
+                col for col in calibration_constant.columns if col not in value_columns
             ]
             calibration_constant = calibration_constant.set_index(index_columns).squeeze()
         value.append(calibration_constant)
@@ -342,4 +409,11 @@ class _RiskAffectedPipeline(Component):
             raise ValueError(f"Unsupported effect type: {self._effect_type}")
         if isinstance(joint_calibration_constant, pd.Series):
             joint_calibration_constant = joint_calibration_constant.reset_index()
+        elif isinstance(joint_calibration_constant, pd.DataFrame):
+            if isinstance(joint_calibration_constant.index, pd.MultiIndex):
+                joint_calibration_constant = joint_calibration_constant.reset_index()
+        elif not isinstance(self._columns, str):
+            # Scalar joint with a multi-column pipeline —
+            # broadcast across columns so the lookup table can ingest one value per column.
+            joint_calibration_constant = [joint_calibration_constant] * len(self._columns)
         return joint_calibration_constant

--- a/src/vivarium_public_health/causal_factor/calibration_constant.py
+++ b/src/vivarium_public_health/causal_factor/calibration_constant.py
@@ -240,10 +240,10 @@ class _RiskAffectedPipeline(Component):
         """
         if self._effect_type == "multiplicative":
             joint_calibration_constant = 1 - raw_union_post_processor(value, manager)
-            if isinstance(joint_calibration_constant, pd.Series):
-                joint_calibration_constant = joint_calibration_constant.reset_index()
-            return joint_calibration_constant
         elif self._effect_type == "additive":
-            return -sum(value)
+            joint_calibration_constant = -sum(value)
         else:
             raise ValueError(f"Unsupported effect type: {self._effect_type}")
+        if isinstance(joint_calibration_constant, pd.Series):
+            joint_calibration_constant = joint_calibration_constant.reset_index()
+        return joint_calibration_constant

--- a/src/vivarium_public_health/causal_factor/calibration_constant.py
+++ b/src/vivarium_public_health/causal_factor/calibration_constant.py
@@ -4,11 +4,13 @@ Calibration Constant
 ====================
 
 This module contains functions and classes for managing calibration constants in
-pipelines that are intended to be modifiable by RiskEffect components. Population
-attributable fractions (PAFs) can often be used interchangeably with calibration
-constants.
+pipelines that are intended to be modifiable by CausalFactorEffect components. Population
+attributable fractions (PAFs) can often be used interchangeably with multiplicative
+calibration constants.
 
 """
+from __future__ import annotations
+
 from collections.abc import Callable, Sequence
 from typing import Any, Literal
 from typing import SupportsFloat as Numeric
@@ -42,14 +44,37 @@ def register_risk_affected_attribute_producer(
     required_resources: Sequence[str | Resource] = (),
     post_processors: AttributePostProcessor | Sequence[AttributePostProcessor] = (),
 ) -> None:
-    """Helper function to register a pipeline that can be modified by CausalFactorEffect components.
+    """Register a pair of pipelines for an attribute targetable by CausalFactorEffect components.
+
+    Two value pipelines are registered:
+
+    * The **target attribute pipeline** (``name``): produces the affected
+      attribute. Other components register their effects as modifiers on
+      this pipeline.
+    * The **calibration constant pipeline**
+      (``<name>.calibration_constant``): a companion pipeline that any
+      component modifying the target should also modify, registering the
+      calibration constant that corresponds to its effect. The joint
+      calibration constant is precomputed at the end of setup and
+      registered as a modifier on the target pipeline so that the
+      population-level baseline is preserved.
+
+    The joint calibration constant is shaped to cancel cleanly against the
+    target pipeline's combiner:
+
+    * For ``"multiplicative"`` effects, the joint value is
+      ``1 - raw_union(c_i) = prod(1 - c_i)``. Multiplying the target by
+      this value scales it by the surviving fraction.
+    * For ``"additive"`` effects, the joint value is ``-sum(c_i)``. Adding
+      this to the target subtracts the cumulative additive effect.
 
     Parameters
     ----------
     builder
         The Builder object to use for registration.
     name
-        The name of the pipeline to register.
+        The name of the target pipeline to register. The calibration constant
+        pipeline is registered at ``<name>.calibration_constant``.
     source
         The source for the attribute pipeline. This can be a callable
         or a list of column names. If a list of column names is provided,
@@ -66,17 +91,8 @@ def register_risk_affected_attribute_producer(
         An AttributePostProcessor or list of AttributePostProcessors to apply
         to the attribute pipeline.
     """
-    post_processors = (
-        post_processors if isinstance(post_processors, Sequence) else [post_processors]
-    )
     _RiskAffectedPipeline.create(
-        builder,
-        name,
-        source,
-        effect_type,
-        required_resources,
-        post_processors,
-        is_rate=False,
+        builder, name, source, effect_type, required_resources, post_processors, is_rate=False
     )
 
 
@@ -88,14 +104,37 @@ def register_risk_affected_rate_producer(
     required_resources: Sequence[str | Resource] = (),
     post_processors: AttributePostProcessor | Sequence[AttributePostProcessor] = (),
 ) -> None:
-    """Helper function to register a rate pipeline that can be modified by CausalFactorEffect components.
+    """Register a pair of pipelines for a rate targetable by CausalFactorEffect components.
+
+    Two value pipelines are registered:
+
+    * The **target rate pipeline** (``name``): produces the affected rate.
+      Other components register their effects as modifiers on this
+      pipeline.
+    * The **calibration constant pipeline**
+      (``<name>.calibration_constant``): a companion pipeline that any
+      component modifying the target should also modify, registering the
+      calibration constant that corresponds to its effect. The joint
+      calibration constant is precomputed at the end of setup and
+      registered as a modifier on the target pipeline so that the
+      population-level baseline is preserved.
+
+    The joint calibration constant is shaped to cancel cleanly against the
+    target pipeline's combiner:
+
+    * For ``"multiplicative"`` effects, the joint value is
+      ``1 - raw_union(c_i) = prod(1 - c_i)``. Multiplying the target by
+      this value scales it by the surviving fraction.
+    * For ``"additive"`` effects, the joint value is ``-sum(c_i)``. Adding
+      this to the target subtracts the cumulative additive effect.
 
     Parameters
     ----------
     builder
         The Builder object to use for registration.
     name
-        The name of the pipeline to register.
+        The name of the target pipeline to register. The calibration constant
+        pipeline is registered at ``<name>.calibration_constant``.
     source
         The source for the rate pipeline. This can be a callable
         or a list of column names. If a list of column names is provided,
@@ -112,16 +151,41 @@ def register_risk_affected_rate_producer(
         An AttributePostProcessor or list of AttributePostProcessors to apply
         to the attribute pipeline.
     """
-    post_processors = (
-        post_processors if isinstance(post_processors, Sequence) else [post_processors]
-    )
     _RiskAffectedPipeline.create(
         builder, name, source, effect_type, required_resources, post_processors, is_rate=True
     )
 
 
 class _RiskAffectedPipeline(Component):
-    """Convenience class to package pipelines that can be targeted by CausalFactorEffect."""
+    """Package a pair of pipelines that can be targeted by CausalFactorEffect components.
+
+    Two value pipelines are registered during ``setup``:
+
+    * The **target pipeline** (``<name>``): produces the affected attribute or
+      rate. Other components register their effects as modifiers on this
+      pipeline. The combiner used depends on ``effect_type`` —
+      :func:`~vivarium.framework.values.multiplication_combiner` for
+      ``"multiplicative"`` effects and
+      :func:`~vivarium.framework.values.addition_combiner` for ``"additive"``
+      effects.
+    * The **calibration constant pipeline**
+      (``<name>.calibration_constant``): a companion pipeline that any
+      component modifying the target should also modify, registering the
+      calibration constant that corresponds to its effect. The collected
+      constants ``c_i`` are reduced to a single joint value (see below).
+      In ``on_post_setup`` the joint value is materialized into
+      :attr:`_calibration_constant_table` and registered as a modifier on
+      the target pipeline.
+
+    The joint calibration constant is shaped to cancel cleanly against the
+    target pipeline's combiner, preserving the population-level baseline:
+
+    * For ``"multiplicative"`` effects, the post-processor returns
+      ``1 - raw_union(c_i) = prod(1 - c_i)``. Multiplying the target by this
+      value scales it by the surviving fraction.
+    * For ``"additive"`` effects, the post-processor returns ``-sum(c_i)``.
+      Adding this to the target subtracts the cumulative additive effect.
+    """
 
     @classmethod
     def create(
@@ -131,13 +195,15 @@ class _RiskAffectedPipeline(Component):
         source: Callable[..., pd.Series],
         effect_type: Literal["multiplicative", "additive"],
         required_resources: Sequence[str | Resource],
-        post_processors: Sequence[AttributePostProcessor],
+        post_processors: AttributePostProcessor | Sequence[AttributePostProcessor],
         is_rate: bool,
-    ) -> None:
+    ) -> _RiskAffectedPipeline:
         """Factory method to create and set up the class."""
-        cls(
+        pipeline = cls(
             name, source, effect_type, required_resources, post_processors, is_rate
-        ).setup_component(builder)
+        )
+        pipeline.setup_component(builder)
+        return pipeline
 
     def __init__(
         self,
@@ -145,16 +211,28 @@ class _RiskAffectedPipeline(Component):
         target_pipeline_source: Callable[..., pd.Series],
         effect_type: Literal["multiplicative", "additive"],
         required_resources: Sequence[str | Resource],
-        post_processors: Sequence[AttributePostProcessor],
+        post_processors: AttributePostProcessor | Sequence[AttributePostProcessor],
         is_rate: bool,
     ):
         super().__init__()
         self._target_pipeline_name = target_pipeline_name
+        """Name of the target pipeline."""
         self._target_pipeline_source = target_pipeline_source
+        """Callable that produces values for the target pipeline."""
         self._effect_type = effect_type
+        """``"multiplicative"`` or ``"additive"``. Determines the combiner used on the
+        target pipeline and the reduction used to compute the joint calibration
+        constant."""
         self._required_resources = required_resources
-        self._post_processors = post_processors
+        """Resources the target pipeline depends on."""
+        self._post_processors = (
+            post_processors if isinstance(post_processors, Sequence) else [post_processors]
+        )
+        """AttributePostProcessors applied to the target pipeline after the combiner
+        runs. Normalized to a sequence even when a single post-processor is supplied."""
         self._is_rate = is_rate
+        """``True`` if the target pipeline is a rate, ``False`` if it is an attribute.
+        Selects between ``register_rate_producer`` and ``register_attribute_producer``."""
 
     def setup(self, builder: Builder) -> None:
         """Register the calibration constant and target pipelines.
@@ -167,12 +245,17 @@ class _RiskAffectedPipeline(Component):
         self._calibration_constant_table = self.build_lookup_table(
             builder, "calibration_constant", data_source=0
         )
+        """Lookup table populated in ``on_post_setup`` with the precomputed joint
+        calibration constant. Registered as a modifier on the target pipeline so the
+        constant is applied uniformly without re-running the reduction each time-step."""
         self._calibration_constant_pipeline = builder.value.register_value_producer(
             get_calibration_constant_pipeline_name(self._target_pipeline_name),
             source=lambda: [0],
             preferred_combiner=self._calibration_constant_combiner,
             preferred_post_processor=self._calibration_constant_post_processor,
         )
+        """Value pipeline that produces the joint calibration constant by reducing
+        the list of registered calibration constants."""
 
         register_pipeline = (
             builder.value.register_rate_producer
@@ -193,6 +276,9 @@ class _RiskAffectedPipeline(Component):
             preferred_post_processor=self._post_processors,
         )
 
+        # Register the calibration constant table as a modifier on the target pipeline.
+        # Calibrations constant application is commutative with other modifiers, so the
+        # order of application does not matter.
         builder.value.register_attribute_modifier(
             self._target_pipeline_name, modifier=self._calibration_constant_table
         )
@@ -231,12 +317,22 @@ class _RiskAffectedPipeline(Component):
     def _calibration_constant_post_processor(
         self, value: list[NumberLike], manager: ValuesManager
     ) -> LookupTableData:
-        """Compute the joint calibration constant.
+        """Reduce the list of registered calibration constants to a single joint value.
 
-        Uses a union post processor if the effect type is multiplicative and an addition
-        post processor if the effect type is additive.
+        The returned value is shaped so that it cancels the cumulative effects
+        when applied to the target pipeline by the corresponding combiner,
+        preserving the population-level baseline.
 
+        * ``"multiplicative"`` effects: returns ``1 - raw_union(c_i)``, which
+          equals ``prod(1 - c_i)``. Applied via
+          :func:`~vivarium.framework.values.multiplication_combiner`, this
+          scales the target by the surviving fraction.
+        * ``"additive"`` effects: returns ``-sum(c_i)``. The negation is
+          essential — applied via
+          :func:`~vivarium.framework.values.addition_combiner`, this
+          subtracts the cumulative additive effect from the target.
 
+        See the class docstring for the broader context.
         """
         if self._effect_type == "multiplicative":
             joint_calibration_constant = 1 - raw_union_post_processor(value, manager)

--- a/src/vivarium_public_health/causal_factor/calibration_constant.py
+++ b/src/vivarium_public_health/causal_factor/calibration_constant.py
@@ -12,8 +12,9 @@ calibration constants.
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from typing import Any, Literal, overload
+from typing import Any, Literal
 from typing import SupportsFloat as Numeric
+from typing import overload
 
 import pandas as pd
 from vivarium import Component
@@ -48,6 +49,7 @@ def register_risk_affected_attribute_producer(
 ) -> None:
     ...
 
+
 @overload
 def register_risk_affected_attribute_producer(
     builder: Builder,
@@ -59,6 +61,7 @@ def register_risk_affected_attribute_producer(
     columns: list[str] = ...,
 ) -> None:
     ...
+
 
 def register_risk_affected_attribute_producer(
     builder: Builder,
@@ -120,7 +123,14 @@ def register_risk_affected_attribute_producer(
         None if the pipeline produces a Series.
     """
     _RiskAffectedPipeline.create(
-        builder, name, source, effect_type, required_resources, post_processors, columns, is_rate=False
+        builder,
+        name,
+        source,
+        effect_type,
+        required_resources,
+        post_processors,
+        columns,
+        is_rate=False,
     )
 
 
@@ -136,6 +146,7 @@ def register_risk_affected_rate_producer(
 ) -> None:
     ...
 
+
 @overload
 def register_risk_affected_rate_producer(
     builder: Builder,
@@ -147,6 +158,8 @@ def register_risk_affected_rate_producer(
     columns: list[str] = ...,
 ) -> None:
     ...
+
+
 def register_risk_affected_rate_producer(
     builder: Builder,
     name: str,
@@ -207,7 +220,14 @@ def register_risk_affected_rate_producer(
         None if the pipeline produces a Series.
     """
     _RiskAffectedPipeline.create(
-        builder, name, source, effect_type, required_resources, post_processors, columns, is_rate=True
+        builder,
+        name,
+        source,
+        effect_type,
+        required_resources,
+        post_processors,
+        columns,
+        is_rate=True,
     )
 
 
@@ -293,7 +313,7 @@ class _RiskAffectedPipeline(Component):
         self._is_rate = is_rate
         """``True`` if the target pipeline is a rate, ``False`` if it is an attribute.
         Selects between ``register_rate_producer`` and ``register_attribute_producer``."""
-    
+
     def setup(self, builder: Builder) -> None:
         """Register the calibration constant and target pipelines.
 
@@ -373,7 +393,9 @@ class _RiskAffectedPipeline(Component):
         """Append the mutator result to the calibration constant list."""
         calibration_constant = mutator(*args, **kwargs)
         if isinstance(calibration_constant, pd.DataFrame):
-            value_columns = self._columns if not isinstance(self._columns, str) else [self._columns]
+            value_columns = (
+                self._columns if not isinstance(self._columns, str) else [self._columns]
+            )
             index_columns = [
                 col for col in calibration_constant.columns if col not in value_columns
             ]

--- a/src/vivarium_public_health/causal_factor/distributions.py
+++ b/src/vivarium_public_health/causal_factor/distributions.py
@@ -621,17 +621,28 @@ class DichotomousDistribution(CausalFactorDistribution):
     Support optional rebinning of polytomous exposure data.
     """
 
+    @staticmethod
+    def get_exposed(causal_factor_type: str) -> str:
+        """The name of the exposed category for the given causal factor type."""
+        return "covered" if causal_factor_type == "intervention" else "exposed"
+
+    @staticmethod
+    def get_unexposed(causal_factor_type: str) -> str:
+        """The name of the unexposed category for the given causal factor type."""
+        return "uncovered" if causal_factor_type == "intervention" else "unexposed"
+
     @property
     def exposed(self) -> str:
         """The name of the exposed category."""
-        return "covered" if self.causal_factor.type == "intervention" else "exposed"
+        return self.get_exposed(self.causal_factor.type)
 
     @property
     def unexposed(self) -> str:
         """The name of the unexposed category."""
-        return "uncovered" if self.causal_factor.type == "intervention" else "unexposed"
+        return self.get_unexposed(self.causal_factor.type)
 
-    def rename_deprecated_categories(self, data: pd.DataFrame) -> pd.DataFrame:
+    @staticmethod
+    def rename_deprecated_categories(causal_factor_type: str, data: pd.DataFrame) -> pd.DataFrame:
         """Rename deprecated cat1/cat2 parameter values to exposed/unexposed.
 
         If the data contains ``'cat1'`` in its ``'parameter'`` column, the
@@ -642,6 +653,8 @@ class DichotomousDistribution(CausalFactorDistribution):
 
         Parameters
         ----------
+        causal_factor_type
+            The type of the causal factor (e.g. ``"intervention"`` or ``"risk_factor"``).
         data
             A DataFrame with a ``'parameter'`` column.
 
@@ -652,17 +665,17 @@ class DichotomousDistribution(CausalFactorDistribution):
         if "cat1" not in data["parameter"].values:
             return data
 
-        if self.causal_factor.type != "intervention":
+        exposed = DichotomousDistribution.get_exposed(causal_factor_type)
+        unexposed = DichotomousDistribution.get_unexposed(causal_factor_type)
+        if causal_factor_type != "intervention":
             warnings.warn(
                 "Using 'cat1' and 'cat2' for dichotomous exposure is deprecated "
                 "and will be removed in a future release. Use "
-                f"'{self.exposed}' and '{self.unexposed}' instead.",
+                f"'{exposed}' and '{unexposed}' instead.",
                 FutureWarning,
                 stacklevel=3,
             )
-        data["parameter"] = data["parameter"].replace(
-            {"cat1": self.exposed, "cat2": self.unexposed}
-        )
+        data["parameter"] = data["parameter"].replace({"cat1": exposed, "cat2": unexposed})
         return data
 
     #####################
@@ -785,7 +798,7 @@ class DichotomousDistribution(CausalFactorDistribution):
         # rebin exposure categories
         self.validate_rebin_source(builder, exposure_data)
         rebin_exposed_categories = set(self.configuration["rebinned_exposed"])
-        exposure_data = self.rename_deprecated_categories(exposure_data)
+        exposure_data = self.rename_deprecated_categories(self.causal_factor.type, exposure_data)
         if rebin_exposed_categories:
             exposure_data = self._rebin_exposure_data(exposure_data, rebin_exposed_categories)
 

--- a/src/vivarium_public_health/causal_factor/distributions.py
+++ b/src/vivarium_public_health/causal_factor/distributions.py
@@ -564,14 +564,15 @@ class PolytomousDistribution(CausalFactorDistribution):
             A lookup table for the exposure parameters.
         """
         data = self.get_exposure_data(builder)
-        value_columns = self.get_exposure_value_columns(data)
 
         if isinstance(data, pd.DataFrame):
-            data = pivot_categorical(data, "parameter")
+            if "parameter" in data.index.names:
+                data = data.reset_index("parameter")
+            index_cols = [c for c in data.columns if c not in ("parameter", "value")]
+            data = data.pivot(index=index_cols, columns="parameter", values="value")
+            data.columns.name = None
 
-        return self.build_lookup_table(
-            builder, "exposure_parameters", data_source=data, value_columns=value_columns
-        )
+        return self.build_lookup_table(builder, "exposure_parameters", data_source=data)
 
     ##################################
     # Pipeline sources and modifiers #
@@ -645,13 +646,7 @@ class DichotomousDistribution(CausalFactorDistribution):
     def rename_deprecated_categories(
         causal_factor_type: str, data: pd.DataFrame
     ) -> pd.DataFrame:
-        """Rename deprecated cat1/cat2 parameter values to exposed/unexposed.
-
-        If the data contains ``'cat1'`` in its ``'parameter'`` column, the
-        values are replaced with the distribution's :attr:`exposed` and
-        :attr:`unexposed` names.  A :class:`FutureWarning` is emitted for
-        non-intervention causal factors to signal that the old names will be
-        removed in a future release.
+        """Rename deprecated cat1/cat2 column names to exposed/unexposed.
 
         Parameters
         ----------
@@ -664,12 +659,9 @@ class DichotomousDistribution(CausalFactorDistribution):
         -------
             The DataFrame with renamed parameter values (modified in place).
         """
-        if "cat1" not in data["parameter"].values:
-            return data
-
-        exposed = DichotomousDistribution.get_exposed(causal_factor_type)
-        unexposed = DichotomousDistribution.get_unexposed(causal_factor_type)
-        if causal_factor_type != "intervention":
+        if "cat1" in data.columns or "cat2" in data.columns:
+            exposed = DichotomousDistribution.get_exposed(causal_factor_type)
+            unexposed = DichotomousDistribution.get_unexposed(causal_factor_type)
             warnings.warn(
                 "Using 'cat1' and 'cat2' for dichotomous exposure is deprecated "
                 "and will be removed in a future release. Use "
@@ -677,7 +669,7 @@ class DichotomousDistribution(CausalFactorDistribution):
                 FutureWarning,
                 stacklevel=3,
             )
-        data["parameter"] = data["parameter"].replace({"cat1": exposed, "cat2": unexposed})
+            data = data.rename(columns={"cat1": exposed, "cat2": unexposed})
         return data
 
     #####################
@@ -768,8 +760,8 @@ class DichotomousDistribution(CausalFactorDistribution):
         data = self.get_exposure_data(builder)
 
         if isinstance(data, pd.DataFrame):
-            any_negatives = (data[DEFAULT_VALUE_COLUMN] < 0).any().any()
-            any_over_one = (data[DEFAULT_VALUE_COLUMN] > 1).any().any()
+            any_negatives = (data < 0).any().any()
+            any_over_one = (data > 1).any().any()
             if any_negatives or any_over_one:
                 raise ValueError(
                     f"All exposures must be in the range [0, 1] for {self.causal_factor}"
@@ -789,25 +781,27 @@ class DichotomousDistribution(CausalFactorDistribution):
 
         Returns
         -------
-            The (possibly rebinned) exposure data for the exposed
-            category.
+            The (possibly rebinned) exposure data with lookup attributes on
+            the row index and exposure categories on the columns.
         """
         exposure_data = super().get_exposure_data(builder)
 
         if isinstance(exposure_data, (int, float)):
             return exposure_data
 
-        # rebin exposure categories
         self.validate_rebin_source(builder, exposure_data)
         rebin_exposed_categories = set(self.configuration["rebinned_exposed"])
-        exposure_data = self.rename_deprecated_categories(
-            self.causal_factor.type, exposure_data
-        )
         if rebin_exposed_categories:
             exposure_data = self._rebin_exposure_data(exposure_data, rebin_exposed_categories)
 
-        exposure_data = exposure_data[exposure_data["parameter"] == self.exposed]
-        return exposure_data.drop(columns="parameter")
+        if "parameter" in exposure_data.index.names:
+            exposure_data = exposure_data.reset_index("parameter")
+        index_cols = [c for c in exposure_data.columns if c not in ("parameter", "value")]
+        exposure_data = exposure_data.pivot(
+            index=index_cols, columns="parameter", values="value"
+        )
+        exposure_data.columns.name = None
+        return self.rename_deprecated_categories(self.causal_factor.type, exposure_data)
 
     def _rebin_exposure_data(
         self, exposure_data: pd.DataFrame, rebin_exposed_categories: set
@@ -893,7 +887,10 @@ class DichotomousDistribution(CausalFactorDistribution):
         -------
             A series of exposure probabilities.
         """
-        return self.exposure_table(index)
+        result = self.exposure_table(index)
+        if isinstance(result, pd.DataFrame):
+            return result[self.exposed]
+        return result
 
     def exposure_ppf(self, index: pd.Index) -> pd.Series:
         """Assign each simulant to the exposed or unexposed category based on propensity.

--- a/src/vivarium_public_health/causal_factor/distributions.py
+++ b/src/vivarium_public_health/causal_factor/distributions.py
@@ -642,7 +642,9 @@ class DichotomousDistribution(CausalFactorDistribution):
         return self.get_unexposed(self.causal_factor.type)
 
     @staticmethod
-    def rename_deprecated_categories(causal_factor_type: str, data: pd.DataFrame) -> pd.DataFrame:
+    def rename_deprecated_categories(
+        causal_factor_type: str, data: pd.DataFrame
+    ) -> pd.DataFrame:
         """Rename deprecated cat1/cat2 parameter values to exposed/unexposed.
 
         If the data contains ``'cat1'`` in its ``'parameter'`` column, the
@@ -798,7 +800,9 @@ class DichotomousDistribution(CausalFactorDistribution):
         # rebin exposure categories
         self.validate_rebin_source(builder, exposure_data)
         rebin_exposed_categories = set(self.configuration["rebinned_exposed"])
-        exposure_data = self.rename_deprecated_categories(self.causal_factor.type, exposure_data)
+        exposure_data = self.rename_deprecated_categories(
+            self.causal_factor.type, exposure_data
+        )
         if rebin_exposed_categories:
             exposure_data = self._rebin_exposure_data(exposure_data, rebin_exposed_categories)
 

--- a/src/vivarium_public_health/causal_factor/effect.py
+++ b/src/vivarium_public_health/causal_factor/effect.py
@@ -8,7 +8,8 @@ exposure models and the models they affect.
 
 """
 
-from abc import ABC
+import warnings
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from importlib import import_module
 from typing import Any
@@ -63,9 +64,10 @@ class CausalFactorEffect(Component, ABC):
         return self.get_name(self.causal_factor, self.target)
 
     @staticmethod
+    @abstractmethod
     def get_name(causal_factor: EntityString, target: TargetString) -> str:
         """Return the component name for a causal factor and target pair."""
-        return f"causal_factor_effect.{causal_factor.name}_on_{target}"
+        ...
 
     @property
     def configuration_defaults(self) -> dict[str, Any]:
@@ -96,11 +98,11 @@ class CausalFactorEffect(Component, ABC):
         return {
             self.name: {
                 "data_sources": {
-                    "relative_risk": f"{self.causal_factor}.relative_risk",
+                    self.effect_type: f"{self.causal_factor}.{self.effect_type}",
                     "population_attributable_fraction": f"{self.causal_factor}.population_attributable_fraction",
                 },
                 "data_source_parameters": {
-                    "relative_risk": {},
+                    self.effect_type: {},
                 },
             }
         }
@@ -113,6 +115,18 @@ class CausalFactorEffect(Component, ABC):
             "ordered_polytomous",
             "unordered_polytomous",
         ]
+
+    @property
+    @abstractmethod
+    def effect_type(self) -> str:
+        """The type of effect data to use for this causal factor effect."""
+        ...
+
+    @property
+    @abstractmethod
+    def calibration_constant_type(self) -> str:
+        """The type of calibration constant data to use for this causal factor effect."""
+        ...
 
     #####################
     # Lifecycle methods #
@@ -140,15 +154,15 @@ class CausalFactorEffect(Component, ABC):
 
         self.exposure_name = f"{self.causal_factor.name}.exposure"
         self.target_name = f"{self.target.name}.{self.target.measure}"
-        self.relative_risk_name = (
-            f"{self.causal_factor.name}_on_{self.target_name}.relative_risk"
+        self.effect_name = (
+            f"{self.causal_factor.name}_on_{self.target_name}.{self.effect_type}"
         )
 
     def setup(self, builder: Builder) -> None:
         """Set up the causal factor effect component.
 
-        Load distribution type and PAF data, define relative risk source,
-        build relative risk lookup tables, register relative risk pipeline,
+        Load distribution type and PAF data, define effect source,
+        build effect lookup tables, register effect pipeline,
         and register target and calibration constant modifiers.
 
         Parameters
@@ -157,11 +171,11 @@ class CausalFactorEffect(Component, ABC):
             Access point for utilizing framework interfaces during setup.
         """
         self._exposure_distribution_type = self.get_distribution_type(builder)
-        self.relative_risk_table = self.build_rr_lookup_table(builder)
-        self.paf_data = self.get_calibration_constant_data(builder)
+        self.effect_table = self.build_effect_lookup_table(builder)
+        self.calibration_constant_data = self.get_calibration_constant_data(builder)
 
-        self._relative_risk_source = self.get_relative_risk_source(builder)
-        self.register_relative_risk_pipeline(builder)
+        self._effect_source = self.get_effect_source(builder)
+        self.register_effect_pipeline(builder)
 
         self.register_target_modifier(builder)
         self.register_calibration_constant_modifier(builder)
@@ -170,8 +184,8 @@ class CausalFactorEffect(Component, ABC):
     # Setup methods #
     #################
 
-    def build_rr_lookup_table(self, builder: Builder) -> LookupTable:
-        """Build a lookup table for relative risk data.
+    def build_effect_lookup_table(self, builder: Builder) -> LookupTable:
+        """Build a lookup table for effect data.
 
         Parameters
         ----------
@@ -180,18 +194,32 @@ class CausalFactorEffect(Component, ABC):
 
         Returns
         -------
-            A lookup table of relative risk values.
+            A lookup table of effect values.
         """
-        rr_data = self.load_relative_risk(builder)
-        rr_value_cols = None
+        if hasattr(self, "build_rr_lookup_table"):
+            warnings.warn(
+                f"{self.__class__.__name__} defines a `build_rr_lookup_table` method, which is "
+                "deprecated. Please rename this method to `build_effect_lookup_table` and change "
+                "your lookup table to use `self.effect_type` as its name.",
+                DeprecationWarning,
+            )
+            return self.build_rr_lookup_table(builder)
+
+        effect_data = self.load_effect_data(builder)
+        effect_value_cols = None
         if self.is_exposure_categorical:
-            rr_data, rr_value_cols = self.process_categorical_data(builder, rr_data)
+            effect_data, effect_value_cols = self.process_categorical_data(
+                builder, effect_data
+            )
         return self.build_lookup_table(
-            builder, "relative_risk", data_source=rr_data, value_columns=rr_value_cols
+            builder,
+            self.effect_type,
+            data_source=effect_data,
+            value_columns=effect_value_cols,
         )
 
     def get_calibration_constant_data(self, builder: Builder) -> LookupTableData:
-        """Load calibration constant (PAF) data for this effect.
+        """Load calibration constant data for this effect.
 
         Parameters
         ----------
@@ -203,25 +231,23 @@ class CausalFactorEffect(Component, ABC):
             The calibration constant data.
         """
         return self.get_filtered_data(
-            builder, self.configuration.data_sources.population_attributable_fraction
+            builder, self.configuration.data_sources[self.calibration_constant_type]
         )
 
     def get_distribution_type(self, builder: Builder) -> str:
         """Get the distribution type for the causal factor from the configuration."""
-        causal_factor_exposure_component = self._get_causal_factor_exposure_component(
-            builder
-        )
+        causal_factor_exposure_component = self._get_causal_factor_exposure_component(builder)
         return (
             causal_factor_exposure_component.distribution_type
             or causal_factor_exposure_component.get_distribution_type(builder)
         )
 
-    def load_relative_risk(
+    def load_effect_data(
         self,
         builder: Builder,
         configuration=None,
     ) -> str | float | pd.DataFrame:
-        """Load relative risk data from the configuration.
+        """Load effect data from the configuration.
 
         Attempt to interpret the configured source as a scipy.stats
         distribution name; if that fails, load it as artifact data.
@@ -236,33 +262,43 @@ class CausalFactorEffect(Component, ABC):
 
         Returns
         -------
-            The relative risk data.
+            The effect data.
 
         Raises
         ------
         ConfigurationError
             If the distribution parameters are invalid.
         """
+        if hasattr(self, "load_relative_risk"):
+            warnings.warn(
+                f"{self.__class__.__name__} defines a `load_relative_risk` method, which is "
+                "deprecated. Please rename this method to `load_effect_data`.",
+                DeprecationWarning,
+            )
+            return self.load_relative_risk(builder, configuration)
+
         if configuration is None:
             configuration = self.configuration
 
-        rr_source = configuration.data_sources.relative_risk
-        rr_dist_parameters = configuration.data_source_parameters.relative_risk.to_dict()
+        effect_source = configuration.data_sources[self.effect_type]
+        effect_dist_parameters = configuration.data_source_parameters[
+            self.effect_type
+        ].to_dict()
 
-        if isinstance(rr_source, str):
+        if isinstance(effect_source, str):
             try:
-                distribution = getattr(import_module("scipy.stats"), rr_source)
+                distribution = getattr(import_module("scipy.stats"), effect_source)
                 rng = np.random.default_rng(builder.randomness.get_seed(self.name))
-                rr_data = distribution(**rr_dist_parameters).ppf(rng.random())
+                effect_data = distribution(**effect_dist_parameters).ppf(rng.random())
             except AttributeError:
-                rr_data = self.get_filtered_data(builder, rr_source)
+                effect_data = self.get_filtered_data(builder, effect_source)
             except TypeError:
                 raise ConfigurationError(
-                    f"Parameters {rr_dist_parameters} are not valid for distribution {rr_source}."
+                    f"Parameters {effect_dist_parameters} are not valid for distribution {effect_source}."
                 )
         else:
-            rr_data = self.get_filtered_data(builder, rr_source)
-        return rr_data
+            effect_data = self.get_filtered_data(builder, effect_source)
+        return effect_data
 
     def get_filtered_data(
         self, builder: Builder, data_source: str | float | pd.DataFrame
@@ -296,11 +332,11 @@ class CausalFactorEffect(Component, ABC):
         return data
 
     def process_categorical_data(
-        self, builder: Builder, rr_data: str | float | pd.DataFrame
+        self, builder: Builder, effect_data: str | float | pd.DataFrame
     ) -> tuple[str | float | pd.DataFrame, list[str]]:
-        """Process relative risk data for categorical exposures.
+        """Process effect data for categorical exposures.
 
-        For scalar RR data with a dichotomous distribution, construct a
+        For scalar effect data with a dichotomous distribution, construct a
         DataFrame with exposed/unexposed categories. Pivot the data to
         wide format for use in a lookup table.
 
@@ -308,63 +344,69 @@ class CausalFactorEffect(Component, ABC):
         ----------
         builder
             Access point for utilizing framework interfaces during setup.
-        rr_data
-            The relative risk data.
+        effect_data
+            The effect data.
 
         Returns
         -------
-            A tuple of the pivoted RR data and the list of value column
+            A tuple of the pivoted effect data and the list of value column
             names.
 
         Raises
         ------
         ValueError
-            If scalar RR data is provided with a non-dichotomous
+            If scalar effect data is provided with a non-dichotomous
             distribution.
         """
-        if not isinstance(rr_data, pd.DataFrame):
+        if not isinstance(effect_data, pd.DataFrame):
             if self._exposure_distribution_type != "dichotomous":
                 raise ValueError(
-                    f"Relative risk data for categorical exposure must be a DataFrame unless the "
-                    f"exposure distribution is dichotomous. Found type {type(rr_data)} with "
+                    f"{self.effect_type} data for categorical exposure must be a DataFrame unless the "
+                    f"exposure distribution is dichotomous. Found type {type(effect_data)} with "
                     f"exposure distribution type {self._exposure_distribution_type}."
                 )
             causal_factor_type = self.causal_factor.type
             cat1 = builder.data.load("population.demographic_dimensions")
             cat1["parameter"] = DichotomousDistribution.get_exposed(causal_factor_type)
-            cat1["value"] = rr_data
+            cat1["value"] = effect_data
             cat2 = cat1.copy()
             cat2["parameter"] = DichotomousDistribution.get_unexposed(causal_factor_type)
             cat2["value"] = 1
-            rr_data = pd.concat([cat1, cat2], ignore_index=True)
-        if "parameter" in rr_data.index.names:
-            rr_data = rr_data.reset_index("parameter")
+            effect_data = pd.concat([cat1, cat2], ignore_index=True)
+        if "parameter" in effect_data.index.names:
+            effect_data = effect_data.reset_index("parameter")
 
         if self._exposure_distribution_type == "dichotomous":
-            rr_data = DichotomousDistribution.rename_deprecated_categories(
-                self.causal_factor.type, rr_data
+            effect_data = DichotomousDistribution.rename_deprecated_categories(
+                self.causal_factor.type, effect_data
             )
 
-        rr_value_cols = list(rr_data["parameter"].unique())
-        rr_data = pivot_categorical(rr_data, "parameter")
-        return rr_data, rr_value_cols
+        effect_value_cols = list(effect_data["parameter"].unique())
+        effect_data = pivot_categorical(effect_data, "parameter")
+        return effect_data, effect_value_cols
 
     # todo currently this isn't being called. we need to properly set rrs if
     #  the exposure has been rebinned
-    def rebin_relative_risk_data(
-        self, builder, relative_risk_data: pd.DataFrame
-    ) -> pd.DataFrame:
-        """Rebin relative risk data.
+    def rebin_effect_data(self, builder, effect_data: pd.DataFrame) -> pd.DataFrame:
+        """Rebin effect data.
 
-        When the polytomous risk is rebinned, matching relative risk needs to be rebinned.
-        After rebinning, rr for both exposed and unexposed categories should be the weighted sum of relative risk
+        When the polytomous effect is rebinned, matching effect data needs to be rebinned.
+        After rebinning, effect data for both exposed and unexposed categories should be the weighted sum of effect data
         of the component categories where weights are relative proportions of exposure of those categories.
         For example, if cat1, cat2, cat3 are exposed categories and cat4 is unexposed with exposure [0.1,0.2,0.3,0.4],
-        for the matching rr = [rr1, rr2, rr3, 1], rebinned rr for the rebinned cat1 should be:
-        (0.1 *rr1 + 0.2 * rr2 + 0.3* rr3) / (0.1+0.2+0.3)
+        for the matching effect data = [effect1, effect2, effect3, 1], rebinned effect data for the rebinned cat1 should be:
+        (0.1 *effect1 + 0.2 * effect2 + 0.3* effect3) / (0.1+0.2+0.3)
         """
+        if hasattr(self, "rebin_relative_risk_data"):
+            warnings.warn(
+                f"{self.__class__.__name__} defines a `rebin_relative_risk_data` method, which is "
+                f"deprecated. Please rename this method to `rebin_effect_data`.",
+                DeprecationWarning,
+            )
+            return self.rebin_relative_risk_data(builder, effect_data)
+
         if not self.causal_factor in builder.configuration.to_dict():
-            return relative_risk_data
+            return effect_data
 
         rebin_exposed_categories = set(
             builder.configuration[self.causal_factor]["rebinned_exposed"]
@@ -373,39 +415,45 @@ class CausalFactorEffect(Component, ABC):
         if rebin_exposed_categories:
             # todo make sure this works
             exposure_data = load_exposure_data(builder, self.causal_factor)
-            relative_risk_data = self._rebin_relative_risk_data(
-                relative_risk_data, exposure_data, rebin_exposed_categories
+            effect_data = self._rebin_effect_data(
+                effect_data, exposure_data, rebin_exposed_categories
             )
 
-        return relative_risk_data
+        return effect_data
 
-    def _rebin_relative_risk_data(
+    def _rebin_effect_data(
         self,
-        relative_risk_data: pd.DataFrame,
+        effect_data: pd.DataFrame,
         exposure_data: pd.DataFrame,
         rebin_exposed_categories: set,
     ) -> pd.DataFrame:
         """Compute exposure-weighted relative risks for rebinned categories."""
+        if hasattr(self, "_rebin_relative_risk_data"):
+            warnings.warn(
+                f"{self.__class__.__name__} defines a `_rebin_relative_risk_data` method, which is "
+                f"deprecated. Please rename this method to `_rebin_effect_data`.",
+                DeprecationWarning,
+            )
+            return self._rebin_relative_risk_data(
+                effect_data, exposure_data, rebin_exposed_categories
+            )
+
         cols = list(exposure_data.columns.difference(["value"]))
 
-        relative_risk_data = relative_risk_data.merge(exposure_data, on=cols)
-        relative_risk_data["value_x"] = relative_risk_data.value_x.multiply(
-            relative_risk_data.value_y
-        )
-        relative_risk_data.parameter = relative_risk_data["parameter"].map(
+        effect_data = effect_data.merge(exposure_data, on=cols)
+        effect_data["value_x"] = effect_data.value_x.multiply(effect_data.value_y)
+        effect_data.parameter = effect_data["parameter"].map(
             lambda p: "cat1" if p in rebin_exposed_categories else "cat2"
         )
-        relative_risk_data = relative_risk_data.groupby(cols).sum().reset_index()
-        relative_risk_data["value"] = relative_risk_data.value_x.divide(
-            relative_risk_data.value_y
-        ).fillna(0)
-        return relative_risk_data.drop(columns=["value_x", "value_y"])
+        effect_data = effect_data.groupby(cols).sum().reset_index()
+        effect_data["value"] = effect_data.value_x.divide(effect_data.value_y).fillna(0)
+        return effect_data.drop(columns=["value_x", "value_y"])
 
-    def get_relative_risk_source(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
-        """Build a callable that computes relative risk from exposure.
+    def get_effect_source(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
+        """Build a callable that computes effect data from exposure.
 
         For continuous exposures, use TMRED-based log-linear scaling.
-        For categorical exposures, look up the RR for each simulant's
+        For categorical exposures, look up the effect data for each simulant's
         exposure category.
 
         Parameters
@@ -416,51 +464,66 @@ class CausalFactorEffect(Component, ABC):
         Returns
         -------
             A callable that accepts a simulant index and returns
-            relative risk values.
+            effect data values.
         """
+        if hasattr(self, "get_relative_risk_source"):
+            warnings.warn(
+                f"{self.__class__.__name__} defines a `get_relative_risk_source` method, which is "
+                f"deprecated. Please rename this method to `get_effect_source`.",
+                DeprecationWarning,
+            )
+            return self.get_relative_risk_source(builder)
 
         if not self.is_exposure_categorical:
             tmred = builder.data.load(f"{self.causal_factor}.tmred")
             tmrel = 0.5 * (tmred["min"] + tmred["max"])
             scale = builder.data.load(f"{self.causal_factor}.relative_risk_scalar")
 
-            def generate_relative_risk(index: pd.Index) -> pd.Series:
-                rr = self.relative_risk_table(index)
+            def generate_effect(index: pd.Index) -> pd.Series:
+                effect = self.effect_table(index)
                 exposure = self.population_view.get(index, self.exposure_name)
-                relative_risk = np.maximum(rr.values ** ((exposure - tmrel) / scale), 1)
-                return relative_risk
+                effect = np.maximum(effect.values ** ((exposure - tmrel) / scale), 1)
+                return effect
 
         else:
             index_columns = ["index", self.causal_factor.name]
 
-            def generate_relative_risk(index: pd.Index) -> pd.Series:
-                rr = self.relative_risk_table(index)
+            def generate_effect(index: pd.Index) -> pd.Series:
+                effect = self.effect_table(index)
                 exposure = self.population_view.get(index, self.exposure_name).reset_index()
                 exposure.columns = index_columns
                 exposure = exposure.set_index(index_columns)
 
-                relative_risk = rr.stack().reset_index()
-                relative_risk.columns = index_columns + ["value"]
-                relative_risk = relative_risk.set_index(index_columns)
+                effect = effect.stack().reset_index()
+                effect.columns = index_columns + ["value"]
+                effect = effect.set_index(index_columns)
 
-                effect = relative_risk.loc[exposure.index, "value"].droplevel(
+                effect = effect.loc[exposure.index, "value"].droplevel(
                     self.causal_factor.name
                 )
                 return effect
 
-        return generate_relative_risk
+        return generate_effect
 
-    def register_relative_risk_pipeline(self, builder: Builder) -> None:
-        """Register the relative risk pipeline with the simulation.
+    def register_effect_pipeline(self, builder: Builder) -> None:
+        """Register the effect pipeline with the simulation.
 
         Parameters
         ----------
         builder
             Access point for utilizing framework interfaces during setup.
         """
+        if hasattr(self, "register_relative_risk_pipeline"):
+            warnings.warn(
+                f"{self.__class__.__name__} defines a `register_relative_risk_pipeline` method, which is "
+                f"deprecated. Please rename this method to `register_effect_pipeline`.",
+                DeprecationWarning,
+            )
+            return self.register_relative_risk_pipeline(builder)
+
         builder.value.register_attribute_producer(
-            self.relative_risk_name,
-            self._relative_risk_source,
+            self.effect_name,
+            self._effect_source,
             required_resources=[self.exposure_name],
         )
 
@@ -472,12 +535,10 @@ class CausalFactorEffect(Component, ABC):
         builder
             Access point for utilizing framework interfaces during setup.
         """
-        builder.value.register_attribute_modifier(
-            self.target_name, modifier=self.relative_risk_name
-        )
+        builder.value.register_attribute_modifier(self.target_name, modifier=self.effect_name)
 
     def register_calibration_constant_modifier(self, builder: Builder) -> None:
-        """Register the PAF data as a modifier on the calibration constant pipeline.
+        """Register the calibration constant data as a modifier on the calibration constant pipeline.
 
         Parameters
         ----------
@@ -486,7 +547,7 @@ class CausalFactorEffect(Component, ABC):
         """
         builder.value.register_value_modifier(
             get_calibration_constant_pipeline_name(self.target_name),
-            modifier=lambda: self.paf_data,
+            modifier=lambda: self.calibration_constant_data,
         )
 
     ##################
@@ -502,6 +563,39 @@ class CausalFactorEffect(Component, ABC):
         )
         if not isinstance(causal_factor_exposure_component, self.EXPOSURE_CLASS):
             raise ValueError(
-                f"{self.__class__.__name__} model {self.name} requires a {self.EXPOSURE_CLASS.__name__} component named {self.causal_factor}"
+                f"{self.__class__.__name__} model {self.name} requires a {self.EXPOSURE_CLASS.__name__} "
+                f"component named '{self.causal_factor}'."
             )
         return causal_factor_exposure_component
+
+
+class MultiplicativeEffect(CausalFactorEffect, ABC):
+    """A multiplicative effect model, where the effect data represents a relative risk
+    that is multiplied by the target measure.
+    """
+
+    @property
+    def effect_type(self) -> str:
+        """The type of effect data to use for this multiplicative effect."""
+        return "relative_risk"
+
+    @property
+    def calibration_constant_type(self) -> str:
+        """The type of calibration constant data to use for this multiplicative effect."""
+        return "population_attributable_fraction"
+
+
+class AdditiveEffect(CausalFactorEffect, ABC):
+    """An additive effect model, where the effect data represents an additive effect
+    that is added to the target measure.
+    """
+
+    @property
+    def effect_type(self) -> str:
+        """The type of effect data to use for this additive effect."""
+        return "additive_effect"
+
+    @property
+    def calibration_constant_type(self) -> str:
+        """The type of calibration constant data to use for this additive effect."""
+        return "calibration_constant"

--- a/src/vivarium_public_health/causal_factor/effect.py
+++ b/src/vivarium_public_health/causal_factor/effect.py
@@ -156,9 +156,6 @@ class CausalFactorEffect(Component, ABC):
         builder
             Access point for utilizing framework interfaces during setup.
         """
-        self.causal_factor_exposure_component = self._get_causal_factor_exposure_component(
-            builder
-        )
         self._exposure_distribution_type = self.get_distribution_type(builder)
         self.relative_risk_table = self.build_rr_lookup_table(builder)
         self.paf_data = self.get_calibration_constant_data(builder)
@@ -211,9 +208,12 @@ class CausalFactorEffect(Component, ABC):
 
     def get_distribution_type(self, builder: Builder) -> str:
         """Get the distribution type for the causal factor from the configuration."""
+        causal_factor_exposure_component = self._get_causal_factor_exposure_component(
+            builder
+        )
         return (
-            self.causal_factor_exposure_component.distribution_type
-            or self.causal_factor_exposure_component.get_distribution_type(builder)
+            causal_factor_exposure_component.distribution_type
+            or causal_factor_exposure_component.get_distribution_type(builder)
         )
 
     def load_relative_risk(
@@ -284,7 +284,7 @@ class CausalFactorEffect(Component, ABC):
 
         if isinstance(data, pd.DataFrame):
             # filter data to only include the target entity and measure
-            correct_target_mask = True
+            correct_target_mask = pd.Series(True, index=data.index)
             columns_to_drop = []
             if "affected_entity" in data.columns:
                 correct_target_mask &= data["affected_entity"] == self.target.name
@@ -323,28 +323,27 @@ class CausalFactorEffect(Component, ABC):
             distribution.
         """
         if not isinstance(rr_data, pd.DataFrame):
-            exposure_distribution = (
-                self.causal_factor_exposure_component.exposure_distribution
-            )
-            if not isinstance(exposure_distribution, DichotomousDistribution):
+            if self._exposure_distribution_type != "dichotomous":
                 raise ValueError(
                     f"Relative risk data for categorical exposure must be a DataFrame unless the "
                     f"exposure distribution is dichotomous. Found type {type(rr_data)} with "
-                    f"exposure distribution type {exposure_distribution.distribution_type}."
+                    f"exposure distribution type {self._exposure_distribution_type}."
                 )
+            causal_factor_type = self.causal_factor.type
             cat1 = builder.data.load("population.demographic_dimensions")
-            cat1["parameter"] = exposure_distribution.exposed
+            cat1["parameter"] = DichotomousDistribution.get_exposed(causal_factor_type)
             cat1["value"] = rr_data
             cat2 = cat1.copy()
-            cat2["parameter"] = exposure_distribution.unexposed
+            cat2["parameter"] = DichotomousDistribution.get_unexposed(causal_factor_type)
             cat2["value"] = 1
             rr_data = pd.concat([cat1, cat2], ignore_index=True)
         if "parameter" in rr_data.index.names:
             rr_data = rr_data.reset_index("parameter")
 
-        exposure_distribution = self.causal_factor_exposure_component.exposure_distribution
-        if isinstance(exposure_distribution, DichotomousDistribution):
-            rr_data = exposure_distribution.rename_deprecated_categories(rr_data)
+        if self._exposure_distribution_type == "dichotomous":
+            rr_data = DichotomousDistribution.rename_deprecated_categories(
+                self.causal_factor.type, rr_data
+            )
 
         rr_value_cols = list(rr_data["parameter"].unique())
         rr_data = pivot_categorical(rr_data, "parameter")

--- a/src/vivarium_public_health/causal_factor/effect.py
+++ b/src/vivarium_public_health/causal_factor/effect.py
@@ -13,7 +13,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from importlib import import_module
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -103,35 +103,40 @@ class CausalFactorEffect(Component, ABC):
 
             {causal_factor_effect_name}:
                 data_sources:
-                    relative_risk:
-                        Source for relative risk data. Default is the artifact
-                        key ``{causal_factor}.relative_risk``. Can also be:
+                    effect:
+                        Source for effect data. Default is the artifact
+                        key ``{causal_factor}.effect``. Can also be:
                         - A scalar value (e.g., ``1.5``)
                         - A scipy.stats distribution name (e.g., ``"uniform"``)
                           with parameters in ``data_source_parameters``
-                    population_attributable_fraction:
-                        Source for PAF data. Default is the artifact key
-                        ``{causal_factor}.population_attributable_fraction``. Used to
-                        adjust the target measure to account for the portion
-                        attributable to this causal factor.
+                    calibration_constant:
+                        Source for calibration constant data. Default is the
+                        artifact key ``{causal_factor}.calibration_constant``.
+                        Used to adjust the target measure to account for the
+                        portion attributable to this causal factor.
                 data_source_parameters:
-                    relative_risk: dict
+                    effect: dict
                         Parameters for scipy.stats distributions when using
-                        a distribution name as the ``relative_risk`` source.
+                        a distribution name as the ``effect`` source.
                         For example, ``{"loc": 1.0, "scale": 0.5}`` for a
                         uniform distribution.
         """
         return {
             self.name: {
                 "data_sources": {
-                    self.effect_type: f"{self.causal_factor}.{self.effect_type}",
-                    "population_attributable_fraction": f"{self.causal_factor}.population_attributable_fraction",
+                    "effect": f"{self.causal_factor}.effect",
+                    "calibration_constant": f"{self.causal_factor}.calibration_constant",
                 },
                 "data_source_parameters": {
-                    self.effect_type: {},
+                    "effect": {},
                 },
             }
         }
+
+    @property
+    def effect_parameters(self) -> dict[str, Any]:
+        """Effect parameters for this component."""
+        return self.configuration.data_source_parameters.effect.to_dict()
 
     @property
     def is_exposure_categorical(self) -> bool:
@@ -142,23 +147,16 @@ class CausalFactorEffect(Component, ABC):
             "unordered_polytomous",
         ]
 
-    @property
-    @abstractmethod
-    def effect_type(self) -> str:
-        """The type of effect data to use for this causal factor effect."""
-        ...
-
-    @property
-    @abstractmethod
-    def calibration_constant_type(self) -> str:
-        """The type of calibration constant data to use for this causal factor effect."""
-        ...
-
     #####################
     # Lifecycle methods #
     #####################
 
-    def __init__(self, causal_factor: str, target: str):
+    def __init__(
+        self,
+        causal_factor: str,
+        target: str,
+        effect_type: Literal["multiplicative", "additive"] = "multiplicative",
+    ):
         """
 
         Parameters
@@ -171,17 +169,24 @@ class CausalFactorEffect(Component, ABC):
             Type, name, and target measure of entity to be affected by causal factor,
             supplied in the form "entity_type.entity_name.measure"
             where entity_type should be singular (e.g., cause instead of causes).
+        effect_type
+            The type of effect model to use, either "multiplicative" or "additive".
+            This determines how the effect data modifies the target measure.
         """
         super().__init__()
         self.causal_factor = EntityString(causal_factor)
         self.target = TargetString(target)
+        self.effect_type = effect_type
 
         self._exposure_distribution_type = None
 
         self.exposure_name = f"{self.causal_factor.name}.exposure"
         self.target_name = f"{self.target.name}.{self.target.measure}"
+        effect_type_name = (
+            "relative_risk" if self.effect_type == "multiplicative" else "additive_effect"
+        )
         self.effect_name = (
-            f"{self.causal_factor.name}_on_{self.target_name}.{self.effect_type}"
+            f"{self.causal_factor.name}_on_{self.target_name}.{effect_type_name}"
         )
 
     def setup(self, builder: Builder) -> None:
@@ -249,7 +254,7 @@ class CausalFactorEffect(Component, ABC):
             The calibration constant data.
         """
         return self.get_filtered_data(
-            builder, self.configuration.data_sources[self.calibration_constant_type]
+            builder, self.configuration.data_sources.calibration_constant
         )
 
     def get_distribution_type(self, builder: Builder) -> str:
@@ -291,21 +296,18 @@ class CausalFactorEffect(Component, ABC):
         if configuration is None:
             configuration = self.configuration
 
-        effect_source = configuration.data_sources[self.effect_type]
-        effect_dist_parameters = configuration.data_source_parameters[
-            self.effect_type
-        ].to_dict()
+        effect_source = configuration.data_sources.effect
 
         if isinstance(effect_source, str):
             try:
                 distribution = getattr(import_module("scipy.stats"), effect_source)
                 rng = np.random.default_rng(builder.randomness.get_seed(self.name))
-                effect_data = distribution(**effect_dist_parameters).ppf(rng.random())
+                effect_data = distribution(**self.effect_parameters).ppf(rng.random())
             except AttributeError:
                 effect_data = self.get_filtered_data(builder, effect_source)
             except TypeError:
                 raise ConfigurationError(
-                    f"Parameters {effect_dist_parameters} are not valid for distribution {effect_source}."
+                    f"Parameters {self.effect_parameters} are not valid for distribution {effect_source}."
                 )
         else:
             effect_data = self.get_filtered_data(builder, effect_source)
@@ -372,7 +374,7 @@ class CausalFactorEffect(Component, ABC):
         if not isinstance(effect_data, pd.DataFrame):
             if self._exposure_distribution_type != "dichotomous":
                 raise ValueError(
-                    f"{self.effect_type} data for categorical exposure must be a DataFrame unless the "
+                    f"Effect data for categorical exposure must be a DataFrame unless the "
                     f"exposure distribution is dichotomous. Found type {type(effect_data)} with "
                     f"exposure distribution type {self._exposure_distribution_type}."
                 )
@@ -548,35 +550,3 @@ class CausalFactorEffect(Component, ABC):
                 f"component named '{self.causal_factor}'."
             )
         return causal_factor_exposure_component
-
-
-class MultiplicativeEffect(CausalFactorEffect, ABC):
-    """A multiplicative effect model, where the effect data represents a relative risk
-    that is multiplied by the target measure.
-    """
-
-    @property
-    def effect_type(self) -> str:
-        """The type of effect data to use for this multiplicative effect."""
-        return "relative_risk"
-
-    @property
-    def calibration_constant_type(self) -> str:
-        """The type of calibration constant data to use for this multiplicative effect."""
-        return "population_attributable_fraction"
-
-
-class AdditiveEffect(CausalFactorEffect, ABC):
-    """An additive effect model, where the effect data represents an additive effect
-    that is added to the target measure.
-    """
-
-    @property
-    def effect_type(self) -> str:
-        """The type of effect data to use for this additive effect."""
-        return "additive_effect"
-
-    @property
-    def calibration_constant_type(self) -> str:
-        """The type of calibration constant data to use for this additive effect."""
-        return "calibration_constant"

--- a/src/vivarium_public_health/causal_factor/effect.py
+++ b/src/vivarium_public_health/causal_factor/effect.py
@@ -229,16 +229,11 @@ class CausalFactorEffect(Component, ABC):
             A lookup table of effect values.
         """
         effect_data = self.load_effect_data(builder)
-        effect_value_cols = None
         if self.is_exposure_categorical:
-            effect_data, effect_value_cols = self.process_categorical_data(
-                builder, effect_data
-            )
+            effect_data = self.process_categorical_data(builder, effect_data)
+
         return self.build_lookup_table(
-            builder,
-            self.effect_type,
-            data_source=effect_data,
-            value_columns=effect_value_cols,
+            builder, self.effect_type, data_source=effect_data
         )
 
     def load_calibration_constant_data(self, builder: Builder) -> LookupTableData:
@@ -345,13 +340,13 @@ class CausalFactorEffect(Component, ABC):
         return data
 
     def process_categorical_data(
-        self, builder: Builder, effect_data: str | float | pd.DataFrame
-    ) -> tuple[str | float | pd.DataFrame, list[str]]:
+        self, builder: Builder, effect_data: float | pd.DataFrame
+    ) -> pd.DataFrame:
         """Process effect data for categorical exposures.
 
         For scalar effect data with a dichotomous distribution, construct a
-        DataFrame with exposed/unexposed categories. Pivot the data to
-        wide format for use in a lookup table.
+        DataFrame with exposed/unexposed categories. Return a DataFrame with
+        lookup dimensions on the row index and exposure categories as columns.
 
         Parameters
         ----------
@@ -362,8 +357,8 @@ class CausalFactorEffect(Component, ABC):
 
         Returns
         -------
-            A tuple of the pivoted effect data and the list of value column
-            names.
+            The processed effect data, with lookup dimensions on the row
+            index and exposure categories as columns.
 
         Raises
         ------
@@ -379,24 +374,30 @@ class CausalFactorEffect(Component, ABC):
                     f"exposure distribution type {self._exposure_distribution_type}."
                 )
             causal_factor_type = self.causal_factor.type
-            cat1 = builder.data.load("population.demographic_dimensions")
-            cat1["parameter"] = DichotomousDistribution.get_exposed(causal_factor_type)
-            cat1["value"] = effect_data
-            cat2 = cat1.copy()
-            cat2["parameter"] = DichotomousDistribution.get_unexposed(causal_factor_type)
-            cat2["value"] = 1
-            effect_data = pd.concat([cat1, cat2], ignore_index=True)
+            exposed = DichotomousDistribution.get_exposed(causal_factor_type)
+            unexposed = DichotomousDistribution.get_unexposed(causal_factor_type)
+            demographic_dimensions = builder.data.load("population.demographic_dimensions")
+
+            effect_data_ = pd.DataFrame(
+                index=pd.MultiIndex.from_frame(demographic_dimensions)
+            )
+            effect_data_[exposed] = effect_data
+            effect_data_[unexposed] = 1
+            return effect_data_
+
         if "parameter" in effect_data.index.names:
             effect_data = effect_data.reset_index("parameter")
+        index_cols = [c for c in effect_data.columns if c not in ("parameter", "value")]
+        effect_data = effect_data.pivot(
+            index=index_cols, columns="parameter", values="value"
+        )
+        effect_data.columns.name = None
 
         if self._exposure_distribution_type == "dichotomous":
             effect_data = DichotomousDistribution.rename_deprecated_categories(
                 self.causal_factor.type, effect_data
             )
-
-        effect_value_cols = list(effect_data["parameter"].unique())
-        effect_data = pivot_categorical(effect_data, "parameter")
-        return effect_data, effect_value_cols
+        return effect_data
 
     # todo currently this isn't being called. we need to properly set rrs if
     #  the exposure has been rebinned

--- a/src/vivarium_public_health/causal_factor/effect.py
+++ b/src/vivarium_public_health/causal_factor/effect.py
@@ -8,6 +8,7 @@ exposure models and the models they affect.
 
 """
 
+import functools
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -32,6 +33,31 @@ from vivarium_public_health.causal_factor.utilities import (
     pivot_categorical,
 )
 from vivarium_public_health.utilities import EntityString, TargetString
+
+
+def _deprecated_method_shim(old_name: str):
+    """Forward to a deprecated method on the same class if a subclass still defines it.
+
+    Wrap a renamed method so that subclasses defining the old name continue to work
+    with a ``DeprecationWarning``. Once the old name is removed, drop the decorator.
+    """
+
+    def decorator(method):
+        @functools.wraps(method)
+        def wrapper(self, *args, **kwargs):
+            if hasattr(self, old_name):
+                warnings.warn(
+                    f"{self.__class__.__name__} defines `{old_name}`, which is deprecated. "
+                    f"Rename to `{method.__name__}`.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return getattr(self, old_name)(*args, **kwargs)
+            return method(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 class CausalFactorEffect(Component, ABC):
@@ -184,6 +210,7 @@ class CausalFactorEffect(Component, ABC):
     # Setup methods #
     #################
 
+    @_deprecated_method_shim("build_rr_lookup_table")
     def build_effect_lookup_table(self, builder: Builder) -> LookupTable:
         """Build a lookup table for effect data.
 
@@ -196,15 +223,6 @@ class CausalFactorEffect(Component, ABC):
         -------
             A lookup table of effect values.
         """
-        if hasattr(self, "build_rr_lookup_table"):
-            warnings.warn(
-                f"{self.__class__.__name__} defines a `build_rr_lookup_table` method, which is "
-                "deprecated. Please rename this method to `build_effect_lookup_table` and change "
-                "your lookup table to use `self.effect_type` as its name.",
-                DeprecationWarning,
-            )
-            return self.build_rr_lookup_table(builder)
-
         effect_data = self.load_effect_data(builder)
         effect_value_cols = None
         if self.is_exposure_categorical:
@@ -242,6 +260,7 @@ class CausalFactorEffect(Component, ABC):
             or causal_factor_exposure_component.get_distribution_type(builder)
         )
 
+    @_deprecated_method_shim("load_relative_risk")
     def load_effect_data(
         self,
         builder: Builder,
@@ -269,14 +288,6 @@ class CausalFactorEffect(Component, ABC):
         ConfigurationError
             If the distribution parameters are invalid.
         """
-        if hasattr(self, "load_relative_risk"):
-            warnings.warn(
-                f"{self.__class__.__name__} defines a `load_relative_risk` method, which is "
-                "deprecated. Please rename this method to `load_effect_data`.",
-                DeprecationWarning,
-            )
-            return self.load_relative_risk(builder, configuration)
-
         if configuration is None:
             configuration = self.configuration
 
@@ -387,6 +398,7 @@ class CausalFactorEffect(Component, ABC):
 
     # todo currently this isn't being called. we need to properly set rrs if
     #  the exposure has been rebinned
+    @_deprecated_method_shim("rebin_relative_risk_data")
     def rebin_effect_data(self, builder, effect_data: pd.DataFrame) -> pd.DataFrame:
         """Rebin effect data.
 
@@ -397,14 +409,6 @@ class CausalFactorEffect(Component, ABC):
         for the matching effect data = [effect1, effect2, effect3, 1], rebinned effect data for the rebinned cat1 should be:
         (0.1 *effect1 + 0.2 * effect2 + 0.3* effect3) / (0.1+0.2+0.3)
         """
-        if hasattr(self, "rebin_relative_risk_data"):
-            warnings.warn(
-                f"{self.__class__.__name__} defines a `rebin_relative_risk_data` method, which is "
-                f"deprecated. Please rename this method to `rebin_effect_data`.",
-                DeprecationWarning,
-            )
-            return self.rebin_relative_risk_data(builder, effect_data)
-
         if not self.causal_factor in builder.configuration.to_dict():
             return effect_data
 
@@ -421,6 +425,7 @@ class CausalFactorEffect(Component, ABC):
 
         return effect_data
 
+    @_deprecated_method_shim("_rebin_relative_risk_data")
     def _rebin_effect_data(
         self,
         effect_data: pd.DataFrame,
@@ -428,16 +433,6 @@ class CausalFactorEffect(Component, ABC):
         rebin_exposed_categories: set,
     ) -> pd.DataFrame:
         """Compute exposure-weighted relative risks for rebinned categories."""
-        if hasattr(self, "_rebin_relative_risk_data"):
-            warnings.warn(
-                f"{self.__class__.__name__} defines a `_rebin_relative_risk_data` method, which is "
-                f"deprecated. Please rename this method to `_rebin_effect_data`.",
-                DeprecationWarning,
-            )
-            return self._rebin_relative_risk_data(
-                effect_data, exposure_data, rebin_exposed_categories
-            )
-
         cols = list(exposure_data.columns.difference(["value"]))
 
         effect_data = effect_data.merge(exposure_data, on=cols)
@@ -449,6 +444,7 @@ class CausalFactorEffect(Component, ABC):
         effect_data["value"] = effect_data.value_x.divide(effect_data.value_y).fillna(0)
         return effect_data.drop(columns=["value_x", "value_y"])
 
+    @_deprecated_method_shim("get_relative_risk_source")
     def get_effect_source(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
         """Build a callable that computes effect data from exposure.
 
@@ -466,14 +462,6 @@ class CausalFactorEffect(Component, ABC):
             A callable that accepts a simulant index and returns
             effect data values.
         """
-        if hasattr(self, "get_relative_risk_source"):
-            warnings.warn(
-                f"{self.__class__.__name__} defines a `get_relative_risk_source` method, which is "
-                f"deprecated. Please rename this method to `get_effect_source`.",
-                DeprecationWarning,
-            )
-            return self.get_relative_risk_source(builder)
-
         if not self.is_exposure_categorical:
             tmred = builder.data.load(f"{self.causal_factor}.tmred")
             tmrel = 0.5 * (tmred["min"] + tmred["max"])
@@ -505,6 +493,7 @@ class CausalFactorEffect(Component, ABC):
 
         return generate_effect
 
+    @_deprecated_method_shim("register_relative_risk_pipeline")
     def register_effect_pipeline(self, builder: Builder) -> None:
         """Register the effect pipeline with the simulation.
 
@@ -513,14 +502,6 @@ class CausalFactorEffect(Component, ABC):
         builder
             Access point for utilizing framework interfaces during setup.
         """
-        if hasattr(self, "register_relative_risk_pipeline"):
-            warnings.warn(
-                f"{self.__class__.__name__} defines a `register_relative_risk_pipeline` method, which is "
-                f"deprecated. Please rename this method to `register_effect_pipeline`.",
-                DeprecationWarning,
-            )
-            return self.register_relative_risk_pipeline(builder)
-
         builder.value.register_attribute_producer(
             self.effect_name,
             self._effect_source,
@@ -528,7 +509,7 @@ class CausalFactorEffect(Component, ABC):
         )
 
     def register_target_modifier(self, builder: Builder) -> None:
-        """Register the relative risk as a modifier on the target pipeline.
+        """Register the effect as a modifier on the target pipeline.
 
         Parameters
         ----------

--- a/src/vivarium_public_health/causal_factor/effect.py
+++ b/src/vivarium_public_health/causal_factor/effect.py
@@ -203,7 +203,7 @@ class CausalFactorEffect(Component, ABC):
         """
         self._exposure_distribution_type = self.get_distribution_type(builder)
         self.effect_table = self.build_effect_lookup_table(builder)
-        self.calibration_constant_data = self.get_calibration_constant_data(builder)
+        self.calibration_constant_data = self.load_calibration_constant_data(builder)
 
         self._effect_source = self.get_effect_source(builder)
         self.register_effect_pipeline(builder)
@@ -241,7 +241,7 @@ class CausalFactorEffect(Component, ABC):
             value_columns=effect_value_cols,
         )
 
-    def get_calibration_constant_data(self, builder: Builder) -> LookupTableData:
+    def load_calibration_constant_data(self, builder: Builder) -> LookupTableData:
         """Load calibration constant data for this effect.
 
         Parameters

--- a/src/vivarium_public_health/causal_factor/exposure.py
+++ b/src/vivarium_public_health/causal_factor/exposure.py
@@ -232,7 +232,7 @@ class CausalFactor(Component, ABC):
         -------
             The distribution type.
         """
-        if self.configuration is None:
+        if not self.configuration:
             self.configuration = self.get_configuration(builder)
 
         distribution_type = self.configuration["distribution_type"]

--- a/src/vivarium_public_health/risks/base_risk.py
+++ b/src/vivarium_public_health/risks/base_risk.py
@@ -160,7 +160,7 @@ class Risk(CausalFactor):
         """Get the exposure attribute and rename it to the internal exposure column name.
 
         HACK: This is effectively caching the exposure pipeline for use by other
-        components. Specifically, :meth:`vivarium_public_health.risks.effect.NonLogLinearRiskEffect.get_relative_risk_source`
+        components. Specifically, :meth:`vivarium_public_health.risks.effect.NonLogLinearRiskEffect.get_effect_source`
         needs the exposure values but calling that pipeline was very slow. By
         maintaining a cached copy of the exposure values in a private column, we
         can then request that corresponding "simple" pipeline from the population

--- a/src/vivarium_public_health/risks/base_risk.py
+++ b/src/vivarium_public_health/risks/base_risk.py
@@ -73,6 +73,11 @@ class Risk(CausalFactor):
 
     """
 
+    @property
+    def risk(self) -> str:
+        """The name of this risk, which is the same as the name of the causal factor."""
+        return self.causal_factor
+
     #####################
     # Lifecycle methods #
     #####################

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -9,7 +9,8 @@ exposure models and disease models.
 """
 
 from collections.abc import Callable
-from typing import Any
+from functools import partial
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -17,14 +18,15 @@ import scipy
 from layered_config_tree import LayeredConfigTree
 from vivarium.framework.engine import Builder
 from vivarium.framework.lookup import LookupTable
+from vivarium.types import DataInput
 
 from vivarium_public_health.causal_factor.distributions import MissingDataError
-from vivarium_public_health.causal_factor.effect import MultiplicativeEffect
+from vivarium_public_health.causal_factor.effect import CausalFactorEffect
 from vivarium_public_health.risks import Risk
 from vivarium_public_health.utilities import EntityString, TargetString
 
 
-class RiskEffect(MultiplicativeEffect):
+class RiskEffect(CausalFactorEffect):
     """A component to model the effect of a risk factor on an affected entity's target rate.
 
     This component can source data either from builder.data or from parameters
@@ -54,15 +56,96 @@ class RiskEffect(MultiplicativeEffect):
         return f"risk_effect.{risk.name}_on_{target}"
 
     @property
+    def configuration_defaults(self) -> dict[str, Any]:
+        """Default configuration values for this component.
+
+        The ``effect`` and ``calibration_constant`` keys are the "real" keys
+        consumed by the underlying component. By default they redirect to the
+        ``relative_risk`` and ``population_attributable_fraction`` keys, which
+        in turn default to the corresponding artifact keys. Users can override
+        either layer: configure ``relative_risk`` / ``population_attributable_fraction``
+        to keep the redirect, or configure ``effect`` / ``calibration_constant``
+        directly to bypass it.
+
+        Configuration structure::
+
+            {risk_effect_name}:
+                data_sources:
+                    effect:
+                        Source for effect data. Defaults to the
+                        ``relative_risk`` key below. Override directly to
+                        bypass the relative-risk redirect.
+                    calibration_constant:
+                        Source for calibration constant data. Defaults to the
+                        ``population_attributable_fraction`` key below.
+                        Override directly to bypass the PAF redirect.
+                    relative_risk:
+                        Source for relative risk data. Default is the artifact
+                        key ``{risk}.relative_risk``. Can also be:
+                        - A scalar value (e.g., ``1.5``)
+                        - A scipy.stats distribution name (e.g., ``"uniform"``)
+                          with parameters in ``data_source_parameters``
+                    population_attributable_fraction:
+                        Source for PAF data. Default is the artifact key
+                        ``{risk}.population_attributable_fraction``. Used to
+                        adjust the target measure to account for the portion
+                        attributable to this risk.
+                data_source_parameters:
+                    effect: dict
+                        Defaults to the ``relative_risk`` parameters below.
+                    relative_risk: dict
+                        Parameters for scipy.stats distributions when using
+                        a distribution name as the ``relative_risk`` source.
+                        For example, ``{"loc": 1.0, "scale": 0.5}`` for a
+                        uniform distribution.
+        """
+
+        def _redirect_source(builder: Builder, key: str) -> DataInput:
+            """Redirect data source to the appropriate configuration key."""
+            return self.get_data(builder, self.configuration.data_sources[key])
+
+        return {
+            self.name: {
+                "data_sources": {
+                    "effect": partial(_redirect_source, key="relative_risk"),
+                    "calibration_constant": partial(
+                        _redirect_source,
+                        key="population_attributable_fraction",
+                    ),
+                    "relative_risk": f"{self.risk}.relative_risk",
+                    "population_attributable_fraction": f"{self.risk}.population_attributable_fraction",
+                },
+                "data_source_parameters": {
+                    "effect": {},
+                    "relative_risk": {},
+                },
+            }
+        }
+
+    @property
     def risk(self) -> str:
         """The type and name of a risk, specified as "type.name". Type is singular."""
         return self.causal_factor
+
+    @property
+    def effect_parameters(self) -> dict[str, Any]:
+        """Effect parameters for this component."""
+        params = (
+            self.configuration.data_source_parameters.effect
+            or self.configuration.data_source_parameters.relative_risk
+        )
+        return params.to_dict()
 
     #####################
     # Lifecycle methods #
     #####################
 
-    def __init__(self, risk: str, target: str):
+    def __init__(
+        self,
+        risk: str,
+        target: str,
+        effect_type: Literal["multiplicative", "additive"] = "multiplicative",
+    ) -> None:
         """
 
         Parameters
@@ -75,8 +158,12 @@ class RiskEffect(MultiplicativeEffect):
             Type, name, and target rate of entity to be affected by risk factor,
             supplied in the form "entity_type.entity_name.measure"
             where entity_type should be singular (e.g., cause instead of causes).
+        effect_type
+            The type of effect model to use, either "multiplicative" or "additive".
+            This determines how the effect data modifies the target rate. Default
+            is "multiplicative".
         """
-        super().__init__(risk, target)
+        super().__init__(risk, target, effect_type)
 
 
 class NonLogLinearRiskEffect(RiskEffect):
@@ -99,39 +186,6 @@ class NonLogLinearRiskEffect(RiskEffect):
        target rate.
 
     """
-
-    ##############
-    # Properties #
-    ##############
-
-    @property
-    def configuration_defaults(self) -> dict[str, Any]:
-        """Default configuration values for this component.
-
-        Configuration structure::
-
-            {risk_effect_name}:
-                data_sources:
-                    relative_risk:
-                        Source for relative risk data. Default is the artifact
-                        key ``{risk}.relative_risk``. The data must be a
-                        DataFrame with a numeric ``parameter`` column containing
-                        exposure thresholds and a ``value`` column with the
-                        corresponding relative risks.
-                    population_attributable_fraction:
-                        Source for PAF data. Default is the artifact key
-                        ``{risk}.population_attributable_fraction``. Used to
-                        adjust the target rate to account for the portion
-                        attributable to this risk.
-        """
-        return {
-            self.name: {
-                "data_sources": {
-                    "relative_risk": f"{self.causal_factor}.relative_risk",
-                    "population_attributable_fraction": f"{self.causal_factor}.population_attributable_fraction",
-                },
-            }
-        }
 
     #################
     # Setup methods #

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -19,12 +19,12 @@ from vivarium.framework.engine import Builder
 from vivarium.framework.lookup import LookupTable
 
 from vivarium_public_health.causal_factor.distributions import MissingDataError
-from vivarium_public_health.causal_factor.effect import CausalFactorEffect
+from vivarium_public_health.causal_factor.effect import MultiplicativeEffect
 from vivarium_public_health.risks import Risk
 from vivarium_public_health.utilities import EntityString, TargetString
 
 
-class RiskEffect(CausalFactorEffect):
+class RiskEffect(MultiplicativeEffect):
     """A component to model the effect of a risk factor on an affected entity's target rate.
 
     This component can source data either from builder.data or from parameters
@@ -52,7 +52,7 @@ class RiskEffect(CausalFactorEffect):
     def get_name(risk: EntityString, target: TargetString) -> str:
         """The name of this risk effect component."""
         return f"risk_effect.{risk.name}_on_{target}"
-    
+
     @property
     def risk(self) -> str:
         """The type and name of a risk, specified as "type.name". Type is singular."""
@@ -142,7 +142,7 @@ class NonLogLinearRiskEffect(RiskEffect):
         """The name of this non-log-linear risk effect component."""
         return f"non_log_linear_risk_effect.{self.causal_factor.name}_on_{self.target}"
 
-    def build_rr_lookup_table(self, builder: Builder) -> LookupTable:
+    def build_effect_lookup_table(self, builder: Builder) -> LookupTable:
         """Build a lookup table mapping exposure intervals to relative risks.
 
         Define left and right edges of exposure bins and their
@@ -159,7 +159,7 @@ class NonLogLinearRiskEffect(RiskEffect):
             A lookup table with columns for left/right exposure and
             left/right relative risk values.
         """
-        rr_data = self.load_relative_risk(builder)
+        rr_data = self.load_effect_data(builder)
         self.validate_rr_data(rr_data)
 
         def define_rr_intervals(df: pd.DataFrame) -> pd.DataFrame:
@@ -201,7 +201,7 @@ class NonLogLinearRiskEffect(RiskEffect):
             builder, "relative_risk", data_source=rr_data, value_columns=rr_value_cols
         )
 
-    def load_relative_risk(
+    def load_effect_data(
         self,
         builder: Builder,
         configuration: LayeredConfigTree | None = None,
@@ -284,7 +284,7 @@ class NonLogLinearRiskEffect(RiskEffect):
 
         return rr_data
 
-    def get_relative_risk_source(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
+    def get_effect_source(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
         """Build a callable that interpolates relative risk from exposure.
 
         Use piecewise linear interpolation within the exposure bins
@@ -303,7 +303,7 @@ class NonLogLinearRiskEffect(RiskEffect):
 
         def generate_relative_risk(index: pd.Index) -> pd.Series:
             """Interpolate relative risk from exposure within RR bins."""
-            rr_intervals = self.relative_risk_table(index)
+            rr_intervals = self.effect_table(index)
             # NOTE: We are calling the cached exposure pipeline here for performance
             # purposes (as opposed to the f{self.causal_factor.name}.exposure pipeline itself).
             exposure = self.population_view.get(

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -18,9 +18,6 @@ from layered_config_tree import LayeredConfigTree
 from vivarium.framework.engine import Builder
 from vivarium.framework.lookup import LookupTable
 
-from vivarium_public_health.causal_factor.calibration_constant import (
-    get_calibration_constant_pipeline_name,
-)
 from vivarium_public_health.causal_factor.distributions import MissingDataError
 from vivarium_public_health.causal_factor.effect import CausalFactorEffect
 from vivarium_public_health.risks import Risk
@@ -51,10 +48,15 @@ class RiskEffect(CausalFactorEffect):
     # Properties #
     ##############
 
-    @property
-    def name(self) -> str:
+    @staticmethod
+    def get_name(risk: EntityString, target: TargetString) -> str:
         """The name of this risk effect component."""
-        return f"risk_effect.{self.causal_factor.name}_on_{self.target}"
+        return f"risk_effect.{risk.name}_on_{target}"
+    
+    @property
+    def risk(self) -> str:
+        """The type and name of a risk, specified as "type.name". Type is singular."""
+        return self.causal_factor
 
     #####################
     # Lifecycle methods #

--- a/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
+++ b/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
@@ -652,7 +652,7 @@ class LBWSGRiskEffect(RiskEffect):
     # Setup methods #
     #################
 
-    def build_rr_lookup_table(self, builder: Builder) -> None:
+    def build_effect_lookup_table(self, builder: Builder) -> None:
         """Skip building a lookup table; LBWSG uses interpolators instead."""
         pass
 
@@ -698,7 +698,7 @@ class LBWSGRiskEffect(RiskEffect):
             for age_start in exposed_age_group_starts
         }
 
-    def register_relative_risk_pipeline(self, builder: Builder) -> None:
+    def register_effect_pipeline(self, builder: Builder) -> None:
         """Register the relative risk pipeline with age and RR columns.
 
         Parameters
@@ -707,8 +707,8 @@ class LBWSGRiskEffect(RiskEffect):
             Access point for utilizing framework interfaces during setup.
         """
         builder.value.register_attribute_producer(
-            self.relative_risk_name,
-            source=self._relative_risk_source,
+            self.effect_name,
+            source=self._effect_source,
             required_resources=["age"] + self.rr_column_names,
         )
 
@@ -807,7 +807,7 @@ class LBWSGRiskEffect(RiskEffect):
     def _get_relative_risk(self, index: pd.Index) -> pd.Series:
         """Return relative risk values based on simulant age group."""
         pop = self.population_view.get(index, self.rr_column_names + ["age"])
-        relative_risk = pd.Series(1.0, index=index, name=self.relative_risk_name)
+        relative_risk = pd.Series(1.0, index=index, name=self.effect_name)
 
         for age_group, interval in self.age_intervals.items():
             age_group_mask = (interval.left <= pop["age"]) & (pop["age"] < interval.right)
@@ -816,7 +816,7 @@ class LBWSGRiskEffect(RiskEffect):
             ]
         return relative_risk
 
-    def get_relative_risk_source(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
+    def get_effect_source(self, builder: Builder) -> Callable[[pd.Index], pd.Series]:
         """Return the callable that computes relative risk from stored columns.
 
         Parameters

--- a/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
+++ b/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
@@ -656,22 +656,6 @@ class LBWSGRiskEffect(RiskEffect):
         """Skip building a lookup table; LBWSG uses interpolators instead."""
         pass
 
-    def get_paf_data(self, builder: Builder) -> LookupTableData:
-        """Load population attributable fraction data.
-
-        Parameters
-        ----------
-        builder
-            Access point for utilizing framework interfaces during setup.
-
-        Returns
-        -------
-            The PAF data for this risk-target pair.
-        """
-        return self.get_data(
-            builder, self.configuration.data_sources.population_attributable_fraction
-        )
-
     def get_age_intervals(self, builder: Builder) -> dict[str, pd.Interval]:
         """Build a mapping of age group names to age intervals.
 

--- a/src/vivarium_public_health/treatment/intervention.py
+++ b/src/vivarium_public_health/treatment/intervention.py
@@ -8,7 +8,7 @@ effects on target measures.
 
 """
 
-from vivarium_public_health.causal_factor.effect import CausalFactorEffect
+from vivarium_public_health.causal_factor.effect import MultiplicativeEffect
 from vivarium_public_health.causal_factor.exposure import CausalFactor
 from vivarium_public_health.utilities import EntityString, TargetString
 
@@ -51,12 +51,12 @@ class Intervention(CausalFactor):
         super().__init__(intervention)
 
 
-class InterventionEffect(CausalFactorEffect):
+class InterventionEffect(MultiplicativeEffect):
     """A model for the effect of an intervention on an affected
     entity's target measure.
 
     This is a specialization of
-    :class:`~vivarium_public_health.causal_factor.effect.CausalFactorEffect`
+    :class:`~vivarium_public_health.causal_factor.effect.MultiplicativeEffect`
     for interventions. It can source relative risk and population attributable
     fraction data from the artifact or from scalar configuration parameters.
 
@@ -82,7 +82,7 @@ class InterventionEffect(CausalFactorEffect):
     def get_name(intervention: EntityString, target: TargetString) -> str:
         """The name of this intervention effect component."""
         return f"intervention_effect.{intervention.name}_on_{target}"
-    
+
     @property
     def intervention(self) -> str:
         """The type and name of the intervention, specified as "type.name". Type is singular."""

--- a/src/vivarium_public_health/treatment/intervention.py
+++ b/src/vivarium_public_health/treatment/intervention.py
@@ -10,6 +10,7 @@ effects on target measures.
 
 from vivarium_public_health.causal_factor.effect import CausalFactorEffect
 from vivarium_public_health.causal_factor.exposure import CausalFactor
+from vivarium_public_health.utilities import EntityString, TargetString
 
 
 class Intervention(CausalFactor):
@@ -29,6 +30,11 @@ class Intervention(CausalFactor):
     """
 
     VALID_ENTITY_TYPES = ["intervention"]
+
+    @property
+    def intervention(self) -> str:
+        """The type and name of the intervention, specified as "type.name". Type is singular."""
+        return self.causal_factor
 
     #####################
     # Lifecycle methods #
@@ -72,10 +78,15 @@ class InterventionEffect(CausalFactorEffect):
     # Properties #
     ##############
 
+    @staticmethod
+    def get_name(intervention: EntityString, target: TargetString) -> str:
+        """The name of this intervention effect component."""
+        return f"intervention_effect.{intervention.name}_on_{target}"
+    
     @property
-    def name(self) -> str:
-        """The unique name for this intervention effect component."""
-        return f"intervention_effect.{self.causal_factor.name}_on_{self.target}"
+    def intervention(self) -> str:
+        """The type and name of the intervention, specified as "type.name". Type is singular."""
+        return self.causal_factor
 
     #####################
     # Lifecycle methods #

--- a/src/vivarium_public_health/treatment/intervention.py
+++ b/src/vivarium_public_health/treatment/intervention.py
@@ -8,7 +8,9 @@ effects on target measures.
 
 """
 
-from vivarium_public_health.causal_factor.effect import MultiplicativeEffect
+from typing import Literal
+
+from vivarium_public_health.causal_factor.effect import CausalFactorEffect
 from vivarium_public_health.causal_factor.exposure import CausalFactor
 from vivarium_public_health.utilities import EntityString, TargetString
 
@@ -51,12 +53,12 @@ class Intervention(CausalFactor):
         super().__init__(intervention)
 
 
-class InterventionEffect(MultiplicativeEffect):
+class InterventionEffect(CausalFactorEffect):
     """A model for the effect of an intervention on an affected
     entity's target measure.
 
     This is a specialization of
-    :class:`~vivarium_public_health.causal_factor.effect.MultiplicativeEffect`
+    :class:`~vivarium_public_health.causal_factor.effect.CausalFactorEffect`
     for interventions. It can source relative risk and population attributable
     fraction data from the artifact or from scalar configuration parameters.
 
@@ -92,7 +94,12 @@ class InterventionEffect(MultiplicativeEffect):
     # Lifecycle methods #
     #####################
 
-    def __init__(self, intervention: str, target: str):
+    def __init__(
+        self,
+        intervention: str,
+        target: str,
+        effect_type: Literal["multiplicative", "additive"] = "multiplicative",
+    ) -> None:
         """
         Parameters
         ----------
@@ -104,5 +111,9 @@ class InterventionEffect(MultiplicativeEffect):
             intervention, supplied in the form
             ``"entity_type.entity_name.measure"`` where ``entity_type``
             should be singular (e.g. ``cause`` instead of ``causes``).
+        effect_type
+            The type of effect model to use, either "multiplicative" or "additive".
+            This determines how the effect data modifies the target measure. Default
+            is "multiplicative".
         """
-        super().__init__(intervention, target)
+        super().__init__(intervention, target, effect_type)

--- a/tests/causal_factor/test_calibration_constant.py
+++ b/tests/causal_factor/test_calibration_constant.py
@@ -52,10 +52,11 @@ class _AttributeSource(Component):
     def __init__(
         self,
         pipeline_name: str,
-        base_value: float,
+        base_value: float | dict[str, float],
         is_rate: bool = False,
         effect_type: str = "multiplicative",
         post_processors: (AttributePostProcessor | Sequence[AttributePostProcessor]) = (),
+        columns: list[str] | None = None,
     ):
         super().__init__()
         self._pipeline_name = pipeline_name
@@ -63,6 +64,7 @@ class _AttributeSource(Component):
         self._is_rate = is_rate
         self._effect_type = effect_type
         self._post_processors = post_processors
+        self._columns = columns
 
     @property
     def name(self) -> str:
@@ -71,6 +73,8 @@ class _AttributeSource(Component):
 
     @property
     def configuration_defaults(self) -> dict:
+        if self._columns is not None:
+            return {}
         return {
             self.name: {
                 "data_sources": {
@@ -80,7 +84,22 @@ class _AttributeSource(Component):
         }
 
     def setup(self, builder: Builder) -> None:
-        self.base_value_table = self.build_lookup_table(builder, "base_value")
+        if self._columns is None:
+            self.base_value_table = self.build_lookup_table(builder, "base_value")
+        else:
+            year_start = builder.configuration.time.start.year
+            year_end = builder.configuration.time.end.year
+            data = build_table_with_age(
+                [self._base_value[col] for col in self._columns],
+                parameter_columns={"year": (year_start, year_end)},
+                value_columns=self._columns,
+            )
+            self.base_value_table = self.build_lookup_table(
+                builder,
+                "base_value",
+                data_source=data,
+                value_columns=self._columns,
+            )
         register_fn = (
             register_risk_affected_rate_producer
             if self._is_rate
@@ -92,6 +111,7 @@ class _AttributeSource(Component):
             source=self.base_value_table,
             effect_type=self._effect_type,
             post_processors=self._post_processors,
+            columns=self._columns,
         )
 
 
@@ -99,10 +119,16 @@ class _CalibrationConstantModifier(Component):
     """Registers a value modifier on ``<target>.calibration_constant``
     with a constant calibration constant."""
 
-    def __init__(self, target_pipeline: str, calibration_value: float):
+    def __init__(
+        self,
+        target_pipeline: str,
+        calibration_value: float | dict[str, float],
+        columns: list[str] | None = None,
+    ):
         super().__init__()
         self._target_pipeline = target_pipeline
         self._calibration_value = calibration_value
+        self._columns = columns
 
     @property
     def name(self) -> str:
@@ -114,9 +140,17 @@ class _CalibrationConstantModifier(Component):
     def setup(self, builder: Builder) -> None:
         year_start = builder.configuration.time.start.year
         year_end = builder.configuration.time.end.year
-        data = build_table_with_age(
-            self._calibration_value, parameter_columns={"year": (year_start, year_end)}
-        )
+        if self._columns is None:
+            data = build_table_with_age(
+                self._calibration_value,
+                parameter_columns={"year": (year_start, year_end)},
+            )
+        else:
+            data = build_table_with_age(
+                [self._calibration_value[col] for col in self._columns],
+                parameter_columns={"year": (year_start, year_end)},
+                value_columns=self._columns,
+            )
         builder.value.register_value_modifier(
             get_calibration_constant_pipeline_name(self._target_pipeline),
             modifier=lambda: data,
@@ -175,6 +209,21 @@ class TestProducer:
         """Return ``(post_processors, expected_transform)``."""
         return request.param
 
+    @pytest.fixture(params=[None, ["col_a", "col_b"]], ids=["series", "multi_col"])
+    def columns(self, request):
+        return request.param
+
+    @staticmethod
+    def _per_column(scalar: float, columns: list[str] | None) -> float | dict[str, float]:
+        """Broadcast a scalar to per-column values when ``columns`` is set.
+
+        Per-column values are scaled by ``i + 1`` so that a calibration constant
+        registered against the wrong column would produce a detectable mismatch.
+        """
+        if columns is None:
+            return scalar
+        return {col: scalar * (i + 1) for i, col in enumerate(columns)}
+
     def _expected(self, base, calibration, is_rate, time_step, transform, effect_type):
         """Compute expected pipeline output for the given effect type."""
         if effect_type == "multiplicative":
@@ -184,6 +233,21 @@ class TestProducer:
         if is_rate:
             value = from_yearly(value, time_step)
         return transform(value)
+
+    def _expected_per_column(
+        self, base, calibration, is_rate, time_step, transform, effect_type, columns
+    ):
+        """Scalar expected (Series mode) or per-column dict (DataFrame mode)."""
+        if columns is None:
+            return self._expected(
+                base, calibration, is_rate, time_step, transform, effect_type
+            )
+        return {
+            col: self._expected(
+                base[col], calibration[col], is_rate, time_step, transform, effect_type
+            )
+            for col in columns
+        }
 
     @staticmethod
     def _joint_calibration(calibrations, effect_type):
@@ -195,13 +259,34 @@ class TestProducer:
             return joint
         return sum(calibrations)  # additive
 
+    def _joint_per_column(self, calibrations, effect_type, columns):
+        """Joint calibration as a scalar (Series) or per-column dict (DataFrame)."""
+        if columns is None:
+            return self._joint_calibration(calibrations, effect_type)
+        return {
+            col: self._joint_calibration([c[col] for c in calibrations], effect_type)
+            for col in columns
+        }
+
+    @staticmethod
+    def _assert_close(actual, expected, columns):
+        if columns is None:
+            assert np.allclose(actual, expected, atol=1e-5)
+        else:
+            for col in columns:
+                assert np.allclose(
+                    actual[col], expected[col], atol=1e-5
+                ), f"column {col} mismatch"
+
     def test_no_calibration_constant_modifier(
-        self, base_config, base_plugins, is_rate, effect_type, post_processor
+        self, base_config, base_plugins, is_rate, effect_type, post_processor, columns
     ):
         """No modifier → base value returned (calibration constant = 0),
         then post-processors applied."""
         post_processors, transform = post_processor
-        base_value = 0.7 if is_rate else 10.0
+        base_scalar = 0.7 if is_rate else 10.0
+        base_value = self._per_column(base_scalar, columns)
+        zero = self._per_column(0.0, columns)
         time_step = pd.Timedelta(days=base_config.time.step_size)
         pipeline_name = "test_pipeline"
         source = _AttributeSource(
@@ -210,6 +295,7 @@ class TestProducer:
             is_rate=is_rate,
             effect_type=effect_type,
             post_processors=post_processors,
+            columns=columns,
         )
 
         sim = InteractiveContext(
@@ -220,20 +306,24 @@ class TestProducer:
         sim.step()
 
         actual = sim.get_population(pipeline_name).squeeze()
-        expected = self._expected(base_value, 0, is_rate, time_step, transform, effect_type)
-        assert np.allclose(actual, expected, atol=1e-5)
+        expected = self._expected_per_column(
+            base_value, zero, is_rate, time_step, transform, effect_type, columns
+        )
+        self._assert_close(actual, expected, columns)
 
     def test_single_calibration_constant_modifier(
-        self, base_config, base_plugins, is_rate, effect_type, post_processor
+        self, base_config, base_plugins, is_rate, effect_type, post_processor, columns
     ):
         """Single calibration constant ``c`` reduces the value: ``base * (1 - c)``
         for multiplicative, ``base - c`` for additive. Then post-processors apply."""
         post_processors, transform = post_processor
-        base_value = 0.7 if is_rate else 10.0
+        base_scalar = 0.7 if is_rate else 10.0
         if effect_type == "multiplicative":
-            calibration_value = 0.25
+            calibration_scalar = 0.25
         else:  # additive — units match base_value
-            calibration_value = 0.175 if is_rate else 2.5
+            calibration_scalar = 0.175 if is_rate else 2.5
+        base_value = self._per_column(base_scalar, columns)
+        calibration_value = self._per_column(calibration_scalar, columns)
         time_step = pd.Timedelta(days=base_config.time.step_size)
         pipeline_name = "test_pipeline"
         source = _AttributeSource(
@@ -242,8 +332,11 @@ class TestProducer:
             is_rate=is_rate,
             effect_type=effect_type,
             post_processors=post_processors,
+            columns=columns,
         )
-        modifier = _CalibrationConstantModifier(pipeline_name, calibration_value)
+        modifier = _CalibrationConstantModifier(
+            pipeline_name, calibration_value, columns=columns
+        )
 
         sim = InteractiveContext(
             components=[BasePopulation(), source, modifier],
@@ -253,23 +346,32 @@ class TestProducer:
         sim.step()
 
         actual = sim.get_population(pipeline_name).squeeze()
-        expected = self._expected(
-            base_value, calibration_value, is_rate, time_step, transform, effect_type
+        expected = self._expected_per_column(
+            base_value,
+            calibration_value,
+            is_rate,
+            time_step,
+            transform,
+            effect_type,
+            columns,
         )
-        assert np.allclose(actual, expected, atol=1e-5)
+        self._assert_close(actual, expected, columns)
 
     def test_multiple_calibration_constant_modifiers(
-        self, base_config, base_plugins, is_rate, effect_type, post_processor
+        self, base_config, base_plugins, is_rate, effect_type, post_processor, columns
     ):
         """Two calibration constants combine via the union formula for
         multiplicative effects and via summation for additive effects, then
         post-processors apply."""
         post_processors, transform = post_processor
-        base_value = 0.7 if is_rate else 10.0
+        base_scalar = 0.7 if is_rate else 10.0
         if effect_type == "multiplicative":
-            c1, c2 = 0.1, 0.3
+            c1_scalar, c2_scalar = 0.1, 0.3
         else:  # additive — units match base_value
-            c1, c2 = (0.07, 0.21) if is_rate else (1.0, 3.0)
+            c1_scalar, c2_scalar = (0.07, 0.21) if is_rate else (1.0, 3.0)
+        base_value = self._per_column(base_scalar, columns)
+        c1 = self._per_column(c1_scalar, columns)
+        c2 = self._per_column(c2_scalar, columns)
         time_step = pd.Timedelta(days=base_config.time.step_size)
         pipeline_name = "test_pipeline"
         source = _AttributeSource(
@@ -278,23 +380,30 @@ class TestProducer:
             is_rate=is_rate,
             effect_type=effect_type,
             post_processors=post_processors,
+            columns=columns,
         )
 
         sim = InteractiveContext(
             components=[
                 BasePopulation(),
                 source,
-                _CalibrationConstantModifier(pipeline_name, c1),
-                _CalibrationConstantModifier(pipeline_name, c2),
+                _CalibrationConstantModifier(pipeline_name, c1, columns=columns),
+                _CalibrationConstantModifier(pipeline_name, c2, columns=columns),
             ],
             configuration=base_config,
             plugin_configuration=base_plugins,
         )
         sim.step()
 
-        joint_calibration = self._joint_calibration([c1, c2], effect_type)
+        joint_calibration = self._joint_per_column([c1, c2], effect_type, columns)
         actual = sim.get_population(pipeline_name).squeeze()
-        expected = self._expected(
-            base_value, joint_calibration, is_rate, time_step, transform, effect_type
+        expected = self._expected_per_column(
+            base_value,
+            joint_calibration,
+            is_rate,
+            time_step,
+            transform,
+            effect_type,
+            columns,
         )
-        assert np.allclose(actual, expected, atol=1e-5)
+        self._assert_close(actual, expected, columns)

--- a/tests/causal_factor/test_calibration_constant.py
+++ b/tests/causal_factor/test_calibration_constant.py
@@ -54,12 +54,14 @@ class _AttributeSource(Component):
         pipeline_name: str,
         base_value: float,
         is_rate: bool = False,
+        effect_type: str = "multiplicative",
         post_processors: (AttributePostProcessor | Sequence[AttributePostProcessor]) = (),
     ):
         super().__init__()
         self._pipeline_name = pipeline_name
         self._base_value = base_value
         self._is_rate = is_rate
+        self._effect_type = effect_type
         self._post_processors = post_processors
 
     @property
@@ -88,6 +90,7 @@ class _AttributeSource(Component):
             builder=builder,
             name=self._pipeline_name,
             source=self.base_value_table,
+            effect_type=self._effect_type,
             post_processors=self._post_processors,
         )
 
@@ -147,8 +150,8 @@ def _add_one_post_processor(
 class TestProducer:
     """Exercise ``register_risk_affected_attribute_producer`` and
     ``register_risk_affected_rate_producer`` through the minimal
-    ``_AttributeSource`` wrapper, parameterized over producer type and
-    post-processors."""
+    ``_AttributeSource`` wrapper, parameterized over producer type,
+    effect type, and post-processors."""
 
     _POST_PROCESSOR_PARAMS = [
         pytest.param(((), lambda v: v), id="no_pp"),
@@ -163,20 +166,37 @@ class TestProducer:
     def is_rate(self, request):
         return request.param
 
+    @pytest.fixture(params=["multiplicative", "additive"])
+    def effect_type(self, request):
+        return request.param
+
     @pytest.fixture(params=_POST_PROCESSOR_PARAMS)
     def post_processor(self, request):
         """Return ``(post_processors, expected_transform)``."""
         return request.param
 
-    def _expected(self, base, calibration, is_rate, time_step, transform):
-        """Compute expected pipeline output."""
-        value = base * (1 - calibration)
+    def _expected(self, base, calibration, is_rate, time_step, transform, effect_type):
+        """Compute expected pipeline output for the given effect type."""
+        if effect_type == "multiplicative":
+            value = base * (1 - calibration)
+        else:  # additive
+            value = base - calibration
         if is_rate:
             value = from_yearly(value, time_step)
         return transform(value)
 
+    @staticmethod
+    def _joint_calibration(calibrations, effect_type):
+        """Combine individual calibration constants the way the framework does."""
+        if effect_type == "multiplicative":
+            joint = 0.0
+            for c in calibrations:
+                joint = 1 - (1 - joint) * (1 - c)
+            return joint
+        return sum(calibrations)  # additive
+
     def test_no_calibration_constant_modifier(
-        self, base_config, base_plugins, is_rate, post_processor
+        self, base_config, base_plugins, is_rate, effect_type, post_processor
     ):
         """No modifier → base value returned (calibration constant = 0),
         then post-processors applied."""
@@ -188,6 +208,7 @@ class TestProducer:
             pipeline_name,
             base_value,
             is_rate=is_rate,
+            effect_type=effect_type,
             post_processors=post_processors,
         )
 
@@ -199,23 +220,27 @@ class TestProducer:
         sim.step()
 
         actual = sim.get_population(pipeline_name).squeeze()
-        expected = self._expected(base_value, 0, is_rate, time_step, transform)
+        expected = self._expected(base_value, 0, is_rate, time_step, transform, effect_type)
         assert np.allclose(actual, expected, atol=1e-5)
 
     def test_single_calibration_constant_modifier(
-        self, base_config, base_plugins, is_rate, post_processor
+        self, base_config, base_plugins, is_rate, effect_type, post_processor
     ):
-        """Single calibration constant = c → value * (1 - c),
-        then post-processors applied."""
+        """Single calibration constant ``c`` reduces the value: ``base * (1 - c)``
+        for multiplicative, ``base - c`` for additive. Then post-processors apply."""
         post_processors, transform = post_processor
         base_value = 0.7 if is_rate else 10.0
-        calibration_value = 0.25
+        if effect_type == "multiplicative":
+            calibration_value = 0.25
+        else:  # additive — units match base_value
+            calibration_value = 0.175 if is_rate else 2.5
         time_step = pd.Timedelta(days=base_config.time.step_size)
         pipeline_name = "test_pipeline"
         source = _AttributeSource(
             pipeline_name,
             base_value,
             is_rate=is_rate,
+            effect_type=effect_type,
             post_processors=post_processors,
         )
         modifier = _CalibrationConstantModifier(pipeline_name, calibration_value)
@@ -229,24 +254,29 @@ class TestProducer:
 
         actual = sim.get_population(pipeline_name).squeeze()
         expected = self._expected(
-            base_value, calibration_value, is_rate, time_step, transform
+            base_value, calibration_value, is_rate, time_step, transform, effect_type
         )
         assert np.allclose(actual, expected, atol=1e-5)
 
     def test_multiple_calibration_constant_modifiers(
-        self, base_config, base_plugins, is_rate, post_processor
+        self, base_config, base_plugins, is_rate, effect_type, post_processor
     ):
-        """Two calibration constants combine via union formula,
-        then post-processors applied."""
+        """Two calibration constants combine via the union formula for
+        multiplicative effects and via summation for additive effects, then
+        post-processors apply."""
         post_processors, transform = post_processor
         base_value = 0.7 if is_rate else 10.0
-        c1, c2 = 0.1, 0.3
+        if effect_type == "multiplicative":
+            c1, c2 = 0.1, 0.3
+        else:  # additive — units match base_value
+            c1, c2 = (0.07, 0.21) if is_rate else (1.0, 3.0)
         time_step = pd.Timedelta(days=base_config.time.step_size)
         pipeline_name = "test_pipeline"
         source = _AttributeSource(
             pipeline_name,
             base_value,
             is_rate=is_rate,
+            effect_type=effect_type,
             post_processors=post_processors,
         )
 
@@ -262,26 +292,9 @@ class TestProducer:
         )
         sim.step()
 
-        joint_calibration = 1 - (1 - c1) * (1 - c2)
+        joint_calibration = self._joint_calibration([c1, c2], effect_type)
         actual = sim.get_population(pipeline_name).squeeze()
         expected = self._expected(
-            base_value, joint_calibration, is_rate, time_step, transform
+            base_value, joint_calibration, is_rate, time_step, transform, effect_type
         )
         assert np.allclose(actual, expected, atol=1e-5)
-
-    def test_calibration_constant_of_one_zeroes(self, base_config, base_plugins, is_rate):
-        """Calibration constant = 1 should zero out the value completely."""
-        base_value = 0.7 if is_rate else 10.0
-        pipeline_name = "test_pipeline"
-        source = _AttributeSource(pipeline_name, base_value, is_rate=is_rate)
-        modifier = _CalibrationConstantModifier(pipeline_name, 1.0)
-
-        sim = InteractiveContext(
-            components=[BasePopulation(), source, modifier],
-            configuration=base_config,
-            plugin_configuration=base_plugins,
-        )
-        sim.step()
-
-        actual = sim.get_population(pipeline_name).squeeze()
-        assert np.allclose(actual, 0.0, atol=1e-10)

--- a/tests/causal_factor/test_calibration_constant.py
+++ b/tests/causal_factor/test_calibration_constant.py
@@ -54,15 +54,13 @@ class _AttributeSource(Component):
         pipeline_name: str,
         base_value: float,
         is_rate: bool = False,
-        additional_post_processors: (
-            AttributePostProcessor | Sequence[AttributePostProcessor]
-        ) = (),
+        post_processors: (AttributePostProcessor | Sequence[AttributePostProcessor]) = (),
     ):
         super().__init__()
         self._pipeline_name = pipeline_name
         self._base_value = base_value
         self._is_rate = is_rate
-        self._additional_post_processors = additional_post_processors
+        self._post_processors = post_processors
 
     @property
     def name(self) -> str:
@@ -90,7 +88,7 @@ class _AttributeSource(Component):
             builder=builder,
             name=self._pipeline_name,
             source=self.base_value_table,
-            additional_post_processors=self._additional_post_processors,
+            post_processors=self._post_processors,
         )
 
 
@@ -190,7 +188,7 @@ class TestProducer:
             pipeline_name,
             base_value,
             is_rate=is_rate,
-            additional_post_processors=post_processors,
+            post_processors=post_processors,
         )
 
         sim = InteractiveContext(
@@ -218,7 +216,7 @@ class TestProducer:
             pipeline_name,
             base_value,
             is_rate=is_rate,
-            additional_post_processors=post_processors,
+            post_processors=post_processors,
         )
         modifier = _CalibrationConstantModifier(pipeline_name, calibration_value)
 
@@ -249,7 +247,7 @@ class TestProducer:
             pipeline_name,
             base_value,
             is_rate=is_rate,
-            additional_post_processors=post_processors,
+            post_processors=post_processors,
         )
 
         sim = InteractiveContext(

--- a/tests/causal_factor/test_calibration_constant.py
+++ b/tests/causal_factor/test_calibration_constant.py
@@ -1,5 +1,5 @@
 """
-Tests for :mod:`vivarium_public_health.risks.calibration_constant`.
+Tests for :mod:`vivarium_public_health.causal_factor.calibration_constant`.
 
 Redundancy notes
 ----------------

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -676,9 +676,7 @@ def test_causal_factor_effect_method_rename_deprecation(old_method, new_method, 
         (RiskEffect,),
         {old_method: lambda self, *args, **kwargs: sentinel},
     )
-    effect = DeprecatedEffect(
-        "risk_factor.test_risk", "cause.test_cause.incidence_rate"
-    )
+    effect = DeprecatedEffect("risk_factor.test_risk", "cause.test_cause.incidence_rate")
 
     with pytest.warns(DeprecationWarning, match=old_method):
         result = getattr(effect, new_method)(*([None] * num_args))

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Any
 
 import numpy as np
@@ -647,3 +648,39 @@ def test_relative_risk_pipeline(dichotomous_risk, base_config, base_plugins):
         exposure_idx = exposures.loc[exposures == exposure].index
         relative_risk = sim.get_population(expected_pipeline).squeeze().loc[exposure_idx]
         assert (relative_risk == rr_mapper[exposure]).all()
+
+
+@pytest.mark.parametrize(
+    "old_method, new_method, num_args",
+    [
+        ("build_rr_lookup_table", "build_effect_lookup_table", 1),
+        ("load_relative_risk", "load_effect_data", 1),
+        ("rebin_relative_risk_data", "rebin_effect_data", 2),
+        ("_rebin_relative_risk_data", "_rebin_effect_data", 3),
+        ("get_relative_risk_source", "get_effect_source", 1),
+        ("register_relative_risk_pipeline", "register_effect_pipeline", 1),
+    ],
+)
+def test_causal_factor_effect_method_rename_deprecation(old_method, new_method, num_args):
+    """Ensure the deprecated CausalFactorEffect method names are removed by 2026-08-06."""
+    assert datetime.date.today() <= datetime.date(2026, 8, 6), (
+        f"The deprecated CausalFactorEffect method `{old_method}` should have been removed "
+        f"by now. Remove the `hasattr` shim from `CausalFactorEffect.{new_method}` and delete "
+        "this test case."
+    )
+
+    sentinel = object()
+
+    DeprecatedEffect = type(
+        f"DeprecatedEffect_{old_method}",
+        (RiskEffect,),
+        {old_method: lambda self, *args, **kwargs: sentinel},
+    )
+    effect = DeprecatedEffect(
+        "risk_factor.test_risk", "cause.test_cause.incidence_rate"
+    )
+
+    with pytest.warns(DeprecationWarning, match=old_method):
+        result = getattr(effect, new_method)(*([None] * num_args))
+
+    assert result is sentinel


### PR DESCRIPTION
## Support additive causal effects
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix/feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7006

### Changes and notes
- New AdditiveEffect class alongside MultiplicativeEffect, driven by abstract effect_type / calibration_constant_type properties on CausalFactorEffect.
- RiskEffect and InterventionEffect now subclass MultiplicativeEffect.
- Renamed relative_risk_* → effect_* across CausalFactorEffect, with a _deprecated_method_shim decorator preserving the old names with DeprecationWarning.
- Effect-type-aware combiner/reduction. Multiplicative uses multiplication_combiner + 1 - raw_union(c_i); additive uses addition_combiner + -sum(c_i). Both preserve the population-level baseline.
- Documentation overhaul of calibration_constant.py

Naming improvements:
- Static get_name(...) on RiskEffect/InterventionEffect, Risk.risk/Intervention.intervention properties
- Static DichotomousDistribution.get_exposed/get_unexposed/rename_deprecated_categories.

Bug fixes:
- Properly-indexed correct_target_mask in get_filtered_data
- Empty-config check in CausalFactor.get_distribution_type.

### Testing
Ran make check
Added new tests
Ran with MNCH NO Child model