### PR TITLE
Albrja/feature/mic-6789/error-empty-rr-df

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**5.1.10 - 06/01/26**
+
+- Raise error if filtered relative risk data is empty
+
 **5.1.9 - 05/22/26**
 
 - Add new intersphinx mappings for vivarium-engine and vivarium-config-tree

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -226,6 +226,8 @@ class NonLogLinearRiskEffect(RiskEffect):
         ------
         MissingDataError
             If the TMRED data uses draw-level TMRELs or is not found.
+        ValueError
+            If the filtered relative risk data is empty.
         """
         if configuration is None:
             configuration = self.configuration
@@ -248,6 +250,14 @@ class NonLogLinearRiskEffect(RiskEffect):
         # calculate RR at TMREL
         rr_source = configuration.data_sources.relative_risk
         original_rrs = self.get_filtered_data(builder, rr_source)
+
+        if isinstance(original_rrs, pd.DataFrame) and original_rrs.empty:
+            raise ValueError(
+                f"The relative risk data for {self.causal_factor.name} affecting "
+                f"{self.target.name} {self.target.measure} is empty. This can happen "
+                "when the data contains no rows matching the affected entity and "
+                "measure of this risk effect."
+            )
 
         self.validate_rr_data(original_rrs)
 

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -227,7 +227,9 @@ class NonLogLinearRiskEffect(RiskEffect):
         MissingDataError
             If the TMRED data uses draw-level TMRELs or is not found.
         ValueError
-            If the filtered relative risk data is empty.
+            If the relative risk data fails validation (e.g. it is empty,
+            or its ``parameter`` column is non-numeric or not monotonically
+            increasing). See :meth:`validate_rr_data`.
         """
         if configuration is None:
             configuration = self.configuration
@@ -250,14 +252,6 @@ class NonLogLinearRiskEffect(RiskEffect):
         # calculate RR at TMREL
         rr_source = configuration.data_sources.relative_risk
         original_rrs = self.get_filtered_data(builder, rr_source)
-
-        if isinstance(original_rrs, pd.DataFrame) and original_rrs.empty:
-            raise ValueError(
-                f"The relative risk data for {self.causal_factor.name} affecting "
-                f"{self.target.name} {self.target.measure} is empty. This can happen "
-                "when the data contains no rows matching the affected entity and "
-                "measure of this risk effect."
-            )
 
         self.validate_rr_data(original_rrs)
 
@@ -348,9 +342,18 @@ class NonLogLinearRiskEffect(RiskEffect):
         Raises
         ------
         ValueError
-            If the ``parameter`` column is not numeric or is not
-            monotonically increasing within demographic groups.
+            If the relative risk data is empty, or if the ``parameter``
+            column is not numeric or is not monotonically increasing
+            within demographic groups.
         """
+        if rr_data.empty:
+            raise ValueError(
+                f"The relative risk data for {self.causal_factor.name} affecting "
+                f"{self.target.name} {self.target.measure} is empty. This can happen "
+                "when the data contains no rows matching the affected entity and "
+                "measure of this risk effect."
+            )
+
         # check that rr_data has numeric parameter data
         parameter_data_is_numeric = rr_data["parameter"].dtype.kind in "biufc"
         if not parameter_data_is_numeric:

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -609,6 +609,41 @@ def test_non_loglinear_effect(rr_parameter_data, error_message, base_config, bas
     assert np.isclose(rate.values, expected_values, rtol=0.0000001).all()
 
 
+def test_non_loglinear_effect_empty_rr_data(base_config, base_plugins):
+    """Empty relative risk data (e.g. after filtering to the target entity
+    and measure) should raise an intuitive error rather than failing
+    downstream when building the lookup table."""
+    risk = CustomExposureRisk("risk_factor.test_risk")
+    effect = NonLogLinearRiskEffect(risk.name, "cause.test_cause.incidence_rate")
+
+    # affected_entity does not match the target ("test_cause"), so filtering
+    # to the target entity and measure leaves no rows.
+    rr_data = pd.DataFrame(
+        {
+            "affected_entity": "some_other_cause",
+            "affected_measure": "incidence_rate",
+            "year_start": 1990,
+            "year_end": 1991,
+            "parameter": [1, 2, 5],
+            "value": [2.0, 2.4, 4.0],
+        },
+    )
+    # enforce TMREL of 1
+    tmred = {"distribution": "uniform", "min": 1, "max": 1, "inverted": False}
+
+    data = {
+        f"{risk.name}.relative_risk": rr_data,
+        f"{risk.name}.tmred": tmred,
+        f"{risk.name}.population_attributable_fraction": 0,
+        "cause.test_cause.incidence_rate": 1,
+    }
+
+    base_config.update({"population": {"population_size": 10}})
+
+    with pytest.raises(ValueError, match="empty"):
+        _setup_risk_effect_simulation(base_config, base_plugins, risk, effect, data)
+
+
 def test_relative_risk_pipeline(dichotomous_risk, base_config, base_plugins):
     risk = dichotomous_risk[0]
     effect = RiskEffect(risk.name, "cause.test_cause.incidence_rate")


### PR DESCRIPTION
## Albrja/feature/mic-6789/error-empty-rr-df

### Runtime error if filtered relative risk dataframe is empty
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6789

### Changes and notes
-raise error if filtered relative risk dataframe is empty

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

