### PR TITLE
support artifactless pop components

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**5.1.13 - 06/09/26**
+
+- Add data_sources configuration to population components for artifactless usage
+
 **5.1.12 - 06/03/26**
 
 - Add observers tutorial

--- a/docs/source/concepts/disease/index.rst
+++ b/docs/source/concepts/disease/index.rst
@@ -18,7 +18,7 @@ Disease
 The ``vivarium_public_health`` disease package provides
 :term:`components <Component>` for modeling disease progression in a
 population of simulants. It builds on vivarium's
-:class:`~vivarium.framework.state_machine.Machine` framework to represent
+:class:`~vivarium.engine.framework.state_machine.Machine` framework to represent
 diseases as state machines where simulants move between health states according
 to epidemiological rates.
 

--- a/docs/source/concepts/disease/model.rst
+++ b/docs/source/concepts/disease/model.rst
@@ -12,7 +12,7 @@ Disease Model
 The :class:`~vivarium_public_health.disease.model.DiseaseModel` is the top-level
 :term:`component <Component>` that orchestrates disease states and transitions
 into a complete disease model. It extends vivarium's
-:class:`~vivarium.framework.state_machine.Machine` class.
+:class:`~vivarium.engine.framework.state_machine.Machine` class.
 
 A ``DiseaseModel`` is responsible for:
 
@@ -71,7 +71,7 @@ Disease States
 
 Disease states represent the distinct health conditions a simulant can occupy
 within a disease model. They extend vivarium's
-:class:`~vivarium.framework.state_machine.State` class with public-health-specific
+:class:`~vivarium.engine.framework.state_machine.State` class with public-health-specific
 attributes such as :term:`prevalence <Prevalence>`,
 :term:`disability weight <Disability Weight>`, and
 :term:`excess mortality rate <Excess Mortality Rate>`.
@@ -178,7 +178,7 @@ Transient Disease State
 +++++++++++++++++++++++
 
 :class:`~vivarium_public_health.disease.state.TransientDiseaseState` uses
-vivarium's :class:`~vivarium.framework.state_machine.Transient` mixin to create
+vivarium's :class:`~vivarium.engine.framework.state_machine.Transient` mixin to create
 states that simulants pass through instantaneously within a single time step.
 This is useful for intermediate states in multi-step disease progressions, e.g.
 an "infection" state that immediately resolves to either "with_condition" or
@@ -191,7 +191,7 @@ Disease Transitions
 
 Disease transitions define the rules by which simulants move between disease
 states. They extend vivarium's
-:class:`~vivarium.framework.state_machine.Transition` with disease-specific
+:class:`~vivarium.engine.framework.state_machine.Transition` with disease-specific
 behavior — primarily the conversion of epidemiological rates into transition
 probabilities and support for fixed-proportion and dwell-time-based transitions.
 
@@ -287,7 +287,7 @@ Dwell Time Transition
 +++++++++++++++++++++
 
 A dwell time transition is a plain
-:class:`~vivarium.framework.state_machine.Transition` (with no rate or
+:class:`~vivarium.engine.framework.state_machine.Transition` (with no rate or
 proportion) that is gated by the :term:`dwell time <Dwell Time>` configured on
 the source state. Simulants remain in the state for the specified duration, then
 transition unconditionally.

--- a/docs/source/concepts/population/base_population.rst
+++ b/docs/source/concepts/population/base_population.rst
@@ -43,8 +43,9 @@ when the simulant leaves the simulation.
 Demographic Sampling
 ++++++++++++++++++++
 
-The initializer loads ``population.structure`` data from the artifact and
-computes conditional sampling distributions with
+The initializer loads population structure data from the configured data source
+(by default from the ``population.structure`` artifact key) and computes
+conditional sampling distributions with
 :func:`~vivarium_public_health.population.data_transformations.assign_demographic_proportions`.
 Three probability views are produced:
 
@@ -107,8 +108,6 @@ runs during ``time_step__cleanup``. When ``population.untracking_age`` is
 configured, any simulant whose age meets or exceeds that threshold is marked
 and subsequently untracked by the framework. This provides a clean way to bound 
 the active population for models focused on specific age windows.
-
-.. _population_configuration_concept:
 
 See Also
 --------

--- a/docs/source/concepts/population/fertility.rst
+++ b/docs/source/concepts/population/fertility.rst
@@ -55,7 +55,7 @@ All newborns enter the simulation at age zero.
 :class:`~vivarium_public_health.population.add_new_birth_cohorts.FertilityCrudeBirthRate`
 computes the expected number of births from live-birth covariate data and the
 ratio of the simulation's ``population.population_size`` to the true population
-count in the artifact. On each time step it draws from a Poisson distribution
+count. On each time step it draws from a Poisson distribution
 to decide how many new simulants to create.
 
 The component respects two time-dependence toggles (``fertility.time_dependent_live_births`` 

--- a/docs/source/concepts/results/index.rst
+++ b/docs/source/concepts/results/index.rst
@@ -33,7 +33,7 @@ The package is organized around two cooperating concerns:
 1. **Observers** — a convenience base class
    (:class:`~vivarium_public_health.results.observer.PublicHealthObserver`)
    that wraps the framework's
-   :class:`~vivarium.framework.results.observer.Observer` with a simplified
+   :class:`~vivarium.engine.framework.results.observer.Observer` with a simplified
    registration method and a standardized results-formatting pipeline, plus a
    set of ready-to-use concrete observers for common public health measures:
    disability (YLDs), disease state person-time and transition counts,

--- a/docs/source/concepts/results/public_health_observer.rst
+++ b/docs/source/concepts/results/public_health_observer.rst
@@ -12,11 +12,11 @@ Public Health Observer
 The :class:`~vivarium_public_health.results.observer.PublicHealthObserver` is a
 convenience base class for building :ref:`observers <results_concept>` in
 public health simulations. It extends vivarium's
-:class:`~vivarium.framework.results.observer.Observer` with two capabilities
+:class:`~vivarium.engine.framework.results.observer.Observer` with two capabilities
 that most public health observers share:
 
 1. A simplified method for registering
-   :class:`adding observations <vivarium.framework.results.observation.AddingObservation>`.
+   :class:`adding observations <vivarium.engine.framework.results.observation.AddingObservation>`.
 2. A standardized results-formatting pipeline that produces a consistent
    column layout across all public health outputs.
 
@@ -36,7 +36,7 @@ which wraps that call with sensible defaults and automatically applies the
 standardized formatter.
 
 The method accepts the same core arguments as
-:meth:`~vivarium.framework.results.interface.ResultsInterface.register_adding_observation`
+:meth:`~vivarium.engine.framework.results.interface.ResultsInterface.register_adding_observation`
 (``pop_filter``, ``when``, ``aggregator``, etc.) plus two convenience
 parameters:
 
@@ -98,7 +98,7 @@ To create a new public health observer:
 
 1. Subclass ``PublicHealthObserver``.
 2. Implement
-   :meth:`~vivarium.framework.results.observer.Observer.register_observations`
+   :meth:`~vivarium.engine.framework.results.observer.Observer.register_observations`
    and call ``self.register_adding_observation(...)`` within it.
 3. Override the formatting sub-methods as needed to populate the metadata
    columns.
@@ -112,7 +112,7 @@ The ``vivarium_public_health`` results package ships several concrete
 observers that cover the most common public health measures. Each inherits
 from :class:`~vivarium_public_health.results.observer.PublicHealthObserver`
 and registers one or more
-:class:`adding observations <vivarium.framework.results.observation.AddingObservation>`
+:class:`adding observations <vivarium.engine.framework.results.observation.AddingObservation>`
 during setup.
 
 All concrete observers support per-observer stratification overrides via the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -205,6 +205,7 @@ intersphinx_mapping = {
         "https://vivarium-config-tree.readthedocs.io/en/latest/",
         None,
     ),
+    "vivarium-artifact": ("https://vivarium-artifact.readthedocs.io/en/latest/", None),
     # Backwards compatibility for legacy docs
     "vivarium": ("https://vivarium.readthedocs.io/en/latest/", None),
 }

--- a/docs/source/tutorials/disease.rst
+++ b/docs/source/tutorials/disease.rst
@@ -8,9 +8,9 @@ models from states and transitions, and how to use the pre-built models for
 common disease progressions.
 
 The disease components in this package extend the base
-:class:`~vivarium.framework.state_machine.State` and
-:class:`~vivarium.framework.state_machine.Transition` classes from
-:mod:`vivarium.framework.state_machine`.
+:class:`~vivarium.engine.framework.state_machine.State` and
+:class:`~vivarium.engine.framework.state_machine.Transition` classes from
+:mod:`vivarium.engine.framework.state_machine`.
 
 .. contents::
    :local:
@@ -20,7 +20,7 @@ The disease components in this package extend the base
 
    import numpy as np
    import pandas as pd
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.disease import *
    from vivarium_public_health.population import BasePopulation
    from vivarium_public_health._example_data import *
@@ -58,7 +58,7 @@ To run any example in a standalone script, include all of these at the top:
 
 .. testcode::
 
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.disease import *
    from vivarium_public_health.population import BasePopulation
    from vivarium_public_health._example_data import BASE_PLUGINS, make_base_config

--- a/docs/source/tutorials/non_standard_risk.rst
+++ b/docs/source/tutorials/non_standard_risk.rst
@@ -99,7 +99,7 @@ model specification, we can specify the component to use its defaults with
 
 We declare the component but don't declare any configuration options for it.
 This will cause the risk component to look up any available exposure
-information in the :class:`~vivarium.framework.artifact.artifact.Artifact`
+information in the :class:`~vivarium.artifact.artifact.Artifact`
 and use the data as presented.
 
 If we change the ``"exposure"`` option to the name of a covariate as
@@ -116,7 +116,7 @@ If we change the ``"exposure"`` option to the name of a covariate as
            exposure: covariate.my_covariate
 
 the component will look for the covariate estimate in the
-:class:`~vivarium.framework.artifact.artifact.Artifact` rather than for
+:class:`~vivarium.artifact.artifact.Artifact` rather than for
 the risk factor exposure. Only covariates with a proportion estimate can be
 substituted for risk exposure. The covariate proportion will be used as the
 proportion of people exposed to the risk factor.

--- a/docs/source/tutorials/observers.rst
+++ b/docs/source/tutorials/observers.rst
@@ -8,7 +8,7 @@ stratification.
 
 These observer classes are public-health-specific helpers built on top of the
 vivarium framework's
-:class:`~vivarium.framework.results.observer.Observer` base class (see the
+:class:`~vivarium.engine.framework.results.observer.Observer` base class (see the
 `vivarium results concepts <https://vivarium.readthedocs.io/en/latest/concepts/results.html>`_
 documentation for details on the underlying results system).
 
@@ -22,8 +22,8 @@ documentation for details on the underlying results system).
    import pandas as pd
    from loguru import logger
    logger.disable("vivarium")
-   from vivarium import Component, InteractiveContext
-   from vivarium.framework.engine import Builder
+   from vivarium.engine import Component, InteractiveContext
+   from vivarium.engine.framework.engine import Builder
    from vivarium_public_health.disease import (
        DiseaseModel, DiseaseState, SusceptibleState, SI, SIS,
    )
@@ -45,8 +45,8 @@ Common Setup
 
 .. testcode::
 
-   from vivarium import Component, InteractiveContext
-   from vivarium.framework.engine import Builder
+   from vivarium.engine import Component, InteractiveContext
+   from vivarium.engine.framework.engine import Builder
    from vivarium_public_health.disease import (
        DiseaseModel, DiseaseState, SusceptibleState, SI, SIS,
    )

--- a/docs/source/tutorials/population.rst
+++ b/docs/source/tutorials/population.rst
@@ -14,7 +14,7 @@ configuration required for each approach.
 
    import numpy as np
    import pandas as pd
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.population import *
    from vivarium_public_health._example_data import *
    base_plugins = BASE_PLUGINS
@@ -54,13 +54,10 @@ simulation begins:
 Common Setup
 ------------
 
-In a vivarium simulation, data can be supplied through a **data artifact** -
-an HDF file that you build with all the input data your model needs. To
-keep the code blocks in this tutorial simple, we use an example artifact for
-keys that must come from the artifact, and supply the rest through
-configuration overrides (see `Data sources`_). The `Artifact Data Format`_
-section shows the expected key names and column layouts for every data key
-so that you know exactly what to put in your own artifact.
+Population components load their data through the ``data_sources``
+configuration pattern (see `Data sources`_). The `Expected Data Layout`_
+section shows the key names and column layouts for every data key so that
+you know exactly what format your data should have.
 
 Every code example in this tutorial uses two helpers imported from
 :mod:`vivarium_public_health._example_data`:
@@ -69,8 +66,7 @@ Every code example in this tutorial uses two helpers imported from
 
    from vivarium_public_health._example_data import BASE_PLUGINS, make_base_config
 
-   # BASE_PLUGINS overrides the data plugin to use ExampleArtifactManager,
-   # which serves example data from memory instead of requiring a real HDF file.
+   # BASE_PLUGINS configures the data plugin to serve example data from memory.
    # Pass it as plugin_configuration to InteractiveContext.
    base_plugins = BASE_PLUGINS
 
@@ -79,25 +75,22 @@ Every code example in this tutorial uses two helpers imported from
    config = make_base_config()
 
 
-Artifact Data Format
+Expected Data Layout
 --------------------
 
 This section documents the **key name** and **column layout** that each
 population component expects. Some components also support a
 ``data_sources`` configuration pattern that lets you override individual
-keys with a scalar, DataFrame, or callable without rebuilding the artifact
-(see `Data sources`_).
+keys with a scalar, DataFrame, or callable (see `Data sources`_).
 
 
 Data keys
 ^^^^^^^^^
 
 The table below lists every data key used by the population components.
-Keys marked **artifact-required** must be present in the artifact - the
-component loads them directly and they cannot be replaced via configuration.
-Keys marked **configurable** can be overridden in the ``data_sources``
-section of the configuration (see `Data sources`_); the artifact key shown
-is simply the default.
+All of them can be overridden in the ``data_sources`` section of the
+configuration (see `Data sources`_); the data key shown is simply the
+default.
 
 .. list-table::
    :header-rows: 1
@@ -106,66 +99,61 @@ is simply the default.
      - Index columns
      - Value columns
      - Used by
-     - Configurable?
+     - Configuration override
    * - ``population.structure``
      - age, sex, year, location
      - ``value`` (population count)
      - :class:`~vivarium_public_health.population.base_population.BasePopulation`,
        :class:`~vivarium_public_health.population.base_population.ScaledPopulation`
-     - No (artifact-required)
-   * - ``population.age_bins``
-     - One row per age group
-     - ``age_start``, ``age_end``, ``age_group_name``
-     - :class:`~vivarium_public_health.population.base_population.BasePopulation`
-     - No (artifact-required)
+     - ``population.population_structure``
    * - ``population.location``
      - *(scalar)*
      - A string (e.g. ``"Kenya"``)
      - :class:`~vivarium_public_health.population.base_population.BasePopulation`
-     - No (artifact-required)
+     - ``population.location``
    * - ``cause.all_causes.cause_specific_mortality_rate``
      - age, sex, year
      - ``value`` (rate)
      - :class:`~vivarium_public_health.population.mortality.Mortality`
-     - Yes - ``mortality.data_sources.all_cause_mortality_rate``
+     - ``mortality.data_sources.all_cause_mortality_rate``
    * - ``population.theoretical_minimum_risk_life_expectancy``
      - age
      - ``value`` (years of remaining life)
      - :class:`~vivarium_public_health.population.mortality.Mortality`
-     - Yes - ``mortality.data_sources.life_expectancy``
+     - ``mortality.data_sources.life_expectancy``
    * - ``covariate.live_births_by_sex.estimate``
      - year, sex, ``parameter``
      - ``value``
      - :class:`~vivarium_public_health.population.add_new_birth_cohorts.FertilityCrudeBirthRate`
-     - No (artifact-required)
+     - ``fertility.data_sources.live_births_by_sex``
    * - ``covariate.age_specific_fertility_rate.estimate``
      - age, sex, year, ``parameter``
      - ``value``
      - :class:`~vivarium_public_health.population.add_new_birth_cohorts.FertilityAgeSpecificRates`
-     - Yes - ``fertility_age_specific_rates.data_sources.age_specific_fertility_rate``
+     - ``fertility_age_specific_rates.data_sources.age_specific_fertility_rate``
 
 
 Data sources
 ^^^^^^^^^^^^
 
 Some components support a ``data_sources`` configuration pattern that lets
-you override individual data keys without rebuilding the artifact. This is
-especially useful during development or for simple tutorial examples like
-the ones in this page. Components that support it declare their data needs
-in ``configuration_defaults``; by default each key points to the
-corresponding artifact key. You can override any of them with:
+you override individual data keys. This is especially useful during
+development or for simple tutorial examples like the ones in this page.
+Components that support it declare their data needs in
+``configuration_defaults``; by default each key points to the
+corresponding data key string. You can override any of them with:
 
 - **Scalar** (int or float) - broadcast a constant value to all simulants.
 - **DataFrame** - use the DataFrame directly.
 - **Callable** - call the function at setup time to produce the data.
-- **Artifact key** (string) - load a different key from the artifact.
+- **Data key** (string) - load a different key from the data plugin.
 
 For example, :class:`~vivarium_public_health.population.mortality.Mortality` declares
 three configurable data sources:
 
 .. code-block:: yaml
 
-   # Default configuration (loaded from the artifact):
+   # Default configuration (loads from the data plugin):
    mortality:
      data_sources:
        all_cause_mortality_rate: "cause.all_causes.cause_specific_mortality_rate"
@@ -182,7 +170,7 @@ Any of these can be overridden in the simulation configuration:
 
 .. code-block:: yaml
 
-   # Override with a scalar - no artifact needed for this key:
+   # Override with a scalar - no data key lookup needed:
    configuration:
      mortality:
        data_sources:
@@ -197,32 +185,21 @@ BasePopulation
 --------------
 
 :class:`~vivarium_public_health.population.base_population.BasePopulation` is the standard way
-to create an initial population. It loads a population structure from the data
-artifact and samples simulants whose age, sex, and location distributions match
-the source data.
-
-``BasePopulation`` itself requires ``population.structure``,
-``population.age_bins``, and ``population.location`` to be present in the
-artifact (these are artifact-required keys). Its
-:class:`~vivarium_public_health.population.mortality.Mortality` sub-component supports
-the ``data_sources`` configuration, so mortality rates and life expectancy
-can be overridden with scalars or DataFrames - which is what we do in the
-tutorial examples below.
+to create an initial population. It loads a population structure and samples
+simulants whose age, sex, and location distributions match the source data.
 
 
-Artifact data consumed by BasePopulation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Data consumed by BasePopulation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``BasePopulation`` and its sub-components load the following keys from the
-artifact. The examples below use the data builders from the
-:mod:`~vivarium_public_health._example_data` module; a production artifact has
-the same column layout but with real GBD values.
+``BasePopulation`` and its sub-components use the following data. The examples
+below show the expected column layout. The data builders come from
+:mod:`~vivarium_public_health._example_data`.
 
 .. testcode::
 
    from vivarium_public_health._example_data import (
        population_structure,
-       age_bins,
        theoretical_minimum_risk_life_expectancy,
    )
 
@@ -240,21 +217,6 @@ the same column layout but with real GBD values.
      0.019178 0.076712 Female        1990      1991    Kenya  5.753425
      0.076712 1.000000   Male        1990      1991    Kenya 92.328767
      0.076712 1.000000 Female        1990      1991    Kenya 92.328767
-
-.. testcode::
-
-   # population.age_bins - defines the age groups used by the demographic data.
-   print(age_bins().head(5).to_string(index=False))
-
-.. testoutput::
-   :options: +NORMALIZE_WHITESPACE
-
-    age_start   age_end age_group_name
-     0.000000  0.019178 Early Neonatal
-     0.019178  0.076712  Late Neonatal
-     0.076712  1.000000  Post Neonatal
-     1.000000  5.000000         1 to 4
-     5.000000 10.000000         5 to 9
 
 .. testcode::
 
@@ -278,15 +240,66 @@ the same column layout but with real GBD values.
           4.0      5.0   98.0
 
 
+.. _data_via_configuration_base_population:
+
+Overriding the default data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, every data source loads from the artifact (configured via
+``BASE_PLUGINS`` in these examples). You can bypass the artifact and supply
+data directly through ``data_sources`` - pass a DataFrame, callable, or
+literal string:
+
+.. testcode::
+
+   import pandas as pd
+   from vivarium.engine import InteractiveContext
+   from vivarium_public_health.population import BasePopulation
+   from vivarium_public_health._example_data import population_structure
+
+   # Build population structure data (same layout as the data key).
+   pop_data = population_structure()
+
+   config = make_base_config()
+   config.update(
+       {
+           "population": {
+               "population_size": 5_000,
+               "data_sources": {
+                   "population_structure": pop_data,
+                   "location": "Kenya",
+               },
+           },
+           "mortality": {"data_sources": {"all_cause_mortality_rate": 0}},
+       },
+       layer="override",
+   )
+
+   sim = InteractiveContext(
+       components=[BasePopulation()],
+       configuration=config,
+       plugin_configuration=base_plugins,
+   )
+
+   pop = sim.get_population(["age", "sex", "location"])
+   assert len(pop) == 5_000
+   assert (pop["location"] == "Kenya").all()
+   print(f"Population: {len(pop)}, location: {pop['location'].iloc[0]}")
+
+.. testoutput::
+
+   Population: 5000, location: Kenya
+
+
 Default configuration
 ^^^^^^^^^^^^^^^^^^^^^
 
 The absolute minimum is a ``population_size``. Everything else has sensible
-defaults (ages 0–125, both sexes, no age-out):
+defaults (ages 0-125, both sexes, no age-out):
 
 .. testcode::
 
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.population import BasePopulation
 
    config = make_base_config()
@@ -495,6 +508,14 @@ Configuration summary for BasePopulation
    * - ``population.population_size``
      - 10000
      - Number of simulants to create.
+   * - ``population.population_structure``
+     - internal method (loads ``population.structure``)
+     - Population structure data. Accepts a DataFrame, callable,
+       or data key.
+   * - ``population.location``
+     - internal method (loads ``population.location``)
+     - Location string. Accepts a scalar string, callable,
+       or data key.
    * - ``population.initialization_age_min``
      - 0
      - Minimum age (years) for the initial population.
@@ -511,15 +532,15 @@ Configuration summary for BasePopulation
    * - ``mortality.data_sources.all_cause_mortality_rate``
      - ``"cause.all_causes.cause_specific_mortality_rate"``
      - All-cause mortality rate. Accepts a scalar, DataFrame, callable,
-       or artifact key.
+       or data key.
    * - ``mortality.data_sources.life_expectancy``
      - ``"population.theoretical_minimum_risk_life_expectancy"``
      - Remaining life expectancy by age. Accepts a scalar, DataFrame,
-       callable, or artifact key.
+       callable, or data key.
    * - ``mortality.data_sources.unmodeled_cause_specific_mortality_rate``
      - internal method
      - CSMR for unmodeled causes. Accepts a scalar, DataFrame, callable,
-       or artifact key.
+       or data key.
 
 
 ScaledPopulation
@@ -532,21 +553,20 @@ when simulants represent a subset of the real population (for example, only
 the population eligible for an intervention).
 
 The scaling factor can be either a :class:`pandas.DataFrame` with the same
-demographic index as the population structure, or a string artifact key that
+demographic index as the population structure, or a string data key that
 resolves to such a DataFrame.
 
 
-``ScaledPopulation`` uses the same artifact keys as ``BasePopulation`` (see
-`Artifact data consumed by BasePopulation`_) plus a user-supplied scaling
+``ScaledPopulation`` uses the same data sources as ``BasePopulation`` (see
+`Data consumed by BasePopulation`_) plus a user-supplied scaling
 factor. The scaling factor can be passed as a :class:`pandas.DataFrame`
-directly or as a string artifact key. Since we already have the data as a
-DataFrame, we pass it directly to the constructor - no artifact write needed:
+directly or as a string data key:
 
 .. testcode::
 
    import numpy as np
    import pandas as pd
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.population import ScaledPopulation
    from vivarium_public_health._example_data import population_structure
 
@@ -587,7 +607,7 @@ DataFrame, we pass it directly to the constructor - no artifact write needed:
 
 .. testcode::
 
-   # Pass the DataFrame directly - no need to write to the artifact.
+   # Pass the DataFrame directly.
    sim = InteractiveContext(
        components=[ScaledPopulation(scalar_data)],
        configuration=config,
@@ -622,11 +642,11 @@ FertilityDeterministic
 
 :class:`~vivarium_public_health.population.add_new_birth_cohorts.FertilityDeterministic` adds a
 fixed number of new simulants each year. This is the simplest fertility model
-and does not require any artifact data.
+and does not require any external data.
 
 .. testcode::
 
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.population import BasePopulation, FertilityDeterministic
 
    config = make_base_config()
@@ -674,11 +694,10 @@ This contrasts with
 :class:`~vivarium_public_health.population.add_new_birth_cohorts.FertilityAgeSpecificRates`, which
 models births at the individual level using rates that vary by age.
 
-It requires ``initialization_age_min`` to be 0 and needs
-``covariate.live_births_by_sex.estimate`` data in the artifact.
+It requires ``initialization_age_min`` to be 0.
 
-The artifact key ``covariate.live_births_by_sex.estimate`` should contain
-a row for each year × sex combination:
+The ``live_births_by_sex`` data should contain a row for each
+year × sex combination:
 
 .. testcode::
 
@@ -699,14 +718,13 @@ a row for each year × sex combination:
           1992      1993 Female mean_value  500.0
           1992      1993   Male mean_value  500.0
 
-This component's artifact key is artifact-required (it does not support
-``data_sources`` overrides). The example artifact provides this data
-automatically:
+Both data sources can be supplied via configuration:
 
 .. testcode::
 
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.population import BasePopulation, FertilityCrudeBirthRate
+   from vivarium_public_health._example_data import population_structure, live_births_by_sex
 
    config = make_base_config()
    config.update(
@@ -715,9 +733,19 @@ automatically:
                "population_size": 10_000,
                "initialization_age_min": 0,
                "initialization_age_max": 125,
+               "data_sources": {
+                   "population_structure": population_structure(),
+                   "location": "Kenya",
+               },
            },
            "time": {"step_size": 10},
            "mortality": {"data_sources": {"all_cause_mortality_rate": 0}},
+           "fertility": {
+               "data_sources": {
+                   "population_structure": population_structure(),
+                   "live_births_by_sex": live_births_by_sex(),
+               },
+           },
        },
        layer="override",
    )
@@ -753,11 +781,7 @@ given birth in the last nine months has a chance of giving birth determined
 by age-specific fertility rates. Newborns are linked to their parent via a
 ``parent_id`` column.
 
-By default this component loads ``covariate.age_specific_fertility_rate.estimate``
-from the artifact. It also supports the ``data_sources`` configuration
-pattern (see `Data sources`_), so you can override it with a scalar,
-DataFrame, callable, or alternative artifact key. The expected data shape
-is one row per age × year × sex × parameter combination:
+The expected data shape is one row per age × year × sex × parameter combination:
 
 .. testcode::
 
@@ -779,13 +803,11 @@ is one row per age × year × sex × parameter combination:
           1990      1991        0.0 0.019178   Male lower_value   0.05
           1990      1991        0.0 0.019178   Male upper_value   0.05
 
-Because this component supports the ``data_sources`` configuration, the
-tutorial example below supplies a constant rate directly instead of loading
-from the artifact:
+The tutorial example below supplies a constant rate directly:
 
 .. testcode::
 
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.population import BasePopulation, FertilityAgeSpecificRates
 
    config = make_base_config()
@@ -836,20 +858,23 @@ Fertility configuration summary
 
    * - Component
      - Configuration key
-     - Artifact data required
+     - Default data keys
      - Notes
    * - ``FertilityDeterministic``
      - ``fertility.number_of_new_simulants_each_year``
      - None
      - Simplest model; fixed birth count. Pure configuration.
    * - ``FertilityCrudeBirthRate``
-     - ``fertility.time_dependent_live_births``,
+     - ``fertility.data_sources.population_structure``,
+       ``fertility.data_sources.live_births_by_sex``,
+       ``fertility.time_dependent_live_births``,
        ``fertility.time_dependent_population_fraction``
-     - ``covariate.live_births_by_sex.estimate``
-     - Requires ``initialization_age_min == 0``. Artifact-required key
-       (no ``data_sources`` support).
+     - ``covariate.live_births_by_sex.estimate``,
+       ``population.structure`` (defaults)
+     - Requires ``initialization_age_min == 0``. Supports
+       ``data_sources`` overrides (DataFrame, callable, data key).
    * - ``FertilityAgeSpecificRates``
      - ``fertility_age_specific_rates.data_sources.age_specific_fertility_rate``
      - ``covariate.age_specific_fertility_rate.estimate`` (default)
      - Supports ``data_sources`` overrides (scalar, DataFrame, callable).
-       Tracks parent–child relationships.
+       Tracks parent-child relationships.

--- a/docs/source/tutorials/risk.rst
+++ b/docs/source/tutorials/risk.rst
@@ -15,7 +15,7 @@ rates, see the :doc:`risk_effect` tutorial.
 
    import numpy as np
    import pandas as pd
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.risks import Risk, RiskEffect, NonLogLinearRiskEffect
    from vivarium_public_health.disease import *
    from vivarium_public_health.population import BasePopulation
@@ -53,7 +53,7 @@ To run any example in a standalone script, include all of these at the top:
 
 .. testcode::
 
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.risks import Risk, RiskEffect
    from vivarium_public_health.disease import SI, SIS
    from vivarium_public_health.population import BasePopulation

--- a/docs/source/tutorials/risk_effect.rst
+++ b/docs/source/tutorials/risk_effect.rst
@@ -16,7 +16,7 @@ For how simulants are assigned exposure values, see the :doc:`risk` tutorial.
 
    import numpy as np
    import pandas as pd
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.risks import Risk, RiskEffect, NonLogLinearRiskEffect
    from vivarium_public_health.disease import *
    from vivarium_public_health.population import BasePopulation
@@ -57,7 +57,7 @@ To run any example in a standalone script, include all of these at the top:
 
 .. testcode::
 
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.risks import Risk, RiskEffect
    from vivarium_public_health.disease import SI, SIS
    from vivarium_public_health.population import BasePopulation

--- a/docs/source/tutorials/treatment.rst
+++ b/docs/source/tutorials/treatment.rst
@@ -21,7 +21,7 @@ For how risk factor *exposures* modify disease outcomes, see the
    import pandas as pd
    from loguru import logger
    logger.disable("vivarium")
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.treatment import (
        Intervention, InterventionEffect, AbsoluteShift,
        LinearScaleUp, TherapeuticInertia,
@@ -71,7 +71,7 @@ To run any example in a standalone script, include all of these at the top:
 
 .. testcode::
 
-   from vivarium import InteractiveContext
+   from vivarium.engine import InteractiveContext
    from vivarium_public_health.treatment import (
        Intervention, InterventionEffect, AbsoluteShift,
        LinearScaleUp, TherapeuticInertia,

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,8 @@ if __name__ == "__main__":
     install_requirements = [
         "vivarium_dependencies[pandas,numpy_lt_2,scipy,tables,loguru,pyarrow]",
         "vivarium_build_utils>=3.0.2,<4.0.0",
-        "vivarium>=4.1.0,<5.0.0",
-        "layered_config_tree",
+        "vivarium-engine>=5.1.1",
+        "vivarium-config-tree",
         "risk_distributions>=2.0.11",
     ]
 

--- a/src/vivarium_public_health/_example_data.py
+++ b/src/vivarium_public_health/_example_data.py
@@ -16,11 +16,11 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from layered_config_tree import LayeredConfigTree
-from vivarium import Component
-from vivarium.framework.artifact import ArtifactManager
-from vivarium.framework.configuration import build_simulation_configuration
-from vivarium.framework.engine import Builder
+from vivarium.config_tree import ConfigTree
+from vivarium.engine import Component
+from vivarium.engine.framework.artifact import ArtifactManager
+from vivarium.engine.framework.configuration import build_simulation_configuration
+from vivarium.engine.framework.engine import Builder
 
 #############
 # Constants #
@@ -523,11 +523,11 @@ class ExampleArtifactManager(ArtifactManager):
     Use this in a plugin configuration so that tutorials and interactive
     sessions can run without access to real GBD data::
 
-        base_plugins = LayeredConfigTree({
+        base_plugins = ConfigTree({
             "required": {
                 "data": {
                     "controller": "vivarium_public_health._example_data.ExampleArtifactManager",
-                    "builder_interface": "vivarium.framework.artifact.ArtifactInterface",
+                    "builder_interface": "vivarium.engine.framework.artifact.ArtifactInterface",
                 }
             }
         })
@@ -559,19 +559,19 @@ class ExampleArtifactManager(ArtifactManager):
 ####################
 
 #: Plugin configuration that wires up the example artifact manager.
-BASE_PLUGINS = LayeredConfigTree(
+BASE_PLUGINS = ConfigTree(
     {
         "required": {
             "data": {
                 "controller": "vivarium_public_health._example_data.ExampleArtifactManager",
-                "builder_interface": "vivarium.framework.artifact.ArtifactInterface",
+                "builder_interface": "vivarium.engine.framework.artifact.ArtifactInterface",
             }
         }
     }
 )
 
 
-def make_base_config() -> LayeredConfigTree:
+def make_base_config() -> ConfigTree:
     """Return a fresh base configuration for tutorial examples."""
     config = build_simulation_configuration()
     config.update(

--- a/src/vivarium_public_health/causal_factor/calibration_constant.py
+++ b/src/vivarium_public_health/causal_factor/calibration_constant.py
@@ -14,18 +14,18 @@ from typing import Any
 from typing import SupportsFloat as Numeric
 
 import pandas as pd
-from vivarium import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
-from vivarium.framework.lookup import DEFAULT_VALUE_COLUMN
-from vivarium.framework.resource import Resource
-from vivarium.framework.values import (
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.event import Event
+from vivarium.engine.framework.lookup import DEFAULT_VALUE_COLUMN
+from vivarium.engine.framework.resource import Resource
+from vivarium.engine.framework.values import (
     AttributePostProcessor,
     ValuesManager,
     multiplication_combiner,
     raw_union_post_processor,
 )
-from vivarium.types import LookupTableData, NumberLike
+from vivarium.engine.types import LookupTableData, NumberLike
 
 
 def get_calibration_constant_pipeline_name(target_pipeline_name: str) -> str:

--- a/src/vivarium_public_health/causal_factor/distributions.py
+++ b/src/vivarium_public_health/causal_factor/distributions.py
@@ -16,11 +16,11 @@ from typing import NamedTuple
 import numpy as np
 import pandas as pd
 import risk_distributions as rd
-from layered_config_tree import LayeredConfigTree
-from vivarium import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.lookup import DEFAULT_VALUE_COLUMN, LookupTable
-from vivarium.framework.population import SimulantData
+from vivarium.config_tree import ConfigTree
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.lookup import DEFAULT_VALUE_COLUMN, LookupTable
+from vivarium.engine.framework.population import SimulantData
 
 from vivarium_public_health.causal_factor.calibration_constant import (
     register_risk_affected_attribute_producer,
@@ -77,7 +77,7 @@ class CausalFactorDistribution(Component, ABC):
     # Setup methods #
     #################
 
-    def get_configuration(self, builder: "Builder") -> LayeredConfigTree | None:
+    def get_configuration(self, builder: "Builder") -> ConfigTree | None:
         """Return the configuration tree for this causal factor.
 
         Parameters

--- a/src/vivarium_public_health/causal_factor/effect.py
+++ b/src/vivarium_public_health/causal_factor/effect.py
@@ -15,11 +15,11 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from layered_config_tree import ConfigurationError
-from vivarium import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.lookup import LookupTable
-from vivarium.types import LookupTableData
+from vivarium.config_tree import ConfigurationError
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.lookup import LookupTable
+from vivarium.engine.types import LookupTableData
 
 from vivarium_public_health.causal_factor.calibration_constant import (
     get_calibration_constant_pipeline_name,

--- a/src/vivarium_public_health/causal_factor/exposure.py
+++ b/src/vivarium_public_health/causal_factor/exposure.py
@@ -10,10 +10,10 @@ from abc import ABC
 from typing import Any
 
 import pandas as pd
-from vivarium import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.population import SimulantData
-from vivarium.framework.randomness import RandomnessStream
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.population import SimulantData
+from vivarium.engine.framework.randomness import RandomnessStream
 
 from vivarium_public_health.causal_factor.distributions import (
     CausalFactorDistribution,

--- a/src/vivarium_public_health/causal_factor/utilities.py
+++ b/src/vivarium_public_health/causal_factor/utilities.py
@@ -9,8 +9,8 @@ This module contains utility functions for the placeholder components.
 
 import numpy as np
 import pandas as pd
-from vivarium.framework.engine import Builder
-from vivarium.framework.lookup import DEFAULT_VALUE_COLUMN
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.lookup import DEFAULT_VALUE_COLUMN
 
 from vivarium_public_health.utilities import EntityString
 

--- a/src/vivarium_public_health/disease/exceptions.py
+++ b/src/vivarium_public_health/disease/exceptions.py
@@ -1,6 +1,6 @@
 """Exception classes for the disease modeling package."""
 
-from vivarium.exceptions import VivariumError
+from vivarium.engine.exceptions import VivariumError
 
 
 class DiseaseModelError(VivariumError):

--- a/src/vivarium_public_health/disease/model.py
+++ b/src/vivarium_public_health/disease/model.py
@@ -15,12 +15,12 @@ from functools import partial
 from typing import Any
 
 import pandas as pd
-from layered_config_tree import ConfigurationError
-from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
-from vivarium.framework.population import SimulantData
-from vivarium.framework.state_machine import Machine
-from vivarium.types import DataInput, LookupTableData
+from vivarium.config_tree import ConfigurationError
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.event import Event
+from vivarium.engine.framework.population import SimulantData
+from vivarium.engine.framework.state_machine import Machine
+from vivarium.engine.types import DataInput, LookupTableData
 
 from vivarium_public_health.disease.exceptions import DiseaseModelError
 from vivarium_public_health.disease.state import BaseDiseaseState, SusceptibleState

--- a/src/vivarium_public_health/disease/special_disease.py
+++ b/src/vivarium_public_health/disease/special_disease.py
@@ -15,10 +15,10 @@ from operator import gt, lt
 from typing import Any
 
 import pandas as pd
-from vivarium import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
-from vivarium.framework.population import SimulantData
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.event import Event
+from vivarium.engine.framework.population import SimulantData
 
 from vivarium_public_health.causal_factor.calibration_constant import (
     register_risk_affected_attribute_producer,

--- a/src/vivarium_public_health/disease/state.py
+++ b/src/vivarium_public_health/disease/state.py
@@ -14,12 +14,12 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from vivarium import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.population import PopulationView, SimulantData
-from vivarium.framework.randomness import RandomnessStream
-from vivarium.framework.state_machine import State, Transient, Transition, Trigger
-from vivarium.types import DataInput, LookupTableData
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.population import PopulationView, SimulantData
+from vivarium.engine.framework.randomness import RandomnessStream
+from vivarium.engine.framework.state_machine import State, Transient, Transition, Trigger
+from vivarium.engine.types import DataInput, LookupTableData
 
 from vivarium_public_health.causal_factor.calibration_constant import (
     register_risk_affected_rate_producer,

--- a/src/vivarium_public_health/disease/transition.py
+++ b/src/vivarium_public_health/disease/transition.py
@@ -13,10 +13,10 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import pandas as pd
-from vivarium.framework.engine import Builder
-from vivarium.framework.state_machine import Transition, Trigger
-from vivarium.framework.utilities import rate_to_probability
-from vivarium.types import DataInput
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.state_machine import Transition, Trigger
+from vivarium.engine.framework.utilities import rate_to_probability
+from vivarium.engine.types import DataInput
 
 from vivarium_public_health.causal_factor.calibration_constant import (
     register_risk_affected_rate_producer,

--- a/src/vivarium_public_health/plugins/parser.py
+++ b/src/vivarium_public_health/plugins/parser.py
@@ -4,7 +4,7 @@ Component Configuration Parsers
 ===============================
 
 Component Configuration Parsers in this module are specialized implementations of
-:class:`ComponentConfigurationParser <vivarium.framework.components.parser.ComponentConfigurationParser>`
+:class:`ComponentConfigurationParser <vivarium.engine.framework.components.parser.ComponentConfigurationParser>`
 that can parse configurations of components specific to the Vivarium Public
 Health package.
 
@@ -16,13 +16,13 @@ from importlib.resources import files
 from typing import Any
 
 import pandas as pd
-from layered_config_tree import LayeredConfigTree
-from vivarium import Component
-from vivarium.framework.components import ComponentConfigurationParser
-from vivarium.framework.components.parser import ParsingError
-from vivarium.framework.engine import Builder
-from vivarium.framework.state_machine import Trigger
-from vivarium.framework.utilities import import_by_path
+from vivarium.config_tree import ConfigTree
+from vivarium.engine import Component
+from vivarium.engine.framework.components import ComponentConfigurationParser
+from vivarium.engine.framework.components.parser import ParsingError
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.state_machine import Trigger
+from vivarium.engine.framework.utilities import import_by_path
 
 from vivarium_public_health.disease import (
     BaseDiseaseState,
@@ -81,7 +81,7 @@ class CausesConfigurationParser(ComponentConfigurationParser):
     This value is used if the transition configuration does not explicity specify it.
     """
 
-    def parse_component_config(self, component_config: LayeredConfigTree) -> list[Component]:
+    def parse_component_config(self, component_config: ConfigTree) -> list[Component]:
         """Parses the component configuration and returns a list of components.
 
         In particular, this method looks for an `external_configuration` key
@@ -133,7 +133,7 @@ class CausesConfigurationParser(ComponentConfigurationParser):
         Parameters
         ----------
         component_config
-            A LayeredConfigTree defining the components to initialize.
+            A ConfigTree defining the components to initialize.
 
         Returns
         -------
@@ -153,7 +153,7 @@ class CausesConfigurationParser(ComponentConfigurationParser):
                     source = f"{package}::{config_file}"
                     config_path = str(files(package).joinpath(config_file))
 
-                    external_config = LayeredConfigTree(config_path)
+                    external_config = ConfigTree(config_path)
                     component_config.update(
                         external_config, layer="model_override", source=source
                     )
@@ -180,7 +180,7 @@ class CausesConfigurationParser(ComponentConfigurationParser):
     # Configuration methods #
     #########################
 
-    def _add_default_config_layer(self, causes_config: LayeredConfigTree) -> None:
+    def _add_default_config_layer(self, causes_config: ConfigTree) -> None:
         """Adds a default layer to the provided configuration.
 
         This default layer specifies values for the cause model configuration.
@@ -188,7 +188,7 @@ class CausesConfigurationParser(ComponentConfigurationParser):
         Parameters
         ----------
         causes_config
-            A LayeredConfigTree defining the cause model configurations
+            A ConfigTree defining the cause model configurations
         """
         default_config = {}
         for cause_name, cause_config in causes_config.items():
@@ -214,15 +214,13 @@ class CausesConfigurationParser(ComponentConfigurationParser):
     # Cause model creation methods #
     ################################
 
-    def _get_cause_model_components(
-        self, causes_config: LayeredConfigTree
-    ) -> list[Component]:
+    def _get_cause_model_components(self, causes_config: ConfigTree) -> list[Component]:
         """Parses the cause model configuration and returns the `DiseaseModel` components.
 
         Parameters
         ----------
         causes_config
-            A LayeredConfigTree defining the cause model components to initialize
+            A ConfigTree defining the cause model components to initialize
 
         Returns
         -------
@@ -258,7 +256,7 @@ class CausesConfigurationParser(ComponentConfigurationParser):
         return cause_models
 
     def _get_state(
-        self, state_name: str, state_config: LayeredConfigTree, cause_name: str
+        self, state_name: str, state_config: ConfigTree, cause_name: str
     ) -> BaseDiseaseState:
         """Parses a state configuration and returns an initialized `BaseDiseaseState` object.
 
@@ -267,7 +265,7 @@ class CausesConfigurationParser(ComponentConfigurationParser):
         state_name
             The name of the state to initialize
         state_config
-            A LayeredConfigTree defining the state to initialize
+            A ConfigTree defining the state to initialize
         cause_name
             The name of the cause to which the state belongs
 
@@ -306,7 +304,7 @@ class CausesConfigurationParser(ComponentConfigurationParser):
         self,
         source_state: BaseDiseaseState,
         sink_state: BaseDiseaseState,
-        transition_config: LayeredConfigTree,
+        transition_config: ConfigTree,
     ) -> None:
         """Adds a transition between two states.
 
@@ -317,7 +315,7 @@ class CausesConfigurationParser(ComponentConfigurationParser):
         sink_state
             The state the transition ends at
         transition_config
-            A `LayeredConfigTree` defining the transition to add
+            A `ConfigTree` defining the transition to add
         """
         triggered = Trigger[transition_config.triggered]
         data_sources = self._get_data_sources(transition_config)
@@ -337,14 +335,14 @@ class CausesConfigurationParser(ComponentConfigurationParser):
             )
 
     def _get_data_sources(
-        self, config: LayeredConfigTree
+        self, config: ConfigTree
     ) -> dict[str, str | float | pd.Timedelta | Callable[[Builder], Any]]:
         """Parses a configuration and returns the data sources.
 
         Parameters
         ----------
         config
-            A LayeredConfigTree defining the data sources to initialize
+            A ConfigTree defining the data sources to initialize
 
         Returns
         -------
@@ -432,13 +430,13 @@ class CausesConfigurationParser(ComponentConfigurationParser):
     _TRANSITION_TYPE_KEYS = {"rate", "proportion", "dwell_time"}
 
     @staticmethod
-    def _validate_external_configuration(external_configuration: LayeredConfigTree) -> None:
+    def _validate_external_configuration(external_configuration: ConfigTree) -> None:
         """Validates the external configuration.
 
         Parameters
         ----------
         external_configuration
-            A LayeredConfigTree defining the external configuration
+            A ConfigTree defining the external configuration
 
         Raises
         ------
@@ -466,13 +464,13 @@ class CausesConfigurationParser(ComponentConfigurationParser):
         if error_messages:
             raise CausesParsingErrors(error_messages)
 
-    def _validate_causes_config(self, causes_config: LayeredConfigTree) -> None:
+    def _validate_causes_config(self, causes_config: ConfigTree) -> None:
         """Validates the cause model configuration.
 
         Parameters
         ----------
         causes_config
-            A LayeredConfigTree defining the cause model configurations
+            A ConfigTree defining the cause model configurations
 
         Raises
         ------
@@ -495,7 +493,7 @@ class CausesConfigurationParser(ComponentConfigurationParser):
         cause_name
             The name of the cause to validate
         cause_config
-            A LayeredConfigTree defining the cause to validate
+            A ConfigTree defining the cause to validate
 
         Returns
         -------
@@ -571,7 +569,7 @@ class CausesConfigurationParser(ComponentConfigurationParser):
         state_name
             The name of the state to validate
         state_config
-            A LayeredConfigTree defining the state to validate
+            A ConfigTree defining the state to validate
 
         Returns
         -------
@@ -664,9 +662,9 @@ class CausesConfigurationParser(ComponentConfigurationParser):
         transition_name
             The name of the transition to validate
         transition_config
-            A LayeredConfigTree defining the transition to validate
+            A ConfigTree defining the transition to validate
         states_config
-            A LayeredConfigTree defining the states for the cause
+            A ConfigTree defining the states for the cause
 
         Returns
         -------
@@ -801,7 +799,7 @@ class CausesConfigurationParser(ComponentConfigurationParser):
         Parameters
         ----------
         config
-            A LayeredConfigTree defining the configuration to validate
+            A ConfigTree defining the configuration to validate
         cause_name
             The name of the cause to which the configuration belongs
         config_type

--- a/src/vivarium_public_health/population/add_new_birth_cohorts.py
+++ b/src/vivarium_public_health/population/add_new_birth_cohorts.py
@@ -7,15 +7,17 @@ Provide several different models of fertility.
 
 """
 
+from typing import Any
+
 import numpy as np
 import pandas as pd
-from vivarium import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
-from vivarium.framework.population import SimulantData
+from vivarium.config_tree import ConfigTree
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.event import Event
+from vivarium.engine.framework.population import SimulantData
 
 from vivarium_public_health import utilities
-from vivarium_public_health.population.data_transformations import get_live_births_per_year
 
 # TODO: Incorporate better data into gestational model (probably as a separate component)
 PREGNANCY_DURATION = pd.Timedelta(days=9 * utilities.DAYS_PER_MONTH)
@@ -95,9 +97,9 @@ class FertilityCrudeBirthRate(Component):
 
     Where:
 
-    - ``sim_pop_size_t0`` — the initial simulation population size
-    - ``live_births`` — annual number of live births in the true population
-    - ``true_pop_size`` — the true population size
+    - ``sim_pop_size_t0`` - the initial simulation population size
+    - ``live_births`` - annual number of live births in the true population
+    - ``true_pop_size`` - the true population size
 
     This component has configuration flags that determine whether the
     live births and the true population size should vary with time.
@@ -111,16 +113,52 @@ class FertilityCrudeBirthRate(Component):
 
     """
 
-    CONFIGURATION_DEFAULTS = {
-        "fertility": {
-            "time_dependent_live_births": True,
-            "time_dependent_population_fraction": False,
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def configuration_defaults(self) -> dict[str, Any]:
+        """The default configuration values for this component.
+
+        Configuration structure::
+
+            fertility:
+                data_sources:
+                    population_structure:
+                        Source for population structure data. Default is the
+                        ``population.structure`` artifact key.
+                    live_births_by_sex:
+                        Source for live births data. Default is the
+                        ``covariate.live_births_by_sex.estimate`` artifact key.
+                time_dependent_live_births: bool
+                    Whether live births should vary with time. Default True.
+                time_dependent_population_fraction: bool
+                    Whether population fractions should vary with time.
+                    Default False.
+        """
+        return {
+            "fertility": {
+                "data_sources": {
+                    "population_structure": "population.structure",
+                    "live_births_by_sex": "covariate.live_births_by_sex.estimate",
+                },
+                "time_dependent_live_births": True,
+                "time_dependent_population_fraction": False,
+            }
         }
-    }
 
     #####################
     # Lifecycle methods #
     #####################
+
+    def get_configuration(self, builder: Builder) -> ConfigTree:
+        """Retrieve the fertility configuration for this component.
+
+        Override the default to use the ``fertility`` configuration key
+        rather than the component name.
+        """
+        return builder.configuration.fertility
 
     def setup(self, builder: Builder) -> None:
         """Set up the component by loading birth rate data and obtaining the simulant creator.
@@ -141,11 +179,156 @@ class FertilityCrudeBirthRate(Component):
                 "Configuration key 'initialization_age_min' must be 0 if using FertilityCrudeBirthRate. "
                 f"Provided value: {config.initialization_age_min}"
             )
-        self.birth_rate = get_live_births_per_year(builder)
+        self.birth_rate = self._get_live_births_per_year(builder)
 
         self.clock = builder.time.clock()
         self.randomness = builder.randomness
         self.simulant_creator = builder.population.get_simulant_creator()
+
+    ##################
+    # Helper methods #
+    ##################
+
+    def _get_live_births_per_year(self, builder: Builder) -> pd.Series:
+        """Compute the simulated number of live births per year.
+
+        Load population structure and live birth data from the configured data
+        sources and delegate to :meth:`_compute_live_births_per_year`.
+
+        Parameters
+        ----------
+        builder
+            Access point for utilizing framework interfaces during setup.
+
+        Returns
+        -------
+            A :class:`pandas.Series` indexed by year containing the expected
+            number of new simulant births per year.
+        """
+        fertility_config = self.get_configuration(builder)
+
+        population_data = self.get_data(
+            builder, fertility_config.data_sources.population_structure
+        )
+        birth_data = self.get_data(builder, fertility_config.data_sources.live_births_by_sex)
+
+        return self._compute_live_births_per_year(builder, population_data, birth_data)
+
+    @staticmethod
+    def _compute_live_births_per_year(
+        builder: Builder,
+        population_data: pd.DataFrame,
+        birth_data: pd.DataFrame,
+    ) -> pd.Series:
+        """Compute the simulated number of live births per year from pre-loaded data.
+
+        Transform population structure and live birth data into a per-year birth
+        rate scaled to the simulation's initial population size. Handle
+        time-dependent vs. fixed birth rates and population fractions according
+        to the fertility configuration, and extend the series to cover the
+        simulation end year if needed.
+
+        Parameters
+        ----------
+        builder
+            Access point for utilizing framework interfaces during setup.
+        population_data
+            Population structure data with columns including ``age_start``,
+            ``age_end``, ``year_start``, ``year_end``, and ``value``.
+        birth_data
+            Live births by sex data with columns including ``parameter``,
+            ``year_start``, and ``value``.
+
+        Returns
+        -------
+            A :class:`pandas.Series` indexed by year containing the expected
+            number of new simulant births per year.
+        """
+        FertilityCrudeBirthRate._validate_crude_birth_rate_data(
+            builder, population_data.year_end.max()
+        )
+        population_data = FertilityCrudeBirthRate._rescale_final_age_bin(
+            builder, population_data
+        )
+
+        initial_population_size = builder.configuration.population.population_size
+        population_data = population_data.groupby(["year_start"])["value"].sum()
+        birth_data = (
+            birth_data[birth_data.parameter == "mean_value"]
+            .drop(columns=["parameter"])
+            .groupby(["year_start"])["value"]
+            .sum()
+        )
+
+        start_year = builder.configuration.time.start.year
+        if (
+            builder.configuration.interpolation.extrapolate
+            and start_year > birth_data.index.max()
+        ):
+            start_year = birth_data.index.max()
+
+        if not builder.configuration.fertility.time_dependent_live_births:
+            birth_data = birth_data.at[start_year]
+
+        if not builder.configuration.fertility.time_dependent_population_fraction:
+            population_data = population_data.at[start_year]
+
+        live_birth_rate = initial_population_size / population_data * birth_data
+
+        if isinstance(live_birth_rate, (int, float)):
+            live_birth_rate = pd.Series(
+                live_birth_rate,
+                index=pd.RangeIndex(
+                    builder.configuration.time.start.year,
+                    builder.configuration.time.end.year + 1,
+                    name="year",
+                ),
+            )
+        else:
+            live_birth_rate = (
+                live_birth_rate.reset_index()
+                .rename(columns={"year_start": "year"})
+                .set_index("year")
+                .value
+            )
+            exceeds_data = builder.configuration.time.end.year > live_birth_rate.index.max()
+            if exceeds_data:
+                new_index = pd.RangeIndex(
+                    live_birth_rate.index.min(), builder.configuration.time.end.year + 1
+                )
+                live_birth_rate = live_birth_rate.reindex(
+                    new_index, fill_value=live_birth_rate.at[live_birth_rate.index.max()]
+                )
+        return live_birth_rate
+
+    @staticmethod
+    def _validate_crude_birth_rate_data(builder: Builder, data_year_max: int) -> None:
+        """Validate that birth rate data covers the simulation time period."""
+        exceeds_data = builder.configuration.time.end.year > data_year_max
+        if exceeds_data and not builder.configuration.interpolation.extrapolate:
+            raise ValueError("Trying to extrapolate beyond the end of available birth data.")
+
+    @staticmethod
+    def _rescale_final_age_bin(
+        builder: Builder, population_data: pd.DataFrame
+    ) -> pd.DataFrame:
+        """Clip and rescale the final age bin to match ``initialization_age_max``."""
+        initialization_age_max = builder.configuration.population.to_dict().get(
+            "initialization_age_max", None
+        )
+
+        if initialization_age_max:
+            population_data = population_data.loc[
+                population_data["age_start"] < initialization_age_max
+            ].copy()
+            cut_bin_idx = initialization_age_max <= population_data["age_end"]
+            cut_age_start = population_data.loc[cut_bin_idx, "age_start"]
+            cut_age_end = population_data.loc[cut_bin_idx, "age_end"]
+            population_data.loc[cut_bin_idx, "value"] *= (
+                initialization_age_max - cut_age_start
+            ) / (cut_age_end - cut_age_start)
+            population_data.loc[cut_bin_idx, "age_end"] = initialization_age_max
+        return population_data
 
     ########################
     # Event-driven methods #

--- a/src/vivarium_public_health/population/base_population.py
+++ b/src/vivarium_public_health/population/base_population.py
@@ -8,22 +8,23 @@ Provide tools for sampling and assigning core demographic characteristics to sim
 """
 
 from collections.abc import Callable, Iterable
+from typing import Any
 
 import numpy as np
 import pandas as pd
-from layered_config_tree.exceptions import ConfigurationKeyError
 from loguru import logger
-from vivarium import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
-from vivarium.framework.population import SimulantData
-from vivarium.framework.randomness import RandomnessStream
-from vivarium.framework.values import Pipeline, list_combiner, union_post_processor
+from vivarium.config_tree import ConfigurationKeyError
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.event import Event
+from vivarium.engine.framework.population import SimulantData
+from vivarium.engine.framework.randomness import RandomnessStream
+from vivarium.engine.framework.values import Pipeline, list_combiner, union_post_processor
 
 from vivarium_public_health import utilities
 from vivarium_public_health.population.data_transformations import (
+    add_age_midpoint,
     assign_demographic_proportions,
-    load_population_structure,
     rescale_binned_proportions,
     smooth_ages,
 )
@@ -35,25 +36,51 @@ class BasePopulation(Component):
 
     This component handles the initialization and lifecycle management of the
     core demographic attributes of the simulated population. At setup it loads
-    a population structure from the artifact, computes demographic sampling
-    proportions, and registers a population initializer that assigns each
-    simulant an age, sex, location, entrance time, and exit time. On each time
-    step simulants are aged forward by the step size.
+    a population structure (from the artifact by default, or from a configured
+    data source), computes demographic sampling proportions, and registers a
+    population initializer that assigns each simulant an age, sex, location,
+    entrance time, and exit time. On each time step simulants are aged forward
+    by the step size.
 
     """
-
-    CONFIGURATION_DEFAULTS = {
-        "population": {
-            "initialization_age_min": 0,
-            "initialization_age_max": 125,
-            "untracking_age": None,
-            "include_sex": "Both",  # Either Female, Male, or Both
-        }
-    }
 
     ##############
     # Properties #
     ##############
+
+    @property
+    def configuration_defaults(self) -> dict[str, Any]:
+        """The default configuration values for this component.
+
+        Configuration structure::
+
+            population:
+                population_structure:
+                    Source for population structure data. Default is the
+                    ``population.structure`` artifact key.
+                location:
+                    Source for location data. Default is the
+                    ``population.location`` artifact key.
+                initialization_age_min: int
+                    Minimum age for initial population generation. Default 0.
+                initialization_age_max: int
+                    Maximum age for initial population generation. Default 125.
+                untracking_age: int | None
+                    Age at which simulants are untracked. Default None.
+                include_sex: str
+                    Which sexes to include. One of 'Male', 'Female', or
+                    'Both'. Default 'Both'.
+        """
+        return {
+            "population": {
+                "population_structure": "population.structure",
+                "location": "population.location",
+                "initialization_age_min": 0,
+                "initialization_age_max": 125,
+                "untracking_age": None,
+                "include_sex": "Both",
+            }
+        }
 
     @property
     def time_step_priority(self) -> int:
@@ -130,7 +157,7 @@ class BasePopulation(Component):
         Returns
         -------
             A dictionary mapping stream name to a
-            :class:`~vivarium.framework.randomness.stream.RandomnessStream`. Keys are:
+            :class:`~vivarium.engine.framework.randomness.stream.RandomnessStream`. Keys are:
 
             ``'general_purpose'``
                 Used for overall population generation.
@@ -312,7 +339,7 @@ class BasePopulation(Component):
             )
 
     def _load_population_structure(self, builder: Builder) -> pd.DataFrame:
-        """Load population structure data from the artifact.
+        """Load population structure data from the configured data source.
 
         Parameters
         ----------
@@ -321,9 +348,13 @@ class BasePopulation(Component):
 
         Returns
         -------
-            A :class:`pandas.DataFrame` containing the raw population structure.
+            A :class:`pandas.DataFrame` containing the raw population structure
+            with derived ``age`` and ``location`` columns.
         """
-        return load_population_structure(builder)
+        data = self.get_data(builder, self.config.population_structure)
+        add_age_midpoint(data)
+        data["location"] = self.get_data(builder, self.config.location)
+        return data
 
 
 class ScaledPopulation(BasePopulation):
@@ -356,6 +387,27 @@ class ScaledPopulation(BasePopulation):
         super().__init__()
         self.scaling_factor = scaling_factor
 
+    @property
+    def configuration_defaults(self) -> dict[str, Any]:
+        """The default configuration values for this component.
+
+        Extends :class:`BasePopulation` configuration with a
+        ``scaling_factor`` data source.
+
+        Configuration structure::
+
+            population:
+                population_structure:
+                    Source for population structure data. Default is the
+                    ``population.structure`` artifact key.
+                scaling_factor:
+                    Source for the scaling factor. Default is the value
+                    passed to the constructor.
+        """
+        configuration_defaults = super().configuration_defaults
+        configuration_defaults["population"]["scaling_factor"] = self.scaling_factor
+        return configuration_defaults
+
     def _load_population_structure(self, builder: Builder) -> pd.DataFrame:
         """Load the population structure and apply the scaling factor.
 
@@ -374,8 +426,8 @@ class ScaledPopulation(BasePopulation):
         ValueError
             If the resolved scaling factor is not a :class:`pandas.DataFrame`.
         """
-        scaling_factor = self.get_data(builder, self.scaling_factor)
-        population_structure = load_population_structure(builder)
+        population_structure = super()._load_population_structure(builder)
+        scaling_factor = self.get_data(builder, self.config.scaling_factor)
         if not isinstance(scaling_factor, pd.DataFrame):
             raise ValueError(
                 f"Scaling factor must be a pandas DataFrame. Provided value: {scaling_factor}"

--- a/src/vivarium_public_health/population/data_transformations.py
+++ b/src/vivarium_public_health/population/data_transformations.py
@@ -12,10 +12,26 @@ from collections import namedtuple
 
 import numpy as np
 import pandas as pd
-from vivarium.framework.engine import Builder
-from vivarium.framework.randomness import RandomnessStream
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.randomness import RandomnessStream
 
 _SORT_ORDER = ["location", "year_start", "sex", "age_start"]
+
+
+def add_age_midpoint(data: pd.DataFrame) -> pd.DataFrame:
+    """Add an ``age`` column as the midpoint of ``age_start`` and ``age_end``.
+
+    Parameters
+    ----------
+    data
+        A DataFrame with ``age_start`` and ``age_end`` columns.
+
+    Returns
+    -------
+        The input DataFrame with an ``age`` column added in place.
+    """
+    data["age"] = (data["age_start"] + data["age_end"]) / 2
+    return data
 
 
 def assign_demographic_proportions(
@@ -532,157 +548,3 @@ def get_cause_deleted_mortality_rate(
     return all_cause_mortality_rate.reset_index().rename(
         columns={"value": "death_due_to_other_causes"}
     )
-
-
-def load_population_structure(builder: Builder) -> pd.DataFrame:
-    """Load population structure data from the artifact and add derived columns.
-
-    Parameters
-    ----------
-    builder
-        Access point for utilizing framework interfaces during setup.
-
-    Returns
-    -------
-        DataFrame with all columns from the raw data plus ``age`` and ``location``.
-    """
-    data = builder.data.load("population.structure")
-    # create an age column which is the midpoint of the age group
-    data["age"] = data.apply(lambda row: (row["age_start"] + row["age_end"]) / 2, axis=1)
-    data["location"] = builder.data.load("population.location")
-
-    return data
-
-
-def get_live_births_per_year(builder: Builder) -> pd.Series:
-    """Compute the simulated number of live births per year.
-
-    Combines population structure data with live birth covariate data to
-    produce a per-year birth rate scaled to the simulation's initial
-    population size. Handles time-dependent vs. fixed birth rates and
-    population fractions according to the fertility configuration, and
-    extends the series to cover the simulation end year if needed.
-
-    Parameters
-    ----------
-    builder
-        Access point for utilizing framework interfaces during setup.
-
-    Returns
-    -------
-        A :class:`pandas.Series` indexed by year containing the expected
-        number of new simulant births per year.
-    """
-    population_data = load_population_structure(builder)
-    birth_data = builder.data.load("covariate.live_births_by_sex.estimate")
-
-    validate_crude_birth_rate_data(builder, population_data.year_end.max())
-    population_data = rescale_final_age_bin(builder, population_data)
-
-    initial_population_size = builder.configuration.population.population_size
-    population_data = population_data.groupby(["year_start"])["value"].sum()
-    birth_data = (
-        birth_data[birth_data.parameter == "mean_value"]
-        .drop(columns=["parameter"])
-        .groupby(["year_start"])["value"]
-        .sum()
-    )
-
-    start_year = builder.configuration.time.start.year
-    if (
-        builder.configuration.interpolation.extrapolate
-        and start_year > birth_data.index.max()
-    ):
-        start_year = birth_data.index.max()
-
-    if not builder.configuration.fertility.time_dependent_live_births:
-        birth_data = birth_data.at[start_year]
-
-    if not builder.configuration.fertility.time_dependent_population_fraction:
-        population_data = population_data.at[start_year]
-
-    live_birth_rate = initial_population_size / population_data * birth_data
-
-    if isinstance(live_birth_rate, (int, float)):
-        live_birth_rate = pd.Series(
-            live_birth_rate,
-            index=pd.RangeIndex(
-                builder.configuration.time.start.year,
-                builder.configuration.time.end.year + 1,
-                name="year",
-            ),
-        )
-    else:
-        live_birth_rate = (
-            live_birth_rate.reset_index()
-            .rename(columns={"year_start": "year"})
-            .set_index("year")
-            .value
-        )
-        exceeds_data = builder.configuration.time.end.year > live_birth_rate.index.max()
-        if exceeds_data:
-            new_index = pd.RangeIndex(
-                live_birth_rate.index.min(), builder.configuration.time.end.year + 1
-            )
-            live_birth_rate = live_birth_rate.reindex(
-                new_index, fill_value=live_birth_rate.at[live_birth_rate.index.max()]
-            )
-    return live_birth_rate
-
-
-def rescale_final_age_bin(builder: Builder, population_data: pd.DataFrame) -> pd.DataFrame:
-    """Clip and rescale the final age bin to match ``initialization_age_max``.
-
-    When ``population.initialization_age_max`` is configured and falls within
-    an existing age bin, that bin is truncated at ``initialization_age_max``
-    and its ``value`` is scaled proportionally to reflect the reduced width.
-
-    Parameters
-    ----------
-    builder
-        Access point for utilizing framework interfaces during setup.
-    population_data
-        DataFrame with columns ``age_start``, ``age_end``, and ``value``.
-
-    Returns
-    -------
-        A copy of ``population_data`` with the final age bin adjusted to end
-        at ``initialization_age_max`` and its value rescaled accordingly.
-        Returned unchanged if ``initialization_age_max`` is not set.
-    """
-    initialization_age_max = builder.configuration.population.to_dict().get(
-        "initialization_age_max", None
-    )
-
-    if initialization_age_max:
-        population_data = population_data.loc[
-            population_data["age_start"] < initialization_age_max
-        ].copy()
-        cut_bin_idx = initialization_age_max <= population_data["age_end"]
-        cut_age_start = population_data.loc[cut_bin_idx, "age_start"]
-        cut_age_end = population_data.loc[cut_bin_idx, "age_end"]
-        population_data.loc[cut_bin_idx, "value"] *= (
-            initialization_age_max - cut_age_start
-        ) / (cut_age_end - cut_age_start)
-        population_data.loc[cut_bin_idx, "age_end"] = initialization_age_max
-    return population_data
-
-
-def validate_crude_birth_rate_data(builder: Builder, data_year_max: int) -> None:
-    """Validate that birth rate data covers the simulation time period.
-
-    Parameters
-    ----------
-    builder
-        Access point for utilizing framework interfaces during setup.
-    data_year_max
-        The latest year covered by the available birth rate data.
-
-    Raises
-    ------
-    ValueError
-        If the simulation end year exceeds ``data_year_max`` and extrapolation is not enabled.
-    """
-    exceeds_data = builder.configuration.time.end.year > data_year_max
-    if exceeds_data and not builder.configuration.interpolation.extrapolate:
-        raise ValueError("Trying to extrapolate beyond the end of available birth data.")

--- a/src/vivarium_public_health/population/mortality.py
+++ b/src/vivarium_public_health/population/mortality.py
@@ -33,11 +33,11 @@ modified unmodeled CSMR.
 from typing import Any
 
 import pandas as pd
-from vivarium import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
-from vivarium.framework.population import SimulantData
-from vivarium.framework.randomness import RandomnessStream
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.event import Event
+from vivarium.engine.framework.population import SimulantData
+from vivarium.engine.framework.randomness import RandomnessStream
 
 from vivarium_public_health.causal_factor.calibration_constant import (
     register_risk_affected_attribute_producer,
@@ -207,7 +207,7 @@ class Mortality(Component):
 
         Returns
         -------
-            The :class:`~vivarium.framework.randomness.stream.RandomnessStream` used
+            The :class:`~vivarium.engine.framework.randomness.stream.RandomnessStream` used
             for filtering deaths and choosing cause of death.
         """
         return builder.randomness.get_stream(self._randomness_stream_name)

--- a/src/vivarium_public_health/results/causal_factor.py
+++ b/src/vivarium_public_health/results/causal_factor.py
@@ -8,7 +8,7 @@ This module contains tools for observing risk exposure during the simulation.
 """
 
 import pandas as pd
-from vivarium.framework.engine import Builder
+from vivarium.engine.framework.engine import Builder
 
 from vivarium_public_health.results.columns import COLUMNS
 from vivarium_public_health.results.observer import PublicHealthObserver

--- a/src/vivarium_public_health/results/columns.py
+++ b/src/vivarium_public_health/results/columns.py
@@ -1,6 +1,6 @@
 from typing import NamedTuple
 
-from vivarium.framework.results import VALUE_COLUMN
+from vivarium.engine.framework.results import VALUE_COLUMN
 
 
 class __Columns(NamedTuple):

--- a/src/vivarium_public_health/results/disability.py
+++ b/src/vivarium_public_health/results/disability.py
@@ -11,7 +11,7 @@ in the simulation.
 import pandas as pd
 from loguru import logger
 from pandas.api.types import CategoricalDtype
-from vivarium.framework.engine import Builder
+from vivarium.engine.framework.engine import Builder
 
 from vivarium_public_health.disease import DiseaseState, RiskAttributableDisease
 from vivarium_public_health.results.columns import COLUMNS

--- a/src/vivarium_public_health/results/disease.py
+++ b/src/vivarium_public_health/results/disease.py
@@ -9,9 +9,9 @@ in the simulation.
 """
 
 import pandas as pd
-from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
-from vivarium.framework.population import SimulantData
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.event import Event
+from vivarium.engine.framework.population import SimulantData
 
 from vivarium_public_health.results.columns import COLUMNS
 from vivarium_public_health.results.observer import PublicHealthObserver

--- a/src/vivarium_public_health/results/mortality.py
+++ b/src/vivarium_public_health/results/mortality.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
-from vivarium.framework.engine import Builder
+from vivarium.engine.framework.engine import Builder
 
 from vivarium_public_health.disease import DiseaseState, RiskAttributableDisease
 from vivarium_public_health.disease.state import ExcessMortalityState

--- a/src/vivarium_public_health/results/observer.py
+++ b/src/vivarium_public_health/results/observer.py
@@ -11,9 +11,9 @@ public health models.
 from collections.abc import Callable
 
 import pandas as pd
-from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
-from vivarium.framework.results import Observer
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.event import Event
+from vivarium.engine.framework.results import Observer
 
 from vivarium_public_health.results.columns import COLUMNS
 

--- a/src/vivarium_public_health/results/stratification.py
+++ b/src/vivarium_public_health/results/stratification.py
@@ -9,8 +9,8 @@ by specified characteristics through the vivarium results interface.
 """
 
 import pandas as pd
-from vivarium import Component
-from vivarium.framework.engine import Builder
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
 
 
 class ResultsStratifier(Component):

--- a/src/vivarium_public_health/risks/base_risk.py
+++ b/src/vivarium_public_health/risks/base_risk.py
@@ -8,9 +8,9 @@ exposure.
 
 """
 import pandas as pd
-from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
-from vivarium.framework.population import SimulantData
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.event import Event
+from vivarium.engine.framework.population import SimulantData
 
 from vivarium_public_health.causal_factor.exposure import CausalFactor
 

--- a/src/vivarium_public_health/risks/effect.py
+++ b/src/vivarium_public_health/risks/effect.py
@@ -14,9 +14,9 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import scipy
-from layered_config_tree import LayeredConfigTree
-from vivarium.framework.engine import Builder
-from vivarium.framework.lookup import LookupTable
+from vivarium.config_tree import ConfigTree
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.lookup import LookupTable
 
 from vivarium_public_health.causal_factor.calibration_constant import (
     get_calibration_constant_pipeline_name,
@@ -202,7 +202,7 @@ class NonLogLinearRiskEffect(RiskEffect):
     def load_relative_risk(
         self,
         builder: Builder,
-        configuration: LayeredConfigTree | None = None,
+        configuration: ConfigTree | None = None,
     ) -> str | float | pd.DataFrame:
         """Load relative risk data, normalizing by RR at the TMREL.
 

--- a/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
+++ b/src/vivarium_public_health/risks/implementations/low_birth_weight_and_short_gestation.py
@@ -16,12 +16,12 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from layered_config_tree import ConfigurationError
 from loguru import logger
-from vivarium.framework.engine import Builder
-from vivarium.framework.lookup import LookupTable
-from vivarium.framework.population import SimulantData
-from vivarium.types import LookupTableData
+from vivarium.config_tree import ConfigurationError
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.lookup import LookupTable
+from vivarium.engine.framework.population import SimulantData
+from vivarium.engine.types import LookupTableData
 
 from vivarium_public_health.causal_factor.distributions import PolytomousDistribution
 from vivarium_public_health.causal_factor.utilities import (

--- a/src/vivarium_public_health/treatment/magic_wand.py
+++ b/src/vivarium_public_health/treatment/magic_wand.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 from typing import Any
 
 import pandas as pd
-from vivarium import Component
-from vivarium.framework.engine import Builder
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
 
 from vivarium_public_health.utilities import TargetString
 

--- a/src/vivarium_public_health/treatment/scale_up.py
+++ b/src/vivarium_public_health/treatment/scale_up.py
@@ -11,11 +11,11 @@ from collections.abc import Callable
 from typing import Any
 
 import pandas as pd
-from vivarium import Component
-from vivarium.framework.engine import Builder
-from vivarium.framework.lookup import LookupTable
-from vivarium.framework.values import Pipeline
-from vivarium.types import Time
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.lookup import LookupTable
+from vivarium.engine.framework.values import Pipeline
+from vivarium.engine.types import Time
 
 from vivarium_public_health.utilities import EntityString
 
@@ -219,7 +219,7 @@ class LinearScaleUp(Component):
         Returns
         -------
             A dictionary mapping pipeline names to
-            :class:`~vivarium.framework.values.pipeline.Pipeline` objects.
+            :class:`~vivarium.engine.framework.values.pipeline.Pipeline` objects.
             The base implementation returns an empty dictionary.
         """
         return {}

--- a/src/vivarium_public_health/treatment/therapeutic_inertia.py
+++ b/src/vivarium_public_health/treatment/therapeutic_inertia.py
@@ -10,8 +10,8 @@ why a treatment algorithm might deviate from clinical guidelines.
 
 import pandas as pd
 import scipy.stats
-from vivarium import Component
-from vivarium.framework.engine import Builder
+from vivarium.engine import Component
+from vivarium.engine.framework.engine import Builder
 
 
 class TherapeuticInertia(Component):

--- a/src/vivarium_public_health/utilities.py
+++ b/src/vivarium_public_health/utilities.py
@@ -10,7 +10,7 @@ vivarium_public_health components.
 from collections.abc import Iterable
 
 import pandas as pd
-from vivarium.framework.lookup import ScalarValue
+from vivarium.engine.framework.lookup import ScalarValue
 
 
 class EntityString(str):

--- a/tests/causal_factor/test_calibration_constant.py
+++ b/tests/causal_factor/test_calibration_constant.py
@@ -15,10 +15,10 @@ from collections.abc import Sequence
 import numpy as np
 import pandas as pd
 import pytest
-from vivarium import Component, InteractiveContext
-from vivarium.framework.engine import Builder
-from vivarium.framework.utilities import from_yearly
-from vivarium.framework.values import AttributePostProcessor, ValuesManager
+from vivarium.engine import Component, InteractiveContext
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.utilities import from_yearly
+from vivarium.engine.framework.values import AttributePostProcessor, ValuesManager
 
 from tests.test_utilities import build_table_with_age
 from vivarium_public_health.causal_factor.calibration_constant import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,9 @@ from pathlib import Path
 
 import pytest
 from _pytest.logging import LogCaptureFixture
-from layered_config_tree import LayeredConfigTree
 from loguru import logger
-from vivarium.framework.configuration import build_simulation_configuration
+from vivarium.config_tree import ConfigTree
+from vivarium.engine.framework.configuration import build_simulation_configuration
 from vivarium_testing_utils import FuzzyChecker
 
 from tests.test_utilities import build_table_with_age
@@ -14,8 +14,8 @@ from vivarium_public_health.disease.state import SusceptibleState
 
 
 @pytest.fixture(scope="session")
-def base_config_factory() -> Callable[[], LayeredConfigTree]:
-    def _base_config() -> LayeredConfigTree:
+def base_config_factory() -> Callable[[], ConfigTree]:
+    def _base_config() -> ConfigTree:
         config = build_simulation_configuration()
 
         config.update(
@@ -32,22 +32,22 @@ def base_config_factory() -> Callable[[], LayeredConfigTree]:
 
 
 @pytest.fixture(scope="function")
-def base_config(base_config_factory) -> LayeredConfigTree:
+def base_config(base_config_factory) -> ConfigTree:
     yield base_config_factory()
 
 
 @pytest.fixture(scope="module")
-def base_plugins() -> LayeredConfigTree:
+def base_plugins() -> ConfigTree:
     config = {
         "required": {
             "data": {
                 "controller": "tests.mock_artifact.MockArtifactManager",
-                "builder_interface": "vivarium.framework.artifact.ArtifactInterface",
+                "builder_interface": "vivarium.engine.framework.artifact.ArtifactInterface",
             }
         }
     }
 
-    return LayeredConfigTree(config)
+    return ConfigTree(config)
 
 
 @pytest.fixture(scope="session")

--- a/tests/disease/test_disease.py
+++ b/tests/disease/test_disease.py
@@ -3,11 +3,11 @@ from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import pytest
-from layered_config_tree import ConfigurationError, LayeredConfigTree
-from vivarium import Component, InteractiveContext
-from vivarium.framework.state_machine import Transition
-from vivarium.framework.utilities import from_yearly
-from vivarium.testing_utilities import metadata
+from vivarium.config_tree import ConfigTree, ConfigurationError
+from vivarium.engine import Component, InteractiveContext
+from vivarium.engine.framework.state_machine import Transition
+from vivarium.engine.framework.utilities import from_yearly
+from vivarium.engine.testing_utilities import metadata
 
 from tests.test_utilities import build_table_with_age
 from vivarium_public_health.disease import (
@@ -529,8 +529,8 @@ def test_artifact_transition_keys(mocker, disease):
 
 @pytest.mark.parametrize("rate_conversion_type", ["linear", "exponential"])
 def test_transition_rate_to_probability_configuration(
-    base_config: LayeredConfigTree,
-    base_plugins: LayeredConfigTree,
+    base_config: ConfigTree,
+    base_plugins: ConfigTree,
     disease: str,
     rate_conversion_type: str,
 ):
@@ -581,8 +581,8 @@ def test_transition_rate_to_probability_configuration(
 
 
 def test_disease_model_rate_conversion_config_error(
-    base_config: LayeredConfigTree,
-    base_plugins: LayeredConfigTree,
+    base_config: ConfigTree,
+    base_plugins: ConfigTree,
     disease: str,
 ):
     """

--- a/tests/mock_artifact.py
+++ b/tests/mock_artifact.py
@@ -9,7 +9,7 @@ testing vivarium_public_health components.
 """
 
 import pandas as pd
-from vivarium.framework.artifact import ArtifactManager
+from vivarium.engine.framework.artifact import ArtifactManager
 
 from tests.test_utilities import build_table_with_age, make_age_bins, make_uniform_pop_data
 

--- a/tests/plugins/test_parser.py
+++ b/tests/plugins/test_parser.py
@@ -3,10 +3,10 @@ from typing import Any, NamedTuple
 
 import pytest
 import yaml
-from layered_config_tree import LayeredConfigTree
-from vivarium import Component, InteractiveContext
-from vivarium.framework.components.parser import ParsingError
-from vivarium.framework.state_machine import Transient, Transition
+from vivarium.config_tree import ConfigTree
+from vivarium.engine import Component, InteractiveContext
+from vivarium.engine.framework.components.parser import ParsingError
+from vivarium.engine.framework.state_machine import Transient, Transition
 
 from tests.mock_artifact import MockArtifact
 from tests.mock_artifact import MockArtifactManager as MockArtifactManager_
@@ -337,7 +337,7 @@ COMPLEX_MODEL_CONFIG = {
 }
 
 
-def create_simulation_config_tree(config_dict: dict) -> LayeredConfigTree:
+def create_simulation_config_tree(config_dict: dict) -> ConfigTree:
     config_tree_layers = [
         "base",
         "user_configs",
@@ -345,30 +345,30 @@ def create_simulation_config_tree(config_dict: dict) -> LayeredConfigTree:
         "model_override",
         "override",
     ]
-    config_tree = LayeredConfigTree(layers=config_tree_layers)
+    config_tree = ConfigTree(layers=config_tree_layers)
     config_tree.update(config_dict, layer="model_override")
     return config_tree
 
 
 @pytest.fixture(scope="module")
-def base_config(base_config_factory) -> LayeredConfigTree:
+def base_config(base_config_factory) -> ConfigTree:
     yield base_config_factory()
 
 
 @pytest.fixture(scope="module")
-def causes_config_parser_plugins() -> LayeredConfigTree:
+def causes_config_parser_plugins() -> ConfigTree:
     config_parser_plugin_config = {
         "required": {
             "data": {
                 "controller": "tests.plugins.test_parser.MockArtifactManager",
-                "builder_interface": "vivarium.framework.artifact.ArtifactInterface",
+                "builder_interface": "vivarium.engine.framework.artifact.ArtifactInterface",
             },
             "component_configuration_parser": {
                 "controller": "vivarium_public_health.plugins.CausesConfigurationParser",
             },
         }
     }
-    return LayeredConfigTree(config_parser_plugin_config)
+    return ConfigTree(config_parser_plugin_config)
 
 
 @pytest.fixture
@@ -392,9 +392,7 @@ ALL_COMPONENTS_CONFIG_DICT = {
 
 
 @pytest.fixture(scope="module")
-def sim_components(
-    base_config: LayeredConfigTree, causes_config_parser_plugins: LayeredConfigTree
-):
+def sim_components(base_config: ConfigTree, causes_config_parser_plugins: ConfigTree):
     simulation = InteractiveContext(
         components=create_simulation_config_tree(ALL_COMPONENTS_CONFIG_DICT),
         configuration=base_config,
@@ -409,7 +407,7 @@ def sim_components(
 
 
 def _test_parsing_of_config_file(
-    component_config: LayeredConfigTree,
+    component_config: ConfigTree,
     expected_component_names: tuple[str] = (
         f"disease_model.{SIR_MODEL}",
         f"complex_model.{COMPLEX_MODEL}",

--- a/tests/population/test_add_new_birth_cohort.py
+++ b/tests/population/test_add_new_birth_cohort.py
@@ -3,12 +3,14 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
-from vivarium import InteractiveContext
-from vivarium.testing_utilities import TestPopulation, metadata
+from vivarium.engine import InteractiveContext
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.testing_utilities import TestPopulation, metadata
 
-from tests.test_utilities import build_table_with_age
+from tests.test_utilities import build_table_with_age, make_uniform_pop_data
 from vivarium_public_health import utilities
 from vivarium_public_health.population import (
+    BasePopulation,
     FertilityAgeSpecificRates,
     FertilityCrudeBirthRate,
     FertilityDeterministic,
@@ -236,3 +238,72 @@ def test_fertility_module(base_config, base_plugins):
             "expect all children to have mothers who"
             " gave birth after the simulation starts."
         )
+
+
+# ---------------------------------------------------------------------------
+# Data sources tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def birth_data():
+    """Live births data matching the year range in the mock artifact."""
+    years = list(zip(range(1990, 2018), range(1991, 2019)))
+    rows = [
+        {
+            "year_start": ys,
+            "year_end": ye,
+            "sex": sex,
+            "parameter": "mean_value",
+            "value": 500.0,
+        }
+        for (ys, ye) in years
+        for sex in ("Female", "Male")
+    ]
+    return pd.DataFrame(rows)
+
+
+class TestFertilityCrudeBirthRateDataSources:
+    """Tests for FertilityCrudeBirthRate with DataFrame and callable data sources."""
+
+    @pytest.mark.parametrize(
+        "use_callable",
+        [False, True],
+        ids=["dataframe", "callable"],
+    )
+    def test_data_sources(self, base_config, base_plugins, birth_data, use_callable):
+        """FertilityCrudeBirthRate works with DataFrame and callable data sources."""
+        pop_data = make_uniform_pop_data()
+        pop_source = (lambda b: pop_data) if use_callable else pop_data
+        birth_source = (lambda b: birth_data) if use_callable else birth_data
+
+        base_config.update(
+            {
+                "population": {
+                    "population_size": 10_000,
+                    "initialization_age_min": 0,
+                    "initialization_age_max": 125,
+                    "data_sources": {
+                        "population_structure": pop_data,
+                    },
+                    "location": "BirthLand",
+                },
+                "time": {"step_size": 10},
+                "mortality": {"data_sources": {"all_cause_mortality_rate": 0}},
+                "fertility": {
+                    "data_sources": {
+                        "population_structure": pop_source,
+                        "live_births_by_sex": birth_source,
+                    }
+                },
+            },
+            layer="override",
+        )
+        sim = InteractiveContext(
+            components=[BasePopulation(), FertilityCrudeBirthRate()],
+            configuration=base_config,
+            plugin_configuration=base_plugins,
+        )
+        initial_pop_size = len(sim.get_population(["age"]))
+        sim.take_steps(number_of_steps=10)
+        assert len(sim.get_population(["age"])) > initial_pop_size

--- a/tests/population/test_base_population.py
+++ b/tests/population/test_base_population.py
@@ -1,11 +1,13 @@
 import math
 from itertools import product
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import pytest
-from vivarium import InteractiveContext
-from vivarium.testing_utilities import get_randomness
+from vivarium.engine import InteractiveContext
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.testing_utilities import get_randomness
 from vivarium_testing_utils import FuzzyChecker
 
 import vivarium_public_health.population.base_population as bp
@@ -661,3 +663,169 @@ def _check_locations(simulants):
             1 / len(simulants.location.unique()),
             abs_tol=0.01,
         )
+
+
+######################
+# Data sources tests #
+######################
+
+
+def _make_data_sources_sim(base_config, base_plugins, config_overrides, components=None):
+    """Build an InteractiveContext with the given config overrides."""
+    base_config.update(config_overrides, layer="override")
+    return InteractiveContext(
+        components=components or [bp.BasePopulation()],
+        configuration=base_config,
+        plugin_configuration=base_plugins,
+    )
+
+
+@pytest.fixture
+def data_sources_config(base_config):
+    base_config.update(
+        {
+            "population": {
+                "population_size": 100,
+                "initialization_age_min": 0,
+                "initialization_age_max": 125,
+            },
+            "mortality": {"data_sources": {"all_cause_mortality_rate": 0}},
+        },
+        source=str(Path(__file__).resolve()),
+        layer="model_override",
+    )
+    return base_config
+
+
+class TestBasePopulationDataSources:
+    """Tests for BasePopulation with various data_sources configurations."""
+
+    def test_dataframe_as_population_structure(self, data_sources_config, base_plugins):
+        """BasePopulation accepts a DataFrame as population_structure."""
+        pop_data = make_uniform_pop_data()
+        sim = _make_data_sources_sim(
+            data_sources_config,
+            base_plugins,
+            {
+                "population": {
+                    "population_structure": pop_data,
+                    "location": "TestLand",
+                }
+            },
+        )
+        pop = sim.get_population(["age", "sex", "location"])
+        assert len(pop) == 100
+        assert (pop["location"] == "TestLand").all()
+
+    def test_callable_as_population_structure(self, data_sources_config, base_plugins):
+        """BasePopulation accepts a callable as population_structure."""
+        pop_data = make_uniform_pop_data()
+        sim = _make_data_sources_sim(
+            data_sources_config,
+            base_plugins,
+            {
+                "population": {
+                    "data_sources": {
+                        "population_structure": lambda b: pop_data,
+                    },
+                    "location": "CallableLand",
+                }
+            },
+        )
+        pop = sim.get_population(["location"])
+        assert (pop["location"] == "CallableLand").all()
+
+    @pytest.mark.parametrize(
+        "location_source,expected_location",
+        [
+            # callable
+            (lambda b: "FunctionLand", "FunctionLand"),
+            # artifact key string
+            ("population.location", "Kenya"),
+            # module::function reference
+            (
+                "tests.population.test_base_population::get_test_location",
+                "ModuleFunctionLand",
+            ),
+            pytest.param(
+                "Ethiopia",
+                "Ethiopia",
+                id="literal_string",
+            ),
+        ],
+        ids=["callable", "data_key_string", "module_function_string", "literal_string"],
+    )
+    def test_location_dispatch(
+        self, data_sources_config, base_plugins, location_source, expected_location
+    ):
+        """Location is resolved correctly for each source type via get_data."""
+        pop_data = make_uniform_pop_data()
+        sim = _make_data_sources_sim(
+            data_sources_config,
+            base_plugins,
+            {
+                "population": {
+                    "data_sources": {
+                        "population_structure": pop_data,
+                    },
+                    "location": location_source,
+                }
+            },
+        )
+        pop = sim.get_population(["location"])
+        assert (pop["location"] == expected_location).all()
+
+    def test_location_default_loads_from_data_plugin(self, data_sources_config, base_plugins):
+        """Omitting location from data_sources uses the default artifact key."""
+        pop_data = make_uniform_pop_data()
+        sim = _make_data_sources_sim(
+            data_sources_config,
+            base_plugins,
+            {"population": {"population_structure": pop_data}},
+        )
+        pop = sim.get_population(["location"])
+        # The default "population.location" key is loaded via get_data;
+        # the mock artifact returns "Kenya".
+        assert (pop["location"] == "Kenya").all()
+
+
+class TestScaledPopulationDataSources:
+    """Tests for ScaledPopulation with configured data sources."""
+
+    def test_scaled_population_with_dataframe_sources(
+        self, data_sources_config, base_plugins
+    ):
+        """ScaledPopulation works with DataFrame data sources."""
+        pop_data = make_uniform_pop_data()
+        scaling_factor = pop_data[
+            ["age_start", "age_end", "sex", "year_start", "year_end"]
+        ].copy()
+        # Scale males by 3x, females by 1x -> expect ~75% male, ~25% female
+        scaling_factor["value"] = scaling_factor["sex"].map({"Male": 3.0, "Female": 1.0})
+
+        sim = _make_data_sources_sim(
+            data_sources_config,
+            base_plugins,
+            {
+                "population": {
+                    "population_size": 100_000,
+                    "data_sources": {
+                        "population_structure": pop_data,
+                    },
+                    "location": "ScaledLand",
+                }
+            },
+            components=[bp.ScaledPopulation(scaling_factor)],
+        )
+        pop = sim.get_population(["age", "sex", "location"])
+        assert len(pop) == 100_000
+        assert (pop["location"] == "ScaledLand").all()
+        # Verify scaling: males should be ~75% of population
+        male_fraction = (pop["sex"] == "Male").sum() / len(pop)
+        assert np.isclose(male_fraction, 0.75, atol=0.01)
+
+
+# Module-level function used by the '::' string test
+def get_test_location(builder: Builder) -> str:
+    """Return a test location string."""
+    return "ModuleFunctionLand"

--- a/tests/population/test_data_transformations.py
+++ b/tests/population/test_data_transformations.py
@@ -3,7 +3,7 @@ import math
 import numpy as np
 import pandas as pd
 import pytest
-from vivarium.testing_utilities import get_randomness
+from vivarium.engine.testing_utilities import get_randomness
 
 import vivarium_public_health.population.data_transformations as dt
 from tests.test_utilities import make_uniform_pop_data

--- a/tests/population/test_mortality.py
+++ b/tests/population/test_mortality.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
-from vivarium import Component, InteractiveContext
+from vivarium.engine import Component, InteractiveContext
 from vivarium_testing_utils import FuzzyChecker
 
 from tests.test_utilities import build_table_with_age

--- a/tests/results/test_categorical_risk_observer.py
+++ b/tests/results/test_categorical_risk_observer.py
@@ -3,7 +3,7 @@ import itertools
 import numpy as np
 import pandas as pd
 import pytest
-from vivarium import InteractiveContext
+from vivarium.engine import InteractiveContext
 
 from tests.test_utilities import build_table_with_age
 from vivarium_public_health.population import BasePopulation

--- a/tests/results/test_disability.py
+++ b/tests/results/test_disability.py
@@ -3,7 +3,7 @@
 # import numpy as np
 # import pandas as pd
 #
-# from vivarium.testing_utilities import build_table
+# from vivarium.engine.testing_utilities import build_table
 # from vivarium.interface.interactive import setup_simulation
 #
 # from vivarium_public_health.population import BasePopulation

--- a/tests/results/test_disability_observer.py
+++ b/tests/results/test_disability_observer.py
@@ -4,8 +4,8 @@ import re
 import numpy as np
 import pandas as pd
 import pytest
-from layered_config_tree import LayeredConfigTree
-from vivarium import InteractiveContext
+from vivarium.config_tree import ConfigTree
+from vivarium.engine import InteractiveContext
 
 from tests.test_utilities import build_table_with_age
 from vivarium_public_health.disease import DiseaseModel, DiseaseState, RiskAttributableDisease
@@ -41,9 +41,7 @@ def test_disability_observer_setup(mocker):
     builder.results.register_adding_observation = mocker.Mock()
     builder.configuration.time.step_size = 28
     builder.configuration.output_data.results_directory = "some/results/directory"
-    builder.configuration.stratification.excluded_categories = LayeredConfigTree(
-        {"disability": []}
-    )
+    builder.configuration.stratification.excluded_categories = ConfigTree({"disability": []})
 
     # Set up fake calls for cause-specific register_observation args
     flu = DiseaseState("flu")
@@ -183,7 +181,7 @@ def test_set_causes_of_disability(exclusions, mocker):
 
     builder = mocker.MagicMock()
     builder.configuration.time.step_size = 28
-    builder.configuration.stratification.excluded_categories = LayeredConfigTree(
+    builder.configuration.stratification.excluded_categories = ConfigTree(
         {"disability": exclusions}
     )
 
@@ -203,7 +201,7 @@ def test_set_causes_of_disability_raises(mocker):
 
     builder = mocker.MagicMock()
     builder.configuration.time.step_size = 28
-    builder.configuration.stratification.excluded_categories = LayeredConfigTree(
+    builder.configuration.stratification.excluded_categories = ConfigTree(
         {"disability": ["arthritis"]}  # not an instantiated disease
     )
 

--- a/tests/results/test_disease_observer.py
+++ b/tests/results/test_disease_observer.py
@@ -3,7 +3,7 @@ import itertools
 import numpy as np
 import pandas as pd
 import pytest
-from vivarium import InteractiveContext
+from vivarium.engine import InteractiveContext
 
 from tests.test_utilities import build_table_with_age
 from vivarium_public_health.disease import DiseaseModel, DiseaseState

--- a/tests/results/test_mortality_observer.py
+++ b/tests/results/test_mortality_observer.py
@@ -3,7 +3,7 @@ from collections import Counter
 
 import numpy as np
 import pytest
-from vivarium import InteractiveContext
+from vivarium.engine import InteractiveContext
 
 from tests.test_utilities import build_table_with_age
 from vivarium_public_health.disease import DiseaseModel, DiseaseState

--- a/tests/risks/test_base_risk.py
+++ b/tests/risks/test_base_risk.py
@@ -3,9 +3,9 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pytest
-from layered_config_tree import LayeredConfigTree
-from vivarium import Component, InteractiveContext
-from vivarium.framework.engine import Builder
+from vivarium.config_tree import ConfigTree
+from vivarium.engine import Component, InteractiveContext
+from vivarium.engine.framework.engine import Builder
 
 from tests.test_utilities import build_table_with_age
 from vivarium_public_health.causal_factor.calibration_constant import (
@@ -80,8 +80,8 @@ def polytomous_risk() -> tuple[Risk, dict[str, Any]]:
 
 
 def _setup_risk_simulation(
-    config: LayeredConfigTree,
-    plugins: LayeredConfigTree,
+    config: ConfigTree,
+    plugins: ConfigTree,
     risk: str | Risk,
     data: dict[str, Any],
     has_risk_effect: bool = True,

--- a/tests/risks/test_distributions.py
+++ b/tests/risks/test_distributions.py
@@ -2,7 +2,7 @@
 # import pandas as pd
 # import pytest
 #
-# from vivarium.testing_utilities import build_table
+# from vivarium.engine.testing_utilities import build_table
 # from vivarium_public_health.risks import distributions
 # from vivarium_public_health.risks.data_transformations import pivot_categorical
 #

--- a/tests/risks/test_effect.py
+++ b/tests/risks/test_effect.py
@@ -3,11 +3,11 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pytest
-from layered_config_tree import LayeredConfigTree
-from vivarium import Component, InteractiveContext
-from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
-from vivarium.framework.population import SimulantData
+from vivarium.config_tree import ConfigTree
+from vivarium.engine import Component, InteractiveContext
+from vivarium.engine.framework.engine import Builder
+from vivarium.engine.framework.event import Event
+from vivarium.engine.framework.population import SimulantData
 
 from vivarium_public_health.disease import SI
 from vivarium_public_health.population import BasePopulation
@@ -15,8 +15,8 @@ from vivarium_public_health.risks import RiskEffect
 from vivarium_public_health.risks.base_risk import Risk
 
 #
-# from vivarium.framework.utilities import from_yearly
-# from vivarium.testing_utilities import build_table, BasePopulation
+# from vivarium.engine.framework.utilities import from_yearly
+# from vivarium.engine.testing_utilities import build_table, BasePopulation
 # from vivarium.interface.interactive import initialize_simulation
 #
 # from vivarium_public_health.disease import RateTransition
@@ -416,8 +416,8 @@ from vivarium_public_health.utilities import EntityString
 
 
 def _setup_risk_effect_simulation(
-    config: LayeredConfigTree,
-    plugins: LayeredConfigTree,
+    config: ConfigTree,
+    plugins: ConfigTree,
     risk: str | Risk,
     risk_effect: RiskEffect,
     data: dict[str, Any],

--- a/tests/risks/test_low_birth_weight_and_short_gestation.py
+++ b/tests/risks/test_low_birth_weight_and_short_gestation.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pandas as pd
 import pytest
-from layered_config_tree import ConfigurationError
-from vivarium import InteractiveContext
-from vivarium.testing_utilities import TestPopulation
+from vivarium.config_tree import ConfigurationError
+from vivarium.engine import InteractiveContext
+from vivarium.engine.testing_utilities import TestPopulation
 
 from tests.risks.test_effect import _setup_risk_effect_simulation
 from tests.test_utilities import make_age_bins

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from hypothesis import given
-from vivarium.testing_utilities import build_table
+from vivarium.engine.testing_utilities import build_table
 
 from vivarium_public_health.utilities import EntityString, TargetString
 


### PR DESCRIPTION
## Support Artifactless Pop Components

### Description
- *Category*: feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7052

### Changes and notes

Add `data_sources` configuration to `BasePopulation`, `ScaledPopulation`, and
`FertilityCrudeBirthRate` so they can load data from DataFrames, callables, or
`module::function` strings without requiring an artifact.

- Extract shared utilities 
- `ScaledPopulation` now calls `super()` instead of duplicating parent logic
- Update population tutorial with new "Overriding the default data" section

### Testing
10 new data-sources tests covering DataFrame, callable, literal, data key, and
module::function dispatch. All 91 population tests and 283 tutorial doctests pass.